### PR TITLE
prepare v0.1.1 release: fix npm package refs, add version management

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <a href="https://github.com/hodakamori/megane/actions/workflows/ci.yml"><img src="https://github.com/hodakamori/megane/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://pypi.org/project/megane/"><img src="https://img.shields.io/pypi/v/megane" alt="PyPI" /></a>
-  <a href="https://www.npmjs.com/package/megane"><img src="https://img.shields.io/npm/v/megane" alt="npm" /></a>
+  <a href="https://www.npmjs.com/package/megane-viewer"><img src="https://img.shields.io/npm/v/megane-viewer" alt="npm" /></a>
   <a href="https://github.com/hodakamori/megane/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License" /></a>
 </p>
 
@@ -16,7 +16,7 @@
   <a href="https://hodakamori.github.io/megane/">Docs</a> &middot;
   <a href="https://hodakamori.github.io/megane/getting-started">Getting Started</a> &middot;
   <a href="https://pypi.org/project/megane/">PyPI</a> &middot;
-  <a href="https://www.npmjs.com/package/megane">npm</a>
+  <a href="https://www.npmjs.com/package/megane-viewer">npm</a>
 </p>
 
 <p align="center">
@@ -45,7 +45,7 @@ pip install megane
 ### npm (for React embedding)
 
 ```bash
-npm install megane
+npm install megane-viewer
 ```
 
 ## Quick Start
@@ -75,7 +75,7 @@ megane serve  # upload from browser
 ### React
 
 ```tsx
-import { MeganeViewer, parseStructureFile } from "megane";
+import { MeganeViewer, parseStructureFile } from "megane-viewer";
 
 function App() {
   const [snapshot, setSnapshot] = useState(null);

--- a/crates/megane-core/Cargo.toml
+++ b/crates/megane-core/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "megane-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"

--- a/crates/megane-python/Cargo.toml
+++ b/crates/megane-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megane-python"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/crates/megane-wasm/Cargo.toml
+++ b/crates/megane-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megane-wasm"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [package.metadata.wasm-pack.profile.release]

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
         items: [
           { text: "GitHub", link: "https://github.com/hodakamori/megane" },
           { text: "PyPI", link: "https://pypi.org/project/megane/" },
-          { text: "npm", link: "https://www.npmjs.com/package/megane" },
+          { text: "npm", link: "https://www.npmjs.com/package/megane-viewer" },
         ],
       },
     ],

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ pip install megane
 ### npm (for React embedding)
 
 ```bash
-npm install megane
+npm install megane-viewer
 ```
 
 ## Quick Start
@@ -68,7 +68,7 @@ megane serve
 ### React Component
 
 ```tsx
