### PR TITLE
feat: add pipeline skills framework with Claude tool_use integration

### DIFF
--- a/src/ai/client.ts
+++ b/src/ai/client.ts
@@ -1,11 +1,34 @@
 /**
  * LLM API client for pipeline generation.
- * Supports Anthropic and OpenAI APIs with streaming.
+ * Supports Anthropic (with tool_use for skills) and OpenAI APIs with streaming.
  */
 
 import type { AIConfig } from "./config";
 import type { SerializedPipeline } from "../pipeline/types";
 import { buildSystemPrompt } from "./prompt";
+import {
+  getSkills,
+  buildToolDefinitions,
+  executeSkill,
+  type PipelineSkill,
+  type ToolDefinition,
+} from "./skillLoader";
+
+// ─── Types for Anthropic SSE parsing ─────────────────────────────────
+
+interface ToolUseAccumulator {
+  id: string;
+  name: string;
+  inputJson: string;
+}
+
+interface AnthropicStreamResult {
+  text: string;
+  stopReason: string;
+  toolUses: ToolUseAccumulator[];
+}
+
+// ─── Public API ──────────────────────────────────────────────────────
 
 /**
  * Generate a pipeline by calling the LLM API with streaming.
@@ -20,54 +43,193 @@ export async function generatePipeline(
   const systemPrompt = buildSystemPrompt();
 
   if (config.provider === "anthropic") {
-    return streamAnthropic(config, systemPrompt, userMessage, onChunk, signal);
+    const skills = getSkills();
+    const tools = buildToolDefinitions(skills);
+    return streamAnthropicWithSkills(
+      config,
+      systemPrompt,
+      userMessage,
+      skills,
+      tools,
+      onChunk,
+      signal,
+    );
   } else {
     return streamOpenAI(config, systemPrompt, userMessage, onChunk, signal);
   }
 }
 
-async function streamAnthropic(
+// ─── Anthropic with tool_use ─────────────────────────────────────────
+
+/**
+ * Stream an Anthropic API call, handling tool_use for skills.
+ * If Claude calls a skill tool, we execute it locally and send
+ * the result back in a follow-up request.
+ */
+async function streamAnthropicWithSkills(
   config: AIConfig,
   systemPrompt: string,
   userMessage: string,
+  skills: PipelineSkill[],
+  tools: ToolDefinition[],
   onChunk: (text: string) => void,
   signal?: AbortSignal,
 ): Promise<string> {
-  const response = await fetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
-    headers: {
-      "x-api-key": config.apiKey,
-      "anthropic-version": "2023-06-01",
-      "content-type": "application/json",
-      "anthropic-dangerous-direct-browser-access": "true",
-    },
-    body: JSON.stringify({
+  type Message = { role: string; content: unknown };
+  const messages: Message[] = [{ role: "user", content: userMessage }];
+
+  // Allow up to 3 tool-use round trips to prevent infinite loops
+  for (let turn = 0; turn < 4; turn++) {
+    const body: Record<string, unknown> = {
       model: config.model,
       max_tokens: 4096,
       system: systemPrompt,
-      messages: [{ role: "user", content: userMessage }],
+      messages,
       stream: true,
-    }),
-    signal,
-  });
+    };
 
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`Anthropic API error (${response.status}): ${body}`);
+    // Only include tools if we have skills defined
+    if (tools.length > 0) {
+      body.tools = tools;
+    }
+
+    const response = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "x-api-key": config.apiKey,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+        "anthropic-dangerous-direct-browser-access": "true",
+      },
+      body: JSON.stringify(body),
+      signal,
+    });
+
+    if (!response.ok) {
+      const errBody = await response.text();
+      throw new Error(`Anthropic API error (${response.status}): ${errBody}`);
+    }
+
+    const result = await readAnthropicSSE(response, onChunk);
+
+    // If the model stopped with end_turn (text response), we're done
+    if (result.stopReason !== "tool_use") {
+      return result.text;
+    }
+
+    // Model wants to use tools — build the assistant message content blocks
+    const assistantContent: unknown[] = [];
+    if (result.text) {
+      assistantContent.push({ type: "text", text: result.text });
+    }
+    for (const tu of result.toolUses) {
+      let parsedInput = {};
+      try {
+        if (tu.inputJson) {
+          parsedInput = JSON.parse(tu.inputJson);
+        }
+      } catch {
+        // empty input is fine for skills with no parameters
+      }
+      assistantContent.push({
+        type: "tool_use",
+        id: tu.id,
+        name: tu.name,
+        input: parsedInput,
+      });
+    }
+    messages.push({ role: "assistant", content: assistantContent });
+
+    // Execute each tool and build tool_result messages
+    const toolResults: unknown[] = [];
+    for (const tu of result.toolUses) {
+      const skillResult = executeSkill(skills, tu.name);
+      toolResults.push({
+        type: "tool_result",
+        tool_use_id: tu.id,
+        content: skillResult ?? `Unknown skill: ${tu.name}`,
+      });
+    }
+    messages.push({ role: "user", content: toolResults });
   }
 
