### PR TITLE
feat: support multiple structure loading with layer-based rendering

### DIFF
--- a/src/components/MeganeViewer.tsx
+++ b/src/components/MeganeViewer.tsx
@@ -20,6 +20,8 @@ import { setStructureLoadHandler } from "./nodes/LoadStructureNode";
 import { setTrajectoryLoadHandler } from "./nodes/LoadTrajectoryNode";
 import { setVectorLoadHandler } from "./nodes/LoadVectorNode";
 import { loadVectorFileData } from "../logic/vectorSourceLogic";
+import { parseStructureFile } from "../parsers/structure";
+import type { NodeSnapshotData } from "../pipeline/execute";
 import type {
   Snapshot,
   Frame,
@@ -94,6 +96,16 @@ export function MeganeViewer({
   // Subscribe to pipeline store's viewportState
   const viewportState = usePipelineStore((s) => s.viewportState);
   const setSnapshot = usePipelineStore((s) => s.setSnapshot);
+  const setNodeSnapshot = usePipelineStore((s) => s.setNodeSnapshot);
+  const updateNodeParams = usePipelineStore((s) => s.updateNodeParams);
+
+  // Track the "primary" load_structure node (the first one, for backward compat)
+  const primaryNodeIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    const nodes = usePipelineStore.getState().nodes;
+    const primary = nodes.find((n) => n.type === "load_structure");
+    primaryNodeIdRef.current = primary?.id ?? null;
+  });
 
   // Push snapshot to pipeline store for selection queries
   useEffect(() => {
@@ -103,18 +115,38 @@ export function MeganeViewer({
     const renderer = rendererRef.current;
     if (renderer) {
       const vs = usePipelineStore.getState().viewportState;
-      applyViewportState(renderer, vs, null);
+      applyViewportState(renderer, vs, null, primaryNodeIdRef.current);
       prevViewportStateRef.current = vs;
     }
   }, [snapshot, setSnapshot]);
 
-  // Wire up node event handlers
+  // Wire up node event handlers for per-node structure loading
   useEffect(() => {
-    setStructureLoadHandler((file) => onUploadStructure(file));
+    setStructureLoadHandler((nodeId, file) => {
+      // Parse file and store per-node snapshot
+      parseStructureFile(file).then((result) => {
+        const data: NodeSnapshotData = {
+          snapshot: result.snapshot,
+          frames: result.frames.length > 0 ? result.frames : null,
+          meta: result.meta,
+          labels: result.labels,
+        };
+        setNodeSnapshot(nodeId, data);
+        // Update node port availability indicators
+        updateNodeParams(nodeId, {
+          hasTrajectory: result.frames.length > 0,
+          hasCell: !!result.snapshot.box,
+        });
+      });
+      // For the primary node, also trigger legacy load path for trajectory/label compat
+      if (nodeId === primaryNodeIdRef.current) {
+        onUploadStructure(file);
+      }
+    });
     return () => {
       setStructureLoadHandler(null);
     };
-  }, [onUploadStructure]);
+  }, [onUploadStructure, setNodeSnapshot, updateNodeParams]);
 
   useEffect(() => {
     if (onUploadTrajectory) {
@@ -144,7 +176,7 @@ export function MeganeViewer({
   useEffect(() => {
     const renderer = rendererRef.current;
     if (!renderer) return;
-    applyViewportState(renderer, viewportState, prevViewportStateRef.current);
+    applyViewportState(renderer, viewportState, prevViewportStateRef.current, primaryNodeIdRef.current);
     prevViewportStateRef.current = viewportState;
   }, [viewportState]);
 
@@ -193,7 +225,7 @@ export function MeganeViewer({
       0,
       pipelineCollapsedRef.current ? 0 : pipelineWidthRef.current + 12,
     );
-    applyViewportState(renderer, usePipelineStore.getState().viewportState, null);
+    applyViewportState(renderer, usePipelineStore.getState().viewportState, null, primaryNodeIdRef.current);
     prevViewportStateRef.current = usePipelineStore.getState().viewportState;
   }, []);
 

--- a/src/components/nodes/LoadStructureNode.tsx
+++ b/src/components/nodes/LoadStructureNode.tsx
@@ -20,7 +20,7 @@ const STRUCTURE_EXTS = [".pdb", ".gro", ".xyz", ".mol", ".sdf"];
  * Event bus for structure loading.
  * MeganeViewer listens for these events to trigger actual file parsing.
  */
-export type StructureLoadHandler = (file: File) => void;
+export type StructureLoadHandler = (nodeId: string, file: File) => void;
 let _onStructureLoad: StructureLoadHandler | null = null;
 export function setStructureLoadHandler(handler: StructureLoadHandler | null) {
   _onStructureLoad = handler;
@@ -36,7 +36,7 @@ export function LoadStructureNode({ id, data }: NodeProps<Node<PipelineNodeData>
       const lower = file.name.toLowerCase();
       if (!STRUCTURE_EXTS.some((ext) => lower.endsWith(ext))) return;
       updateNodeParams(id, { fileName: file.name });
-      _onStructureLoad?.(file);
+      _onStructureLoad?.(id, file);
     },
     [id, updateNodeParams],
   );

--- a/src/pipeline/apply.ts
+++ b/src/pipeline/apply.ts
@@ -1,6 +1,12 @@
 /**
  * Applies a ViewportState to a MoleculeRenderer instance.
  * Translates the typed data streams into renderer calls.
+ *
+ * Supports multi-structure overlay: particles/bonds/cells from different
+ * load_structure nodes are routed to separate StructureLayers in the renderer.
+ * The "primary" structure (first particle source, matching the Viewport's
+ * snapshot prop) uses the renderer's built-in atom/bond renderers.
+ * Additional structures use StructureLayer instances.
  */
 
 import type { ViewportState, ParticleData, BondData, CellData, LabelData, MeshData, VectorData } from "./types";
@@ -15,35 +21,106 @@ export function applyViewportState(
   renderer: MoleculeRenderer,
   current: ViewportState,
   previous: ViewportState | null,
+  primaryNodeId?: string | null,
 ): void {
-  // ─── Atom visibility (hide when no viewport node produces data) ──
-  const hasParticles = current.particles.length > 0;
-  const hadParticles = (previous?.particles.length ?? 0) > 0;
+  // ─── Determine which node IDs are primary vs layer ─────────
+  const currentNodeIds = collectSourceNodeIds(current);
+  const resolvedPrimaryId = primaryNodeId ?? currentNodeIds[0] ?? null;
+
+  // Group data by source node
+  const primaryParticles = current.particles.filter((p) => p.sourceNodeId === resolvedPrimaryId);
+  const layerParticles = current.particles.filter((p) => p.sourceNodeId !== resolvedPrimaryId);
+  const primaryBonds = current.bonds.filter((b) => b.sourceNodeId === resolvedPrimaryId);
+  const layerBonds = current.bonds.filter((b) => b.sourceNodeId !== resolvedPrimaryId);
+  const primaryCells = current.cells.filter((c) => c.sourceNodeId === resolvedPrimaryId);
+  const layerCells = current.cells.filter((c) => c.sourceNodeId !== resolvedPrimaryId);
+
+  // Previous state grouping
+  const prevPrimaryParticles = previous?.particles.filter((p) => p.sourceNodeId === resolvedPrimaryId) ?? null;
+  const prevPrimaryBonds = previous?.bonds.filter((b) => b.sourceNodeId === resolvedPrimaryId) ?? null;
+
+  // ─── Primary structure: use renderer's built-in renderers ──
+  const hasParticles = primaryParticles.length > 0;
+  const hadParticles = (prevPrimaryParticles?.length ?? 0) > 0;
   if (!previous || hasParticles !== hadParticles) {
     renderer.setAtomsVisible(hasParticles);
   }
 
-  // ─── Atom scale/opacity from particle data ─────────────────
-  applyParticleOverrides(renderer, current.particles, previous?.particles ?? null);
+  applyParticleOverrides(renderer, primaryParticles, prevPrimaryParticles);
+  applyBondSettings(renderer, primaryBonds, prevPrimaryBonds);
 
-  // ─── Bond scale/opacity ────────────────────────────────────
-  applyBondSettings(renderer, current.bonds, previous?.bonds ?? null);
-
-  // ─── Cell visibility ───────────────────────────────────────
-  const hasCells = current.cells.length > 0;
-  const hadCells = (previous?.cells.length ?? 0) > 0;
-  const cellVisible = hasCells && current.cells.some((c) => c.visible);
-  const prevCellVisible = hadCells && (previous?.cells.some((c) => c.visible) ?? false);
+  // Primary cell visibility
+  const hasCells = primaryCells.length > 0;
+  const hadCells = (previous ? previous.cells.filter((c) => c.sourceNodeId === resolvedPrimaryId).length : 0) > 0;
+  const cellVisible = hasCells && primaryCells.some((c) => c.visible);
+  const prevCellVisible = hadCells && (previous?.cells.filter((c) => c.sourceNodeId === resolvedPrimaryId).some((c) => c.visible) ?? false);
   if (!previous || cellVisible !== prevCellVisible) {
     renderer.setCellVisible(cellVisible);
   }
 
-  const cellAxesVisible = hasCells && current.cells.some((c) => c.axesVisible);
-  if (!previous || cellAxesVisible !== (previous.cellAxesVisible ?? true)) {
+  const cellAxesVisible = hasCells && primaryCells.some((c) => c.axesVisible);
+  if (!previous || cellAxesVisible !== (previous?.cellAxesVisible ?? true)) {
     renderer.setCellAxesVisible(cellAxesVisible);
   }
 
-  // ─── Display settings ──────────────────────────────────────
+  // Primary bonds visibility
+  const bondsVisible = primaryBonds.length > 0;
+  const prevBondsVisible = (prevPrimaryBonds?.length ?? 0) > 0;
+  if (!previous || bondsVisible !== prevBondsVisible) {
+    renderer.setBondsVisible(bondsVisible);
+  }
+
+  // ─── Layer structures: use StructureLayer instances ────────
+  const activeLayerIds = new Set<string>();
+
+  // Group layer particles by sourceNodeId
+  const layerParticlesByNode = groupBy(layerParticles, (p) => p.sourceNodeId);
+  const layerBondsByNode = groupBy(layerBonds, (b) => b.sourceNodeId);
+  const layerCellsByNode = groupBy(layerCells, (c) => c.sourceNodeId);
+
+  for (const [nodeId, particles] of layerParticlesByNode) {
+    activeLayerIds.add(nodeId);
+    const layer = renderer.getOrCreateLayer(nodeId);
+
+    // Load snapshot if the layer doesn't have one yet, or if it changed
+    const firstParticle = particles[0];
+    if (firstParticle && layer.snapshot !== firstParticle.source) {
+      layer.loadSnapshot(firstParticle.source);
+    }
+
+    // Apply overrides
+    applyLayerParticleOverrides(layer, particles);
+
+    // Apply bonds for this layer
+    const bonds = layerBondsByNode.get(nodeId);
+    if (bonds && bonds.length > 0) {
+      const bond = bonds[0];
+      layer.updateBondsExt(
+        bond.bondIndices, bond.bondOrders,
+        bond.positions, bond.elements, bond.nAtoms,
+      );
+      layer.setBondScale(bond.scale);
+      layer.setBondOpacity(bond.opacity);
+      layer.setBondsVisible(true);
+    } else {
+      layer.setBondsVisible(false);
+    }
+
+    // Apply cells for this layer
+    const cells = layerCellsByNode.get(nodeId);
+    if (cells && cells.length > 0) {
+      layer.setCellVisible(cells.some((c) => c.visible));
+    } else {
+      layer.setCellVisible(false);
+    }
+
+    layer.setAtomsVisible(true);
+  }
+
+  // Remove layers that no longer have particles
+  renderer.removeInactiveLayers(activeLayerIds);
+
+  // ─── Display settings (global) ─────────────────────────────
   if (!previous || current.perspective !== previous.perspective) {
     renderer.setPerspective(current.perspective);
   }
@@ -51,21 +128,38 @@ export function applyViewportState(
     renderer.setCellAxesVisible(current.cellAxesVisible);
   }
 
-  // ─── Labels ────────────────────────────────────────────────
+  // ─── Labels (primary structure only for now) ───────────────
   applyLabels(renderer, current.labels, previous?.labels ?? null);
 
-  // ─── Meshes (polyhedra) ───────────────────────────────────
+  // ─── Meshes (polyhedra) ────────────────────────────────────
   applyMeshes(renderer, current.meshes, previous?.meshes ?? null);
 
-  // ─── Vectors (arrows) ──────────────────────────────────────
+  // ─── Vectors (arrows, primary structure only for now) ──────
   applyVectors(renderer, current.vectors, previous?.vectors ?? null);
+}
 
-  // ─── Bonds visibility ──────────────────────────────────────
-  const bondsVisible = current.bonds.length > 0;
-  const prevBondsVisible = (previous?.bonds.length ?? 0) > 0;
-  if (!previous || bondsVisible !== prevBondsVisible) {
-    renderer.setBondsVisible(bondsVisible);
+/** Collect unique source node IDs from all data in a ViewportState. */
+function collectSourceNodeIds(state: ViewportState): string[] {
+  const ids = new Set<string>();
+  for (const p of state.particles) ids.add(p.sourceNodeId);
+  for (const b of state.bonds) ids.add(b.sourceNodeId);
+  for (const c of state.cells) ids.add(c.sourceNodeId);
+  return Array.from(ids);
+}
+
+/** Group items by a key function. */
+function groupBy<T>(items: T[], keyFn: (item: T) => string): Map<string, T[]> {
+  const map = new Map<string, T[]>();
+  for (const item of items) {
+    const key = keyFn(item);
+    let list = map.get(key);
+    if (!list) {
+      list = [];
+      map.set(key, list);
+    }
+    list.push(item);
   }
+  return map;
 }
 
 function applyParticleOverrides(
@@ -82,8 +176,7 @@ function applyParticleOverrides(
     return;
   }
 
-  // Merge overrides from all particle streams
-  // (for now, take the first particle with overrides or the first particle)
+  // Merge overrides from all particle streams for the primary structure
   let mergedScale: Float32Array | null = null;
   let mergedOpacity: Float32Array | null = null;
 
@@ -92,7 +185,6 @@ function applyParticleOverrides(
       if (!mergedScale) {
         mergedScale = new Float32Array(p.scaleOverrides);
       } else {
-        // Merge: overwrite values where the new override differs
         for (let i = 0; i < mergedScale.length; i++) {
           if (p.scaleOverrides[i] !== 1.0) {
             mergedScale[i] = p.scaleOverrides[i];
@@ -129,6 +221,55 @@ function applyParticleOverrides(
   }
 }
 
+/** Apply overrides to a StructureLayer. */
+function applyLayerParticleOverrides(
+  layer: { setAtomScale: (s: number) => void; setAtomOpacity: (o: number) => void; setAtomScaleOverrides: (o: Float32Array) => void; setAtomOpacityOverrides: (o: Float32Array) => void; clearAtomOverrides: () => void },
+  particles: ParticleData[],
+): void {
+  let mergedScale: Float32Array | null = null;
+  let mergedOpacity: Float32Array | null = null;
+
+  for (const p of particles) {
+    if (p.scaleOverrides) {
+      if (!mergedScale) {
+        mergedScale = new Float32Array(p.scaleOverrides);
+      } else {
+        for (let i = 0; i < mergedScale.length; i++) {
+          if (p.scaleOverrides[i] !== 1.0) {
+            mergedScale[i] = p.scaleOverrides[i];
+          }
+        }
+      }
+    }
+    if (p.opacityOverrides) {
+      if (!mergedOpacity) {
+        mergedOpacity = new Float32Array(p.opacityOverrides);
+      } else {
+        for (let i = 0; i < mergedOpacity.length; i++) {
+          if (p.opacityOverrides[i] !== 1.0) {
+            mergedOpacity[i] = p.opacityOverrides[i];
+          }
+        }
+      }
+    }
+  }
+
+  if (mergedScale) {
+    layer.setAtomScale(1.0);
+    layer.setAtomScaleOverrides(mergedScale);
+  } else {
+    layer.clearAtomOverrides();
+    layer.setAtomScale(1.0);
+  }
+
+  if (mergedOpacity) {
+    layer.setAtomOpacity(1.0);
+    layer.setAtomOpacityOverrides(mergedOpacity);
+  } else {
+    layer.setAtomOpacity(1.0);
+  }
+}
+
 function applyBondSettings(
   renderer: MoleculeRenderer,
   bonds: BondData[],
@@ -136,11 +277,9 @@ function applyBondSettings(
 ): void {
   if (bonds.length === 0) return;
 
-  // Use the first bond stream's settings (merge is possible in future)
   const bond = bonds[0];
   const prevBond = prevBonds?.[0];
 
-  // Update bond topology when bond indices change (PBC filtering, etc.)
   if (!prevBond || bond.bondIndices !== prevBond.bondIndices) {
     renderer.updateBondsExt(
       bond.bondIndices, bond.bondOrders,

--- a/src/pipeline/execute.ts
+++ b/src/pipeline/execute.ts
@@ -48,6 +48,14 @@ export interface PipelineNodeData {
  * Execute the pipeline and produce a ViewportState.
  * Returns DEFAULT_VIEWPORT_STATE if no viewport node exists.
  */
+/** Per-node snapshot data stored for each load_structure node. */
+export interface NodeSnapshotData {
+  snapshot: Snapshot;
+  frames: Frame[] | null;
+  meta: TrajectoryMeta | null;
+  labels: string[] | null;
+}
+
 export interface PipelineExecutionContext {
   snapshot?: Snapshot | null;
   atomLabels?: string[] | null;
@@ -56,6 +64,8 @@ export interface PipelineExecutionContext {
   fileFrames?: Frame[] | null;
   fileMeta?: TrajectoryMeta | null;
   fileVectors?: VectorFrame[] | null;
+  /** Per-node snapshots keyed by load_structure node ID. */
+  nodeSnapshots?: Record<string, NodeSnapshotData>;
 }
 
 export function executePipeline(
@@ -99,11 +109,17 @@ export function executePipeline(
 
     switch (data.params.type) {
       case "load_structure": {
+        // Per-node snapshot takes priority; fall back to global snapshot for backward compat
+        const nodeData = ctx.nodeSnapshots?.[id];
+        const snapshot = nodeData?.snapshot ?? ctx.snapshot ?? null;
+        const frames = nodeData?.frames ?? ctx.structureFrames ?? null;
+        const meta = nodeData?.meta ?? ctx.structureMeta ?? null;
         const outputs = executeLoadStructure(
           data.params as LoadStructureParams,
-          ctx.snapshot ?? null,
-          ctx.structureFrames ?? null,
-          ctx.structureMeta ?? null,
+          snapshot,
+          frames,
+          meta,
+          id,
         );
         edgeOutputs.set(id, outputs);
         break;

--- a/src/pipeline/executors/addBond.ts
+++ b/src/pipeline/executors/addBond.ts
@@ -200,6 +200,7 @@ export function executeAddBond(
       if (nBonds > 0) {
         const bond: BondData = {
           type: "bond",
+          sourceNodeId: particleData.sourceNodeId,
           bondIndices,
           bondOrders,
           nBonds,
@@ -240,6 +241,7 @@ export function executeAddBond(
       if (nBonds > 0) {
         const bond: BondData = {
           type: "bond",
+          sourceNodeId: particleData.sourceNodeId,
           bondIndices,
           bondOrders: null,
           nBonds,

--- a/src/pipeline/executors/loadStructure.ts
+++ b/src/pipeline/executors/loadStructure.ts
@@ -12,6 +12,7 @@ export function executeLoadStructure(
   snapshot: Snapshot | null,
   structureFrames: Frame[] | null,
   structureMeta: TrajectoryMeta | null,
+  sourceNodeId: string,
 ): Map<string, PipelineData> {
   const outputs = new Map<string, PipelineData>();
   if (!snapshot) return outputs;
@@ -19,6 +20,7 @@ export function executeLoadStructure(
   const particle: ParticleData = {
     type: "particle",
     source: snapshot,
+    sourceNodeId,
     indices: null,
     scaleOverrides: null,
     opacityOverrides: null,
@@ -38,6 +40,7 @@ export function executeLoadStructure(
   if (snapshot.box) {
     const cell: CellData = {
       type: "cell",
+      sourceNodeId,
       box: snapshot.box,
       visible: true,
       axesVisible: true,

--- a/src/pipeline/store.ts
+++ b/src/pipeline/store.ts
@@ -6,7 +6,7 @@
 import { create } from "zustand";
 import type { Node, Edge, OnNodesChange, OnEdgesChange, Connection } from "@xyflow/react";
 import { applyNodeChanges, applyEdgeChanges, addEdge } from "@xyflow/react";
-import type { PipelineNodeData, PipelineExecutionContext } from "./execute";
+import type { PipelineNodeData, PipelineExecutionContext, NodeSnapshotData } from "./execute";
 import type { Snapshot, Frame, TrajectoryMeta, VectorFrame } from "../types";
 import type { PipelineNodeType, ViewportState, SerializedPipeline } from "./types";
 import { defaultParams, DEFAULT_VIEWPORT_STATE, canConnect, NODE_PORTS, GENERIC_NODE_ACCEPTS } from "./types";
@@ -37,11 +37,16 @@ export interface PipelineStore {
   fileMeta: TrajectoryMeta | null;
   fileVectors: VectorFrame[] | null;
 
+  // Per-node snapshot storage (keyed by load_structure node ID)
+  nodeSnapshots: Record<string, NodeSnapshotData>;
+
   setSnapshot: (s: Snapshot | null) => void;
   setAtomLabels: (labels: string[] | null) => void;
   setStructureFrames: (frames: Frame[] | null, meta: TrajectoryMeta | null) => void;
   setFileFrames: (frames: Frame[] | null, meta: TrajectoryMeta | null) => void;
   setFileVectors: (vectors: VectorFrame[] | null) => void;
+  setNodeSnapshot: (nodeId: string, data: NodeSnapshotData) => void;
+  removeNodeSnapshot: (nodeId: string) => void;
 
   // xyflow change handlers
   onNodesChange: OnNodesChange<Node<PipelineNodeData>>;
@@ -94,6 +99,7 @@ export const usePipelineStore = create<PipelineStore>((set, get) => ({
   fileFrames: null,
   fileMeta: null,
   fileVectors: null,
+  nodeSnapshots: {},
 
   setSnapshot: (s) => {
     set({ snapshot: s });
@@ -113,6 +119,21 @@ export const usePipelineStore = create<PipelineStore>((set, get) => ({
   },
   setFileVectors: (vectors) => {
     set({ fileVectors: vectors });
+    get().execute();
+  },
+
+  setNodeSnapshot: (nodeId, data) => {
+    set((state) => ({
+      nodeSnapshots: { ...state.nodeSnapshots, [nodeId]: data },
+    }));
+    get().execute();
+  },
+
+  removeNodeSnapshot: (nodeId) => {
+    set((state) => {
+      const { [nodeId]: _, ...rest } = state.nodeSnapshots;
+      return { nodeSnapshots: rest };
+    });
     get().execute();
   },
 
@@ -195,10 +216,14 @@ export const usePipelineStore = create<PipelineStore>((set, get) => ({
   },
 
   removeNode: (id) => {
-    set((state) => ({
-      nodes: state.nodes.filter((n) => n.id !== id),
-      edges: state.edges.filter((e) => e.source !== id && e.target !== id),
-    }));
+    set((state) => {
+      const { [id]: _, ...restSnapshots } = state.nodeSnapshots;
+      return {
+        nodes: state.nodes.filter((n) => n.id !== id),
+        edges: state.edges.filter((e) => e.source !== id && e.target !== id),
+        nodeSnapshots: restSnapshots,
+      };
+    });
     get().execute();
   },
 
@@ -232,7 +257,7 @@ export const usePipelineStore = create<PipelineStore>((set, get) => ({
   },
 
   execute: () => {
-    const { nodes, edges, snapshot, atomLabels, structureFrames, structureMeta, fileFrames, fileMeta, fileVectors } = get();
+    const { nodes, edges, snapshot, atomLabels, structureFrames, structureMeta, fileFrames, fileMeta, fileVectors, nodeSnapshots } = get();
     const ctx: PipelineExecutionContext = {
       snapshot,
       atomLabels,
@@ -241,6 +266,7 @@ export const usePipelineStore = create<PipelineStore>((set, get) => ({
       fileFrames,
       fileMeta,
       fileVectors,
+      nodeSnapshots,
     };
     const viewportState = executePipeline(nodes, edges, ctx);
     set({ viewportState });

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -26,6 +26,7 @@ export const DATA_TYPE_COLORS: Record<PipelineDataType, string> = {
 export interface ParticleData {
   type: "particle";
   source: Snapshot;
+  sourceNodeId: string;                  // load_structure node that produced this
   indices: Uint32Array | null;           // null = all atoms
   scaleOverrides: Float32Array | null;
   opacityOverrides: Float32Array | null;
@@ -34,6 +35,7 @@ export interface ParticleData {
 /** Bond data flowing through the pipeline. */
 export interface BondData {
   type: "bond";
+  sourceNodeId: string;              // load_structure node that produced the particles
   bondIndices: Uint32Array;  // pairs: [a0,b0, a1,b1, ...]
   bondOrders: Uint8Array | null;
   nBonds: number;
@@ -48,6 +50,7 @@ export interface BondData {
 /** Simulation cell data. */
 export interface CellData {
   type: "cell";
+  sourceNodeId: string;              // load_structure node that produced this
   box: Float32Array; // 3x3 row-major
   visible: boolean;
   axesVisible: boolean;

--- a/src/renderer/MoleculeRenderer.ts
+++ b/src/renderer/MoleculeRenderer.ts
@@ -26,6 +26,7 @@ import { CellAxesRenderer } from "./CellAxesRenderer";
 import { LabelOverlay } from "./LabelOverlay";
 import { ArrowRenderer } from "./ArrowRenderer";
 import { PolyhedronRenderer } from "./PolyhedronRenderer";
+import { StructureLayer } from "./StructureLayer";
 import type { MeshData } from "../pipeline/types";
 import {
   getRadius,
@@ -76,6 +77,9 @@ export class MoleculeRenderer {
   private lastContainerW = 0;
   private lastContainerH = 0;
   private lastDpr = 1;
+
+  /** Structure layers for multi-structure overlay rendering. */
+  private layers = new Map<string, StructureLayer>();
 
   // (screen-space picking replaces Three.js raycasting)
 
@@ -335,6 +339,65 @@ export class MoleculeRenderer {
     if (this.polyhedronRenderer) {
       this.polyhedronRenderer.clear();
     }
+  }
+
+  // ── Structure Layer Management ─────────────────────────────────
+
+  /** Get or create a structure layer for a given node ID. */
+  getOrCreateLayer(layerId: string): StructureLayer {
+    let layer = this.layers.get(layerId);
+    if (!layer) {
+      layer = new StructureLayer(layerId, this.scene);
+      this.layers.set(layerId, layer);
+    }
+    return layer;
+  }
+
+  /** Get an existing structure layer (or undefined). */
+  getLayer(layerId: string): StructureLayer | undefined {
+    return this.layers.get(layerId);
+  }
+
+  /** Remove a structure layer and dispose its resources. */
+  removeLayer(layerId: string): void {
+    const layer = this.layers.get(layerId);
+    if (layer) {
+      layer.dispose();
+      this.layers.delete(layerId);
+    }
+  }
+
+  /** Get all current layer IDs. */
+  getLayerIds(): string[] {
+    return Array.from(this.layers.keys());
+  }
+
+  /** Remove layers not in the given set of active IDs. */
+  removeInactiveLayers(activeIds: Set<string>): void {
+    for (const [id, layer] of this.layers) {
+      if (!activeIds.has(id)) {
+        layer.dispose();
+        this.layers.delete(id);
+      }
+    }
+  }
+
+  /**
+   * Fit camera to show all structures (from all layers + primary snapshot).
+   * Call after loading snapshots into layers.
+   */
+  fitToViewAll(): void {
+    // Collect all snapshots from layers
+    const snapshots: Snapshot[] = [];
+    if (this.snapshot) snapshots.push(this.snapshot);
+    for (const layer of this.layers.values()) {
+      if (layer.snapshot) snapshots.push(layer.snapshot);
+    }
+    if (snapshots.length === 0) return;
+
+    // Use the first snapshot for fitToView (simple approach)
+    // TODO: merge bounding boxes from all snapshots for true fit
+    this.fitToView(snapshots[0]);
   }
 
   /** Set atom radius scale multiplier. */
@@ -815,6 +878,11 @@ export class MoleculeRenderer {
     if (this.arrowRenderer) this.arrowRenderer.dispose();
     if (this.polyhedronRenderer) this.polyhedronRenderer.dispose();
     if (this.labelOverlay) this.labelOverlay.dispose();
+    // Dispose all structure layers
+    for (const layer of this.layers.values()) {
+      layer.dispose();
+    }
+    this.layers.clear();
     if (this.dprMediaQuery && this.dprChangeHandler) {
       this.dprMediaQuery.removeEventListener("change", this.dprChangeHandler);
     }

--- a/src/renderer/StructureLayer.ts
+++ b/src/renderer/StructureLayer.ts
@@ -1,0 +1,186 @@
+/**
+ * StructureLayer: manages rendering objects for a single molecular structure.
+ * Multiple StructureLayers can coexist in the same Three.js scene,
+ * enabling overlay of e.g. all-atom and coarse-grained models.
+ */
+
+import * as THREE from "three";
+import type { Snapshot, Frame, AtomRenderer, BondRenderer } from "../types";
+import { ImpostorAtomMesh } from "./ImpostorAtomMesh";
+import { ImpostorBondMesh } from "./ImpostorBondMesh";
+import { CellRenderer } from "./CellRenderer";
+
+export class StructureLayer {
+  readonly id: string;
+  snapshot: Snapshot | null = null;
+  currentPositions: Float32Array | null = null;
+
+  private scene: THREE.Scene;
+  private atomRenderer: AtomRenderer | null = null;
+  private bondRenderer: BondRenderer | null = null;
+  private cellRenderer: CellRenderer | null = null;
+
+  private atomScale = 1.0;
+  private atomOpacity = 1.0;
+  private bondScale = 1.0;
+  private bondOpacity = 1.0;
+
+  constructor(id: string, scene: THREE.Scene) {
+    this.id = id;
+    this.scene = scene;
+  }
+
+  loadSnapshot(snapshot: Snapshot): void {
+    this.snapshot = snapshot;
+    this.currentPositions = new Float32Array(snapshot.positions);
+
+    if (!this.atomRenderer) {
+      const atoms = new ImpostorAtomMesh();
+      this.atomRenderer = atoms;
+      this.scene.add(atoms.mesh);
+    }
+    this.atomRenderer.loadSnapshot(snapshot);
+
+    if (this.atomScale !== 1.0 && this.atomRenderer.setScale) {
+      this.atomRenderer.setScale(this.atomScale, snapshot);
+    }
+    if (this.atomOpacity !== 1.0 && this.atomRenderer.setOpacity) {
+      this.atomRenderer.setOpacity(this.atomOpacity);
+    }
+
+    if (!this.bondRenderer) {
+      const bonds = new ImpostorBondMesh();
+      this.bondRenderer = bonds;
+      this.scene.add(bonds.mesh);
+    }
+
+    // Cell
+    if (snapshot.box) {
+      const hasNonZero = snapshot.box.some((v) => v !== 0);
+      if (hasNonZero) {
+        if (!this.cellRenderer) {
+          this.cellRenderer = new CellRenderer();
+          this.scene.add(this.cellRenderer.mesh);
+        }
+        this.cellRenderer.loadBox(snapshot.box);
+      }
+    }
+  }
+
+  updateFrame(frame: Frame): void {
+    if (!this.snapshot || !this.atomRenderer || !this.bondRenderer) return;
+    if (!this.currentPositions || this.currentPositions.length < frame.positions.length) {
+      this.currentPositions = new Float32Array(frame.positions.length);
+    }
+    this.currentPositions.set(frame.positions);
+    this.atomRenderer.updatePositions(frame.positions);
+    this.bondRenderer.updatePositions(
+      frame.positions,
+      this.snapshot.bonds,
+      this.snapshot.nBonds,
+    );
+  }
+
+  updateBondsExt(
+    bonds: Uint32Array,
+    bondOrders: Uint8Array | null,
+    positions: Float32Array | null,
+    elements: Uint8Array | null,
+    nAtoms: number,
+  ): void {
+    if (!this.snapshot || !this.bondRenderer) return;
+    const pos = positions ?? this.currentPositions ?? this.snapshot.positions;
+    const elems = elements ?? this.snapshot.elements;
+    const atomCount = nAtoms || this.snapshot.nAtoms;
+    this.bondRenderer.loadSnapshot({
+      ...this.snapshot,
+      nAtoms: atomCount,
+      nBonds: bonds.length / 2,
+      bonds,
+      bondOrders,
+      positions: pos,
+      elements: elems,
+    });
+    if (this.bondScale !== 1.0 && this.bondRenderer.setScale) {
+      this.bondRenderer.setScale(this.bondScale, this.snapshot);
+    }
+  }
+
+  setAtomScale(scale: number): void {
+    this.atomScale = scale;
+    if (this.atomRenderer?.setScale && this.snapshot) {
+      this.atomRenderer.setScale(scale, this.snapshot);
+    }
+  }
+
+  setAtomOpacity(opacity: number): void {
+    this.atomOpacity = opacity;
+    this.atomRenderer?.setOpacity?.(opacity);
+  }
+
+  setAtomScaleOverrides(overrides: Float32Array): void {
+    this.atomRenderer?.setScaleOverrides?.(overrides);
+  }
+
+  setAtomOpacityOverrides(overrides: Float32Array): void {
+    this.atomRenderer?.setOpacityOverrides?.(overrides);
+  }
+
+  clearAtomOverrides(): void {
+    this.atomRenderer?.clearOverrides?.();
+  }
+
+  setBondScale(scale: number): void {
+    this.bondScale = scale;
+    if (this.bondRenderer?.setScale && this.snapshot) {
+      this.bondRenderer.setScale(scale, this.snapshot);
+    }
+  }
+
+  setBondOpacity(opacity: number): void {
+    this.bondOpacity = opacity;
+    this.bondRenderer?.setOpacity?.(opacity);
+  }
+
+  setAtomsVisible(visible: boolean): void {
+    if (this.atomRenderer) {
+      this.atomRenderer.mesh.visible = visible;
+    }
+  }
+
+  setBondsVisible(visible: boolean): void {
+    if (this.bondRenderer) {
+      this.bondRenderer.mesh.visible = visible;
+    }
+  }
+
+  setCellVisible(visible: boolean): void {
+    if (this.cellRenderer) {
+      this.cellRenderer.setVisible(visible);
+    }
+  }
+
+  getPositions(): Float32Array | null {
+    return this.currentPositions ?? this.snapshot?.positions ?? null;
+  }
+
+  dispose(): void {
+    if (this.atomRenderer) {
+      this.scene.remove(this.atomRenderer.mesh);
+      this.atomRenderer.dispose();
+      this.atomRenderer = null;
+    }
+    if (this.bondRenderer) {
+      this.scene.remove(this.bondRenderer.mesh);
+      this.bondRenderer.dispose();
+      this.bondRenderer = null;
+    }
+    if (this.cellRenderer) {
+      this.scene.remove(this.cellRenderer.mesh);
+      this.cellRenderer.dispose();
+      this.cellRenderer = null;
+    }
+    this.snapshot = null;
+    this.currentPositions = null;
+  }
+}


### PR DESCRIPTION
Each load_structure node can now independently load its own structure file. Multiple structures overlay in the same viewport using separate rendering layers (StructureLayer), with correct depth testing.

Key changes:
- Per-node snapshot storage in pipeline store (nodeSnapshots map)
- Pipeline execution uses per-node snapshots for each load_structure node
- New StructureLayer class manages per-structure atom/bond/cell rendering
- MoleculeRenderer gains layer management (getOrCreateLayer, removeLayer)
- apply.ts routes particle/bond/cell data to correct layers by sourceNodeId
- LoadStructureNode handler passes nodeId for per-node file parsing

https://claude.ai/code/session_01BuZvdELRyXC1HFEMahLAeA