### PR TITLE
fix: include LICENSE in PyPI sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ manifest-path = "crates/megane-python/Cargo.toml"
 python-source = "python"
 module-name = "megane.megane_parser"
 features = ["pyo3/extension-module"]
-include = ["python/megane/static/**"]
+include = ["python/megane/static/**", "LICENSE"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests/python"]


### PR DESCRIPTION
The LICENSE file was missing from the maturin include list, causing PyPI upload to fail with "License-File LICENSE does not exist".

https://claude.ai/code/session_01LLWJHEBiehZ9cE6HMBTKHt