-  return readSSE(response, (event, data) => {
-    if (event === "content_block_delta") {
-      const parsed = JSON.parse(data);
-      const text = parsed.delta?.text;
-      if (text) {
-        onChunk(text);
-        return text;
+  throw new Error("Too many tool-use rounds. Please try again.");
+}
+
+/**
+ * Read Anthropic SSE stream, tracking both text deltas and tool_use blocks.
+ */
+async function readAnthropicSSE(
+  response: Response,
+  onChunk: (text: string) => void,
+): Promise<AnthropicStreamResult> {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let currentEvent = "";
+
+  let text = "";
+  let stopReason = "end_turn";
+  const toolUses: ToolUseAccumulator[] = [];
+  let activeToolUse: ToolUseAccumulator | null = null;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop()!;
+
+    for (const line of lines) {
+      if (line.startsWith("event: ")) {
+        currentEvent = line.slice(7).trim();
+      } else if (line.startsWith("data: ")) {
+        const data = line.slice(6);
+        let parsed: Record<string, unknown>;
+        try {
+          parsed = JSON.parse(data);
+        } catch {
+          continue;
+        }
+
+        if (currentEvent === "content_block_start") {
+          const block = parsed.content_block as Record<string, unknown> | undefined;
+          if (block?.type === "tool_use") {
+            activeToolUse = {
+              id: block.id as string,
+              name: block.name as string,
+              inputJson: "",
+            };
+            toolUses.push(activeToolUse);
+          }
+        } else if (currentEvent === "content_block_delta") {
+          const delta = parsed.delta as Record<string, unknown> | undefined;
+          if (delta?.type === "text_delta") {
+            const chunk = delta.text as string;
+            text += chunk;
+            onChunk(chunk);
+          } else if (delta?.type === "input_json_delta" && activeToolUse) {
+            activeToolUse.inputJson += delta.partial_json as string;
+          }
+        } else if (currentEvent === "content_block_stop") {
+          activeToolUse = null;
+        } else if (currentEvent === "message_delta") {
+          const delta = parsed.delta as Record<string, unknown> | undefined;
+          if (delta?.stop_reason) {
+            stopReason = delta.stop_reason as string;
+          }
+        }
+      } else if (line === "") {
+        currentEvent = "";
       }
     }
-    return null;
-  });
+  }
+
+  return { text, stopReason, toolUses };
 }
+
+// ─── OpenAI (unchanged) ─────────────────────────────────────────────
 
 async function streamOpenAI(
   config: AIConfig,
@@ -114,10 +276,8 @@ async function streamOpenAI(
   });
 }
 