-import { MeganeViewer } from "megane";
+import { MeganeViewer } from "megane-viewer";
 
 function App() {
   return (

--- a/docs/guide/web.md
+++ b/docs/guide/web.md
@@ -5,7 +5,7 @@ megane can be embedded in React applications as a component library. It provides
 ## Installation
 
 ```bash
-npm install megane
+npm install megane-viewer
 ```
 
 ## Full-Featured Viewer
@@ -14,8 +14,8 @@ The easiest way to get started is the `MeganeViewer` component. It includes the 
 
 ```tsx
 import { useState, useCallback, useMemo } from "react";
-import { MeganeViewer, parseStructureFile } from "megane";
-import type { Snapshot, BondSource } from "megane";
+import { MeganeViewer, parseStructureFile } from "megane-viewer";
+import type { Snapshot, BondSource } from "megane-viewer";
 
 function App() {
   const [snapshot, setSnapshot] = useState<Snapshot | null>(null);
@@ -110,8 +110,8 @@ For custom layouts, megane exports each panel as a separate component. This give
 The core rendering surface without any UI panels:
 
 ```tsx
-import { Viewport } from "megane";
-import type { Snapshot, HoverInfo } from "megane";
+import { Viewport } from "megane-viewer";
+import type { Snapshot, HoverInfo } from "megane-viewer";
 
 function MinimalViewer({ snapshot }: { snapshot: Snapshot }) {
   return (
@@ -139,7 +139,7 @@ function MinimalViewer({ snapshot }: { snapshot: Snapshot }) {
 Combine individual panels for a custom layout:
 
 ```tsx
-import { Viewport, Sidebar, Timeline, AppearancePanel } from "megane";
+import { Viewport, Sidebar, Timeline, AppearancePanel } from "megane-viewer";
 
 function CustomLayout({ snapshot, frame }) {
   const [renderer, setRenderer] = useState(null);
@@ -198,8 +198,8 @@ function CustomLayout({ snapshot, frame }) {
 For non-React applications (Vue, Svelte, vanilla JS), use `MoleculeRenderer` directly. This is the same Three.js renderer powering all megane components:
 
 ```ts
-import { MoleculeRenderer } from "megane";
-import type { Snapshot } from "megane";
+import { MoleculeRenderer } from "megane-viewer";
+import type { Snapshot } from "megane-viewer";
 
 // Create and mount
 const renderer = new MoleculeRenderer();
@@ -264,7 +264,7 @@ title: Protein Visualization
 ---
 
 import { useState, useEffect } from "react";
-import { MeganeViewer, parseStructureFile } from "megane";
+import { MeganeViewer, parseStructureFile } from "megane-viewer";
 
 export function ProteinDemo() {
   const [snapshot, setSnapshot] = useState(null);
@@ -311,7 +311,7 @@ For a simpler embed without panels:
 
 ```mdx
 import { useState, useEffect } from "react";
-import { Viewport, parseStructureText } from "megane";
+import { Viewport, parseStructureText } from "megane-viewer";
 
 export function SimpleViewer() {
   const [snapshot, setSnapshot] = useState(null);
@@ -366,7 +366,7 @@ import {
   MSG_SNAPSHOT,
   MSG_FRAME,
   MSG_METADATA,
-} from "megane";
+} from "megane-viewer";
 
 ws.onmessage = (event) => {
   const buffer = event.data as ArrayBuffer;
@@ -407,13 +407,13 @@ import type {
   LabelConfig,         // Label panel configuration
   VectorConfig,        // Vector arrow configuration
   StructureParseResult,// Parse result from parseStructureFile/Text
-} from "megane";
+} from "megane-viewer";
 ```
 
 ### Parser Functions
 
 ```ts
-import { parseStructureFile, parseStructureText } from "megane";
+import { parseStructureFile, parseStructureText } from "megane-viewer";
 
 // Parse from File object (drag-and-drop, file input)
 const result = await parseStructureFile(file);

--- a/docs/scripts/prepare-notebooks.py
+++ b/docs/scripts/prepare-notebooks.py
@@ -43,7 +43,7 @@ def inject_demo_outputs(nb: nbformat.NotebookNode) -> None:
         cell_id = cell.get("id", "")
 
         if cell_id == "cell-1" or 'print(f"megane v' in source:
-            cell.outputs = [make_stream("megane v0.1.0\n")]
+            cell.outputs = [make_stream("megane v0.1.1\n")]
 
         elif cell_id == "cell-3" or (
             source.strip().endswith("viewer")
@@ -89,7 +89,7 @@ def inject_external_events_outputs(nb: nbformat.NotebookNode) -> None:
         cell.outputs = []
 
         if 'print(f"megane v' in source:
-            cell.outputs = [make_stream("megane v0.1.0\n")]
+            cell.outputs = [make_stream("megane v0.1.1\n")]
 
         elif "viewer.load" in source and "xtc=" in source and "print" in source:
             cell.outputs = [make_stream("Loaded trajectory: 100 frames\n")]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "megane",
-  "version": "0.1.0",
+  "name": "megane-viewer",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "megane",
-      "version": "0.1.0",
+      "name": "megane-viewer",
+      "version": "0.1.1",
+      "license": "MIT",
       "dependencies": {
         "puppeteer": "^24.37.5",
         "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "megane-viewer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "A fast, beautiful molecular viewer – anywidget-compatible",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "megane"
-version = "0.1.0"
+version = "0.1.1"
 description = "A fast, beautiful molecular viewer"
 requires-python = ">=3.10"
 license = "MIT"
@@ -53,3 +53,44 @@ include = ["python/megane/static/**", "LICENSE"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests/python"]
+
+[tool.bumpversion]
+current_version = "0.1.1"
+commit = false
+tag = false
+allow_dirty = true
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "package.json"
+search = '"version": "{current_version}"'
+replace = '"version": "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "crates/megane-core/Cargo.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "crates/megane-python/Cargo.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "crates/megane-wasm/Cargo.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "python/megane/__init__.py"
+search = '__version__ = "{current_version}"'
+replace = '__version__ = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "docs/scripts/prepare-notebooks.py"
+search = 'megane v{current_version}'
+replace = 'megane v{new_version}'

--- a/python/megane/__init__.py
+++ b/python/megane/__init__.py
@@ -5,4 +5,4 @@ from megane.parsers.xtc import load_trajectory
 from megane.widget import MolecularViewer
 
 __all__ = ["load_pdb", "load_trajectory", "MolecularViewer"]
-__version__ = "0.1.0"
+__version__ = "0.1.1"


### PR DESCRIPTION
- Update all docs to reference npm package name "megane-viewer" (README, getting-started, web guide, VitePress config)
- Update all import examples from "megane" to "megane-viewer"
- Fix npm badge and link URLs to point to megane-viewer
- Add bump-my-version config to pyproject.toml for unified version management
- Bump all versions from 0.1.0 to 0.1.1 (pyproject.toml, package.json, Cargo.toml x3, __init__.py, prepare-notebooks.py)
- Update publish-npm.yml Node version from 20 to 22 (for future OIDC support)

https://claude.ai/code/session_01LLWJHEBiehZ9cE6HMBTKHt