-/**
- * Read Server-Sent Events from a streaming response.
- * Calls handler for each event; handler returns text to accumulate or null.
- */
+// ─── Shared SSE reader (used by OpenAI path) ────────────────────────
+
 async function readSSE(
   response: Response,
   handler: (event: string, data: string) => string | null,
@@ -151,6 +311,8 @@ async function readSSE(
 
   return accumulated;
 }
+
+// ─── JSON extraction ─────────────────────────────────────────────────
 
 /**
  * Extract a SerializedPipeline JSON from the LLM response text.

--- a/src/ai/prompt.ts
+++ b/src/ai/prompt.ts
@@ -189,5 +189,7 @@ User request: "Show a molecule with bonds and trajectory"
 - Set \`fileName\` to \`null\` (the user loads files separately).
 - For typical molecular visualization: load_structure → add_bond → viewport (plus particle and cell connections to viewport).
 - For filtered views: add filter nodes between load_structure and viewport.
-- For modified appearance: add modify nodes to change scale/opacity.`;
+- For modified appearance: add modify nodes to change scale/opacity.
+- You have access to pipeline skill tools. Use them to retrieve base templates and domain knowledge when relevant, then customize the result for the user's specific request.
+- If no skill matches the request, generate the pipeline from scratch using the schema above.`;
 }

--- a/src/ai/skillLoader.ts
+++ b/src/ai/skillLoader.ts
@@ -1,0 +1,131 @@
+/**
+ * Pipeline skill loader.
+ * Reads skill markdown files from src/ai/skills/, parses frontmatter,
+ * and converts them to Claude tool definitions for tool_use.
+ *
+ * Skills follow the Claude Code SKILL.md format:
+ *   ---
+ *   name: skill-name
+ *   description: When to use this skill
+ *   ---
+ *   Markdown content...
+ *
+ * To add a new skill, create a .md file in src/ai/skills/.
+ */
+
+/** A parsed pipeline skill. */
+export interface PipelineSkill {
+  /** Skill name from frontmatter (kebab-case). */
+  name: string;
+  /** Description from frontmatter (used as Claude tool description). */
+  description: string;
+  /** Markdown body after frontmatter (returned as tool result). */
+  content: string;
+}
+
+/** Claude API tool definition shape. */
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  input_schema: { type: "object"; properties: Record<string, never> };
+}
+
+/**
+ * Import all .md files from the skills directory at build time.
+ * Vite's import.meta.glob with ?raw returns file contents as strings.
+ */
+const skillModules: Record<string, { default: string }> = import.meta.glob(
+  "./skills/*.md",
+  { query: "?raw", eager: true },
+) as Record<string, { default: string }>;
+
+/**
+ * Parse YAML frontmatter from a markdown string.
+ * Returns the frontmatter key-value pairs and the remaining content.
+ */
+function parseFrontmatter(raw: string): {
+  attrs: Record<string, string>;
+  content: string;
+} {
+  const match = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+  if (!match) {
+    return { attrs: {}, content: raw };
+  }
+
+  const attrs: Record<string, string> = {};
+  for (const line of match[1].split("\n")) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx > 0) {
+      const key = line.slice(0, colonIdx).trim();
+      const value = line.slice(colonIdx + 1).trim();
+      attrs[key] = value;
+    }
+  }
+
+  return { attrs, content: match[2].trim() };
+}
+
+/** Convert kebab-case to snake_case for Claude tool names. */
+function toSnakeCase(s: string): string {
+  return s.replace(/-/g, "_");
+}
+
+/**
+ * Load and parse all pipeline skills from the skills directory.
+ * Called once at module load time; results are cached.
+ */
+export function loadSkills(): PipelineSkill[] {
+  const skills: PipelineSkill[] = [];
+
+  for (const [, mod] of Object.entries(skillModules)) {
+    const raw = mod.default;
+    const { attrs, content } = parseFrontmatter(raw);
+
+    if (!attrs.name || !attrs.description) {
+      continue; // skip files without required frontmatter
+    }
+
+    skills.push({
+      name: attrs.name,
+      description: attrs.description,
+      content,
+    });
+  }
+
+  return skills;
+}
+
+/**
+ * Build Claude API tool definitions from loaded skills.
+ * Each skill becomes a tool with no input parameters.
+ */
+export function buildToolDefinitions(skills: PipelineSkill[]): ToolDefinition[] {
+  return skills.map((skill) => ({
+    name: toSnakeCase(skill.name),
+    description: skill.description,
+    input_schema: { type: "object" as const, properties: {} },
+  }));
+}
+
+/**
+ * Execute a skill by tool name. Returns the skill's markdown content.
+ * Returns null if no matching skill is found.
+ */
+export function executeSkill(
+  skills: PipelineSkill[],
+  toolName: string,
+): string | null {
+  const skill = skills.find((s) => toSnakeCase(s.name) === toolName);
+  return skill?.content ?? null;
+}
+
+/** Cached skills loaded at module init. */
+let _cachedSkills: PipelineSkill[] | null = null;
+
+/** Get skills (lazy-loaded and cached). */
+export function getSkills(): PipelineSkill[] {
+  if (!_cachedSkills) {
+    _cachedSkills = loadSkills();
+  }
+  return _cachedSkills;
+}

--- a/src/ai/skills/molecule-template.md
+++ b/src/ai/skills/molecule-template.md
@@ -1,0 +1,65 @@
+---
+name: get-molecule-template
+description: Get a base pipeline template for molecular visualization with bonds and trajectory animation. Use when the user wants to visualize a molecule, show chemical bonds, or animate a trajectory.
+---
+
+# Molecule Pipeline Template
+
+A standard pipeline for molecular visualization with bonds and optional trajectory playback.
+
+Structure: LoadStructure -> AddBond -> Viewport, with optional LoadTrajectory.
+
+```json
+{
+  "version": 3,
+  "nodes": [
+    {
+      "id": "loader-1",
+      "type": "load_structure",
+      "position": { "x": 425, "y": 0 },
+      "fileName": null,
+      "hasTrajectory": false,
+      "hasCell": true,
+      "enabled": true
+    },
+    {
+      "id": "traj-1",
+      "type": "load_trajectory",
+      "position": { "x": 85, "y": 310 },
+      "fileName": null,
+      "enabled": true
+    },
+    {
+      "id": "addbond-1",
+      "type": "add_bond",
+      "position": { "x": 425, "y": 310 },
+      "bondSource": "structure",
+      "enabled": true
+    },
+    {
+      "id": "viewport-1",
+      "type": "viewport",
+      "position": { "x": 425, "y": 615 },
+      "perspective": false,
+      "cellAxesVisible": true,
+      "enabled": true
+    }
+  ],
+  "edges": [
+    { "source": "loader-1", "target": "addbond-1", "sourceHandle": "particle", "targetHandle": "particle" },
+    { "source": "loader-1", "target": "traj-1", "sourceHandle": "particle", "targetHandle": "particle" },
+    { "source": "loader-1", "target": "viewport-1", "sourceHandle": "particle", "targetHandle": "particle" },
+    { "source": "loader-1", "target": "viewport-1", "sourceHandle": "cell", "targetHandle": "cell" },
+    { "source": "addbond-1", "target": "viewport-1", "sourceHandle": "bond", "targetHandle": "bond" },
+    { "source": "traj-1", "target": "viewport-1", "sourceHandle": "trajectory", "targetHandle": "trajectory" }
+  ]
+}
+```
+
+## Customization Notes
+
+- Set `fileName` to `null` (the user loads files separately).
+- Use `bondSource: "structure"` for PDB/MOL files that contain bond information.
+- Use `bondSource: "distance"` for XYZ/GRO files without explicit bonds.
+- Remove the `traj-1` node and its edges if no trajectory is needed.
+- Add `filter` and `modify` nodes between `loader-1` and `viewport-1` for selective visualization.

--- a/src/ai/skills/solid-template.md
+++ b/src/ai/skills/solid-template.md
@@ -1,0 +1,71 @@
+---
+name: get-solid-template
+description: Get a base pipeline template for crystalline solid visualization with coordination polyhedra. Use when the user wants to visualize a crystal structure, perovskite, oxide, or show coordination polyhedra around specific atoms.
+---
+
+# Solid / Crystal Pipeline Template
+
+A pipeline for crystalline solid visualization with distance-based bonds and coordination polyhedra.
+
+Structure: LoadStructure -> AddBond (distance) -> Viewport, plus PolyhedronGenerator -> Viewport.
+
+```json
+{
+  "version": 3,
+  "nodes": [
+    {
+      "id": "loader-1",
+      "type": "load_structure",
+      "position": { "x": 425, "y": 0 },
+      "fileName": null,
+      "hasTrajectory": false,
+      "hasCell": true,
+      "enabled": true
+    },
+    {
+      "id": "addbond-1",
+      "type": "add_bond",
+      "position": { "x": 170, "y": 310 },
+      "bondSource": "distance",
+      "enabled": true
+    },
+    {
+      "id": "polyhedron-1",
+      "type": "polyhedron_generator",
+      "position": { "x": 680, "y": 310 },
+      "centerElements": [22],
+      "ligandElements": [8],
+      "maxDistance": 2.5,
+      "opacity": 0.5,
+      "showEdges": false,
+      "edgeColor": "#dddddd",
+      "edgeWidth": 3,
+      "enabled": true
+    },
+    {
+      "id": "viewport-1",
+      "type": "viewport",
+      "position": { "x": 425, "y": 615 },
+      "perspective": false,
+      "cellAxesVisible": true,
+      "enabled": true
+    }
+  ],
+  "edges": [
+    { "source": "loader-1", "target": "addbond-1", "sourceHandle": "particle", "targetHandle": "particle" },
+    { "source": "loader-1", "target": "polyhedron-1", "sourceHandle": "particle", "targetHandle": "particle" },
+    { "source": "loader-1", "target": "viewport-1", "sourceHandle": "particle", "targetHandle": "particle" },
+    { "source": "loader-1", "target": "viewport-1", "sourceHandle": "cell", "targetHandle": "cell" },
+    { "source": "addbond-1", "target": "viewport-1", "sourceHandle": "bond", "targetHandle": "bond" },
+    { "source": "polyhedron-1", "target": "viewport-1", "sourceHandle": "mesh", "targetHandle": "mesh" }
+  ]
+}
+```
+
+## Customization Notes
+
+- Adjust `centerElements` and `ligandElements` to match the target material.
+- Common atomic numbers: Ti=22, O=8, Sr=38, Fe=26, Al=13, Si=14, Mg=12, Ca=20, Zn=30.
+- Adjust `maxDistance` based on the expected bond length for the center-ligand pair.
+- Use `bondSource: "distance"` for crystal structures (XYZ, GRO) that lack explicit bond info.
+- Set `hasCell: true` and `cellAxesVisible: true` to show the unit cell.


### PR DESCRIPTION
Introduce a skill system that allows defining pipeline generation skills as markdown files (Claude Code SKILL.md format) that are automatically registered as Claude tool_use tools. This enables the LLM to retrieve base templates and domain knowledge on demand for more accurate pipeline generation.

- Add src/ai/skillLoader.ts: skill loading, frontmatter parsing, tool definition generation, and skill execution
- Add src/ai/skills/ directory with 2 sample skills (molecule-template, solid-template) as .md files with YAML frontmatter
- Update src/ai/client.ts: Anthropic streaming now handles tool_use content blocks with multi-turn conversation support
- Update src/ai/prompt.ts: add guidelines for skill tool usage

New skills can be added by creating a .md file in src/ai/skills/.

https://claude.ai/code/session_012EuUFW89c2E8WDTqHr16uG