### PR TITLE
Add Python Pipeline interface with NetworkX-style graph builder

### DIFF
--- a/python/megane/__init__.py
+++ b/python/megane/__init__.py
@@ -4,7 +4,35 @@ from megane.parsers.lammps_data import load_lammps_data
 from megane.parsers.pdb import load_pdb
 from megane.parsers.traj import load_traj
 from megane.parsers.xtc import load_trajectory
+from megane.pipeline import (
+    AddBonds,
+    AddLabels,
+    AddPolyhedra,
+    Filter,
+    LoadStructure,
+    LoadTrajectory,
+    LoadVector,
+    Modify,
+    Pipeline,
+    VectorOverlay,
+)
 from megane.widget import MolecularViewer
 
-__all__ = ["load_lammps_data", "load_pdb", "load_traj", "load_trajectory", "MolecularViewer"]
+__all__ = [
+    "AddBonds",
+    "AddLabels",
+    "AddPolyhedra",
+    "Filter",
+    "LoadStructure",
+    "LoadTrajectory",
+    "LoadVector",
+    "MolecularViewer",
+    "Modify",
+    "Pipeline",
+    "VectorOverlay",
+    "load_lammps_data",
+    "load_pdb",
+    "load_traj",
+    "load_trajectory",
+]
 __version__ = "0.3.2"

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -1,0 +1,505 @@
+"""NetworkX-style pipeline builder for megane molecular viewer.
+
+Nodes are class instances added via ``add_node()``, connections via
+``add_edge()`` with ports auto-resolved from types.  The pipeline
+serializes to the same ``SerializedPipeline`` v3 JSON format used by
+the TypeScript pipeline engine, which remains the source of truth.
+
+Example::
+
+    from megane.pipeline import Pipeline, LoadStructure, Filter, Modify, AddBonds
+
+    pipe = Pipeline()
+    s = pipe.add_node(LoadStructure("protein.pdb"))
+    carbons = pipe.add_node(Filter(query="element == 'C'"))
+    m = pipe.add_node(Modify(scale=1.3))
+    bonds = pipe.add_node(AddBonds(source="distance"))
+
+    pipe.add_edge(s, carbons)
+    pipe.add_edge(carbons, m)
+    pipe.add_edge(s, bonds)
+
+    viewer.set_pipeline(pipe)
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+
+# ─── Node Classes ───────────────────────────────────────────────────
+
+
+class PipelineNode:
+    """Base class for all pipeline node types."""
+
+    _node_type: str = ""
+
+    def __init__(self) -> None:
+        self._id: str | None = None
+
+
+class LoadStructure(PipelineNode):
+    """Load a molecular structure from a file.
+
+    Supported formats: PDB, GRO, XYZ, MOL, LAMMPS data, CIF.
+    """
+
+    _node_type = "load_structure"
+
+    def __init__(self, path: str) -> None:
+        super().__init__()
+        self.path = path
+
+
+class LoadTrajectory(PipelineNode):
+    """Load an external trajectory (XTC or ASE .traj).
+
+    Requires connection from a ``LoadStructure`` node.
+    Frames are loaded lazily when ``frame_index`` changes.
+    """
+
+    _node_type = "load_trajectory"
+
+    def __init__(
+        self,
+        *,
+        xtc: str | None = None,
+        traj: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.xtc = xtc
+        self.traj = traj
+
+
+class LoadVector(PipelineNode):
+    """Load per-atom vector data from a file."""
+
+    _node_type = "load_vector"
+
+    def __init__(self, path: str) -> None:
+        super().__init__()
+        self.path = path
+
+
+class Filter(PipelineNode):
+    """Filter atoms by a selection query.
+
+    Query syntax examples::
+
+        element == 'C'
+        element == 'O' and x > 5.0
+        resname == 'ALA'
+        index >= 100 and index < 200
+    """
+
+    _node_type = "filter"
+
+    def __init__(self, *, query: str) -> None:
+        super().__init__()
+        self.query = query
+
+
+class Modify(PipelineNode):
+    """Modify per-atom visual properties (scale, opacity)."""
+
+    _node_type = "modify"
+
+    def __init__(
+        self,
+        *,
+        scale: float = 1.0,
+        opacity: float = 1.0,
+    ) -> None:
+        super().__init__()
+        self.scale = scale
+        self.opacity = opacity
+
+
+class AddBonds(PipelineNode):
+    """Compute and display bonds.
+
+    Args:
+        source: ``"distance"`` for VDW-based inference,
+                ``"structure"`` to use bonds from the file.
+    """
+
+    _node_type = "add_bond"
+
+    def __init__(
+        self,
+        *,
+        source: Literal["distance", "structure"] = "distance",
+    ) -> None:
+        super().__init__()
+        self.source = source
+
+
+class AddLabels(PipelineNode):
+    """Generate text labels at atom positions.
+
+    Args:
+        source: ``"element"``, ``"resname"``, or ``"index"``.
+    """
+
+    _node_type = "label_generator"
+
+    def __init__(
+        self,
+        *,
+        source: Literal["element", "resname", "index"] = "element",
+    ) -> None:
+        super().__init__()
+        self.source = source
+
+
+class AddPolyhedra(PipelineNode):
+    """Generate coordination polyhedra mesh."""
+
+    _node_type = "polyhedron_generator"
+
+    def __init__(
+        self,
+        *,
+        center_elements: list[int],
+        ligand_elements: list[int] | None = None,
+        max_distance: float = 2.5,
+        opacity: float = 0.5,
+        show_edges: bool = False,
+        edge_color: str = "#dddddd",
+        edge_width: float = 3.0,
+    ) -> None:
+        super().__init__()
+        self.center_elements = center_elements
+        self.ligand_elements = ligand_elements if ligand_elements is not None else [8]
+        self.max_distance = max_distance
+        self.opacity = opacity
+        self.show_edges = show_edges
+        self.edge_color = edge_color
+        self.edge_width = edge_width
+
+
+class VectorOverlay(PipelineNode):
+    """Configure per-atom vector visualization (e.g. forces)."""
+
+    _node_type = "vector_overlay"
+
+    def __init__(self, *, scale: float = 1.0) -> None:
+        super().__init__()
+        self.scale = scale
+
+
+# ─── Port Resolution ────────────────────────────────────────────────
+
+# target_node_type → (default source_handle, target_handle)
+_TARGET_PORT_MAP: dict[str, tuple[str, str]] = {
+    "load_trajectory": ("particle", "particle"),
+    "filter": ("particle", "in"),
+    "modify": ("particle", "in"),
+    "add_bond": ("particle", "particle"),
+    "label_generator": ("particle", "particle"),
+    "polyhedron_generator": ("particle", "particle"),
+    "vector_overlay": ("vector", "vector"),
+    "viewport": ("particle", "particle"),  # fallback; actual handle varies
+}
+
+# source_node_type → default output handle
+_SOURCE_OUTPUT_MAP: dict[str, str] = {
+    "filter": "out",
+    "modify": "out",
+    "load_vector": "vector",
+    "vector_overlay": "vector",
+    "add_bond": "bond",
+    "label_generator": "label",
+    "polyhedron_generator": "mesh",
+}
+
+
+def _resolve_ports(
+    source: PipelineNode,
+    target: PipelineNode,
+) -> tuple[str, str]:
+    """Resolve source and target port handles from node types."""
+    target_handle = _TARGET_PORT_MAP.get(
+        target._node_type, ("particle", "particle")
+    )[1]
+
+    # Source handle: use the source node's known output, or infer
+    # from what the target expects.
+    source_handle = _SOURCE_OUTPUT_MAP.get(source._node_type)
+    if source_handle is None:
+        # LoadStructure or other multi-output node: use what the
+        # target expects as its input type.
+        source_handle = _TARGET_PORT_MAP.get(
+            target._node_type, ("particle", "particle")
+        )[0]
+
+    return source_handle, target_handle
+
+
+# ─── Pipeline ───────────────────────────────────────────────────────
+
+
+def _load_structure_file(path: str):
+    """Auto-detect format and load a structure file.
+
+    Returns a ``Structure`` object (from ``megane.parsers.pdb``).
+    """
+    import pathlib
+
+    import numpy as np
+
+    from megane import megane_parser
+    from megane.parsers.pdb import Structure
+
+    ext = pathlib.Path(path).suffix.lower()
+
+    with open(path) as f:
+        text = f.read()
+
+    parsers = {
+        ".pdb": megane_parser.parse_pdb,
+        ".gro": megane_parser.parse_gro,
+        ".xyz": megane_parser.parse_xyz,
+        ".mol": megane_parser.parse_mol,
+        ".data": megane_parser.parse_lammps_data,
+    }
+
+    parse_fn = parsers.get(ext)
+    if parse_fn is None:
+        raise ValueError(
+            f"Unsupported structure format: {ext!r}.  "
+            f"Supported: {', '.join(sorted(parsers))}"
+        )
+
+    result = parse_fn(text)
+    return Structure(
+        n_atoms=result.n_atoms,
+        positions=np.asarray(result.positions, dtype=np.float32),
+        elements=np.asarray(result.elements, dtype=np.uint8),
+        bonds=np.asarray(result.bonds, dtype=np.uint32),
+        bond_orders=np.asarray(result.bond_orders, dtype=np.uint8),
+        box=np.asarray(result.box_matrix, dtype=np.float32),
+    )
+
+
+class Pipeline:
+    """NetworkX-style pipeline graph builder.
+
+    Build a DAG of processing nodes and serialize to the
+    ``SerializedPipeline`` v3 JSON format understood by the
+    TypeScript pipeline engine.
+    """
+
+    def __init__(self) -> None:
+        self._nodes: list[tuple[PipelineNode, dict]] = []
+        self._edges: list[dict] = []
+        self._node_data: dict[str, bytes] = {}
+        self._trajectories: dict[str, object] = {}
+        self._structures: dict[str, object] = {}
+        self._counter = 0
+
+    # ── Public API ──────────────────────────────────────────
+
+    def add_node(self, node: PipelineNode) -> PipelineNode:
+        """Add a node to the pipeline.
+
+        Returns the same node instance so it can be used in
+        ``add_edge()`` calls.
+        """
+        self._counter += 1
+        node._id = f"{node._node_type}-{self._counter}"
+
+        config = self._serialize_node(node)
+        self._nodes.append((node, config))
+
+        if isinstance(node, LoadStructure):
+            self._load_structure_data(node)
+
+        return node
+
+    def add_edge(
+        self,
+        source: PipelineNode,
+        target: PipelineNode,
+    ) -> None:
+        """Connect *source* → *target*.
+
+        Port handles are auto-resolved from the node types.
+        """
+        if source._id is None or target._id is None:
+            raise ValueError(
+                "Both nodes must be added to the pipeline before connecting."
+            )
+        source_handle, target_handle = _resolve_ports(source, target)
+        self._edges.append({
+            "source": source._id,
+            "target": target._id,
+            "sourceHandle": source_handle,
+            "targetHandle": target_handle,
+        })
+
+        # Trigger lazy trajectory loading when connecting
+        # LoadStructure → LoadTrajectory.
+        if isinstance(target, LoadTrajectory) and isinstance(
+            source, LoadStructure
+        ):
+            self._load_trajectory_data(target, source)
+
+    # ── Serialization ───────────────────────────────────────
+
+    def to_dict(self) -> dict:
+        """Serialize to ``SerializedPipeline`` v3 format.
+
+        A viewport node is auto-generated and connected to all
+        unconnected output ports.
+        """
+        nodes = [config for _, config in self._nodes]
+        edges = list(self._edges)
+
+        viewport_id = "viewport-auto"
+        viewport_node = {
+            "id": viewport_id,
+            "type": "viewport",
+            "perspective": False,
+            "cellAxesVisible": True,
+            "position": {"x": 0, "y": 0},
+        }
+        nodes.append(viewport_node)
+
+        viewport_edges = self._auto_connect_viewport(viewport_id)
+        edges.extend(viewport_edges)
+
+        return {"version": 3, "nodes": nodes, "edges": edges}
+
+    # ── Internal ────────────────────────────────────────────
+
+    def _serialize_node(self, node: PipelineNode) -> dict:
+        """Convert a node instance to the TS SerializedPipeline node dict."""
+        base: dict = {
+            "id": node._id,
+            "type": node._node_type,
+            "position": {"x": 0, "y": 0},
+        }
+
+        if isinstance(node, LoadStructure):
+            structure = self._structures.get(node._id)
+            has_cell = False
+            if structure is not None:
+                import numpy as np
+                has_cell = bool(np.any(structure.box != 0))
+            base["fileName"] = node.path
+            base["hasTrajectory"] = False
+            base["hasCell"] = has_cell
+        elif isinstance(node, LoadTrajectory):
+            base["fileName"] = node.xtc or node.traj
+        elif isinstance(node, Filter):
+            base["query"] = node.query
+        elif isinstance(node, Modify):
+            base["scale"] = node.scale
+            base["opacity"] = node.opacity
+        elif isinstance(node, AddBonds):
+            base["bondSource"] = node.source
+        elif isinstance(node, AddLabels):
+            base["source"] = node.source
+        elif isinstance(node, AddPolyhedra):
+            base["centerElements"] = node.center_elements
+            base["ligandElements"] = node.ligand_elements
+            base["maxDistance"] = node.max_distance
+            base["opacity"] = node.opacity
+            base["showEdges"] = node.show_edges
+            base["edgeColor"] = node.edge_color
+            base["edgeWidth"] = node.edge_width
+        elif isinstance(node, LoadVector):
+            base["fileName"] = node.path
+        elif isinstance(node, VectorOverlay):
+            base["scale"] = node.scale
+
+        return base
+
+    def _load_structure_data(self, node: LoadStructure) -> None:
+        """Load structure file and store binary snapshot data."""
+        from megane.protocol import encode_snapshot
+
+        structure = _load_structure_file(node.path)
+        self._structures[node._id] = structure
+        self._node_data[node._id] = encode_snapshot(structure)
+
+        # Re-serialize to update hasCell
+        import numpy as np
+        for i, (n, _) in enumerate(self._nodes):
+            if n._id == node._id:
+                self._nodes[i] = (n, self._serialize_node(n))
+                break
+
+    def _load_trajectory_data(
+        self,
+        node: LoadTrajectory,
+        source: LoadStructure,
+    ) -> None:
+        """Load trajectory object for lazy frame loading."""
+        if node.xtc is not None:
+            from megane.parsers.xtc import load_trajectory
+
+            self._trajectories[node._id] = load_trajectory(
+                source.path, node.xtc
+            )
+
+            # Update parent LoadStructure's hasTrajectory flag
+            for i, (n, config) in enumerate(self._nodes):
+                if n._id == source._id:
+                    config["hasTrajectory"] = True
+                    break
+        elif node.traj is not None:
+            from megane.parsers.traj import load_traj
+
+            _, trajectory = load_traj(node.traj)
+            self._trajectories[node._id] = trajectory
+
+    def _auto_connect_viewport(self, viewport_id: str) -> list[dict]:
+        """Connect all unconnected outputs to the auto-generated viewport."""
+        # Collect set of (node_id, handle) that are already used as edge sources
+        used_outputs: set[tuple[str, str]] = set()
+        for edge in self._edges:
+            used_outputs.add((edge["source"], edge["sourceHandle"]))
+
+        # Map of node_type → list of output handles
+        output_handles: dict[str, list[str]] = {
+            "load_structure": ["particle", "trajectory", "cell"],
+            "load_trajectory": ["trajectory"],
+            "load_vector": ["vector"],
+            "filter": ["out"],
+            "modify": ["out"],
+            "add_bond": ["bond"],
+            "label_generator": ["label"],
+            "polyhedron_generator": ["mesh"],
+            "vector_overlay": ["vector"],
+        }
+
+        # Map output handle name → viewport input handle name
+        handle_to_viewport: dict[str, str] = {
+            "particle": "particle",
+            "out": "particle",  # filter/modify output → viewport particle
+            "bond": "bond",
+            "cell": "cell",
+            "trajectory": "trajectory",
+            "label": "label",
+            "mesh": "mesh",
+            "vector": "vector",
+        }
+
+        viewport_edges: list[dict] = []
+        for node, _ in self._nodes:
+            handles = output_handles.get(node._node_type, [])
+            for handle in handles:
+                if (node._id, handle) not in used_outputs:
+                    viewport_handle = handle_to_viewport.get(handle)
+                    if viewport_handle:
+                        viewport_edges.append({
+                            "source": node._id,
+                            "target": viewport_id,
+                            "sourceHandle": handle,
+                            "targetHandle": viewport_handle,
+                        })
+
+        return viewport_edges

--- a/python/megane/widget.py
+++ b/python/megane/widget.py
@@ -4,14 +4,18 @@ from __future__ import annotations
 
 import json
 import pathlib
+import warnings
 from collections import defaultdict
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import anywidget
 import traitlets
 
 from megane.parsers.pdb import load_pdb
 from megane.protocol import encode_frame, encode_snapshot
+
+if TYPE_CHECKING:
+    from megane.pipeline import Pipeline
 
 _STATIC_DIR = pathlib.Path(__file__).parent / "static"
 
@@ -64,8 +68,11 @@ class MolecularViewer(anywidget.AnyWidget):
     _measurement_json = traitlets.Unicode("").tag(sync=True)
 
     # Pipeline
-    pipeline = traitlets.Bool(False).tag(sync=True)
+    _pipeline_enabled = traitlets.Bool(False).tag(sync=True)
     _pipeline_json = traitlets.Unicode("").tag(sync=True)
+    _node_snapshots_data = traitlets.Dict(
+        value_trait=traitlets.Bytes(),
+    ).tag(sync=True)
 
     # Internal (not synced)
     _structure = None
@@ -74,6 +81,7 @@ class MolecularViewer(anywidget.AnyWidget):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._event_handlers: dict[str, list[Callable]] = defaultdict(list)
+        self._pipeline_ref: Pipeline | None = None
 
     def load(
         self,
@@ -83,6 +91,10 @@ class MolecularViewer(anywidget.AnyWidget):
     ) -> None:
         """Load a molecular structure, optionally with a trajectory.
 
+        .. deprecated::
+            Use :meth:`set_pipeline` with a :class:`~megane.pipeline.Pipeline`
+            instead.
+
         Args:
             pdb_path: Path to PDB file.
             xtc: Optional path to XTC trajectory file.
@@ -90,6 +102,12 @@ class MolecularViewer(anywidget.AnyWidget):
                 *pdb_path* is ignored and both structure and trajectory
                 are read from the .traj file.
         """
+        warnings.warn(
+            "MolecularViewer.load() is deprecated. "
+            "Use set_pipeline() with a Pipeline instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if traj is not None:
             from megane.parsers.traj import load_traj
 
@@ -113,13 +131,24 @@ class MolecularViewer(anywidget.AnyWidget):
     @traitlets.observe("frame_index")
     def _on_frame_change(self, change: dict) -> None:
         """Send new frame data when frame_index changes."""
+        idx = change["new"]
+
+        # Legacy trajectory (from viewer.load())
         if self._trajectory is not None:
-            idx = change["new"]
             if 0 <= idx < self._trajectory.n_frames:
                 positions = self._trajectory.get_frame(idx)
                 self._frame_data = encode_frame(idx, positions)
+
+        # Pipeline trajectory (from set_pipeline())
+        if self._pipeline_ref is not None:
+            for traj in self._pipeline_ref._trajectories.values():
+                if 0 <= idx < traj.n_frames:
+                    positions = traj.get_frame(idx)
+                    self._frame_data = encode_frame(idx, positions)
+                    break
+
         self._fire_event("frame_change", {
-            "frame_index": change["new"],
+            "frame_index": idx,
         })
 
     @traitlets.observe("_measurement_json")
@@ -205,22 +234,32 @@ class MolecularViewer(anywidget.AnyWidget):
                 h for h in handlers if h is not callback
             ]
 
-    def load_pipeline(self, config: dict | str) -> None:
-        """Load a pipeline configuration.
+    def set_pipeline(self, pipeline: Pipeline | None) -> None:
+        """Apply a pipeline to this viewer.
 
         Args:
-            config: Pipeline configuration as a dict or JSON string.
+            pipeline: A :class:`~megane.pipeline.Pipeline` instance,
+                or ``None`` to clear the pipeline.
         """
-        if isinstance(config, dict):
-            config = json.dumps(config)
-        self._pipeline_json = config
+        if pipeline is None:
+            self._pipeline_enabled = False
+            self._pipeline_json = ""
+            self._node_snapshots_data = {}
+            self._pipeline_ref = None
+            return
 
-    @property
-    def pipeline_config(self) -> dict | None:
-        """Current pipeline configuration, or None if not set."""
-        if not self._pipeline_json:
-            return None
-        return json.loads(self._pipeline_json)
+        # Send per-node binary snapshot data
+        self._node_snapshots_data = dict(pipeline._node_data)
+
+        # Send pipeline config JSON
+        self._pipeline_json = json.dumps(pipeline.to_dict())
+        self._pipeline_enabled = True
+
+        # Store trajectory refs for lazy loading
+        self._pipeline_ref = pipeline
+        if pipeline._trajectories:
+            first_traj = next(iter(pipeline._trajectories.values()))
+            self.total_frames = first_traj.n_frames
 
     def _fire_event(self, event_name: str, data) -> None:
         """Invoke all registered callbacks for an event."""

--- a/src/components/WidgetViewer.tsx
+++ b/src/components/WidgetViewer.tsx
@@ -2,20 +2,26 @@
  * Simplified megane viewer for Jupyter widget embedding.
  * Minimal UI: Viewport + Timeline only.
  *
- * When `pipeline` prop is true, shows the PipelineEditor and drives
- * rendering through the pipeline store (like MeganeViewer).
+ * When `pipeline` prop is true, drives rendering through the pipeline
+ * store using the pipeline JSON and per-node snapshot data from Python.
+ * The pipeline editor UI is not shown — pipeline is built in Python.
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Viewport } from "./Viewport";
-import { PipelineEditor } from "./PipelineEditor";
 import { Timeline } from "./Timeline";
 import { MoleculeRenderer } from "../renderer/MoleculeRenderer";
 import { inferBondsVdwJS } from "../parsers/inferBondsJS";
 import { processPbcBonds } from "../pipeline/executors/addBond";
 import { usePipelineStore } from "../pipeline/store";
 import { applyViewportState } from "../pipeline/apply";
+import {
+  decodeSnapshot,
+  decodeHeader,
+  MSG_SNAPSHOT,
+} from "../protocol/protocol";
 import type { ViewportState, AddBondParams } from "../pipeline/types";
+import type { NodeSnapshotData } from "../pipeline/execute";
 import type {
   Snapshot,
   Frame,
@@ -32,6 +38,7 @@ interface WidgetViewerProps {
   onMeasurementChange?: (measurement: Measurement | null) => void;
   pipeline?: boolean;
   pipelineJson?: string;
+  nodeSnapshotsData?: Record<string, DataView>;
   onPipelineChange?: (json: string) => void;
 }
 
@@ -44,6 +51,20 @@ export function WidgetViewer(props: WidgetViewerProps) {
 
 /* ─── Pipeline mode ──────────────────────────────────────────────── */
 
+/** Decode a binary DataView into a Snapshot. */
+function decodeNodeSnapshot(data: DataView): Snapshot | null {
+  if (!data || data.byteLength === 0) return null;
+  const buffer = new ArrayBuffer(data.byteLength);
+  new Uint8Array(buffer).set(
+    new Uint8Array(data.buffer, data.byteOffset, data.byteLength),
+  );
+  const { msgType } = decodeHeader(buffer);
+  if (msgType === MSG_SNAPSHOT) {
+    return decodeSnapshot(buffer);
+  }
+  return null;
+}
+
 function WidgetViewerPipeline({
   snapshot,
   frame,
@@ -51,36 +72,51 @@ function WidgetViewerPipeline({
   totalFrames,
   onSeek,
   pipelineJson,
-  onPipelineChange,
+  nodeSnapshotsData,
 }: WidgetViewerProps) {
   const rendererRef = useRef<MoleculeRenderer | null>(null);
   const playIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const [playing, setPlaying] = useState(false);
   const [fps, setFps] = useState(30);
-  const isNarrow = typeof window !== "undefined" && window.innerWidth < 768;
-  const [pipelineCollapsed, setPipelineCollapsed] = useState(isNarrow);
-  const pipelineCollapsedRef = useRef(isNarrow);
-  const pipelineWidthRef = useRef(480);
   const prevViewportStateRef = useRef<ViewportState | null>(null);
-
-  useEffect(() => {
-    pipelineCollapsedRef.current = pipelineCollapsed;
-  }, [pipelineCollapsed]);
 
   // Subscribe to pipeline store
   const viewportState = usePipelineStore((s) => s.viewportState);
   const setSnapshot = usePipelineStore((s) => s.setSnapshot);
 
-  // Push snapshot to pipeline store
+  // Push per-node snapshots from Python to the pipeline store
   useEffect(() => {
-    setSnapshot(snapshot);
+    if (!nodeSnapshotsData || Object.keys(nodeSnapshotsData).length === 0) {
+      // Fall back to the global snapshot (legacy)
+      setSnapshot(snapshot);
+    } else {
+      // Decode each per-node snapshot and populate nodeSnapshots
+      const store = usePipelineStore.getState();
+      for (const [nodeId, data] of Object.entries(nodeSnapshotsData)) {
+        const decoded = decodeNodeSnapshot(data);
+        if (decoded) {
+          store.setNodeSnapshot(nodeId, {
+            snapshot: decoded,
+            frames: null,
+            meta: null,
+            labels: null,
+          });
+        }
+      }
+      // Also set the first snapshot as the global one for the renderer
+      const firstData = Object.values(nodeSnapshotsData)[0];
+      if (firstData) {
+        const firstSnapshot = decodeNodeSnapshot(firstData);
+        setSnapshot(firstSnapshot);
+      }
+    }
     const renderer = rendererRef.current;
     if (renderer) {
       const vs = usePipelineStore.getState().viewportState;
       applyViewportState(renderer, vs, null);
       prevViewportStateRef.current = vs;
     }
-  }, [snapshot, setSnapshot]);
+  }, [snapshot, nodeSnapshotsData, setSnapshot]);
 
   // Apply viewportState changes to the renderer
   useEffect(() => {
@@ -132,49 +168,11 @@ function WidgetViewerPipeline({
     }
   }, [pipelineJson]);
 
-  // Sync pipeline changes back to Python
-  const syncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(() => {
-    if (!onPipelineChange) return;
-    // Debounce pipeline sync to avoid excessive updates
-    if (syncTimeoutRef.current) clearTimeout(syncTimeoutRef.current);
-    syncTimeoutRef.current = setTimeout(() => {
-      const serialized = usePipelineStore.getState().serialize();
-      const json = JSON.stringify(serialized);
-      if (json !== prevPipelineJsonRef.current) {
-        prevPipelineJsonRef.current = json;
-        onPipelineChange(json);
-      }
-    }, 500);
-  }, [viewportState, onPipelineChange]);
-
   const handleRendererReady = useCallback((renderer: MoleculeRenderer) => {
     rendererRef.current = renderer;
-    renderer.setViewInsets(
-      0,
-      pipelineCollapsedRef.current ? 0 : pipelineWidthRef.current + 12,
-    );
     applyViewportState(renderer, usePipelineStore.getState().viewportState, null);
     prevViewportStateRef.current = usePipelineStore.getState().viewportState;
   }, []);
-
-  const handleTogglePipeline = useCallback(() => {
-    setPipelineCollapsed((prev) => !prev);
-  }, []);
-
-  const handlePipelineWidthChange = useCallback((w: number) => {
-    pipelineWidthRef.current = w;
-    if (!pipelineCollapsedRef.current) {
-      rendererRef.current?.setViewInsets(0, w + 12);
-    }
-  }, []);
-
-  useEffect(() => {
-    rendererRef.current?.setViewInsets(
-      0,
-      pipelineCollapsed ? 0 : pipelineWidthRef.current + 12,
-    );
-  }, [pipelineCollapsed]);
 
   const handlePlayPause = useCallback(() => {
     setPlaying((prev) => {
@@ -236,12 +234,6 @@ function WidgetViewerPipeline({
         onHover={() => {}}
         onAtomRightClick={() => {}}
         onFrameUpdated={() => {}}
-      />
-
-      <PipelineEditor
-        collapsed={pipelineCollapsed}
-        onToggleCollapse={handleTogglePipeline}
-        onWidthChange={handlePipelineWidthChange}
       />
 
       {totalFrames > 1 && (

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -99,8 +99,9 @@ function render({ model, el }: { model: AnyWidgetModel; el: HTMLElement }) {
     const frameIndex = (model.get("frame_index") as number) || 0;
     const totalFrames = (model.get("total_frames") as number) || 0;
     const selectedAtoms = (model.get("selected_atoms") as number[]) || [];
-    const pipelineEnabled = (model.get("pipeline") as boolean) || false;
+    const pipelineEnabled = (model.get("_pipeline_enabled") as boolean) || false;
     const pipelineJson = (model.get("_pipeline_json") as string) || "";
+    const nodeSnapshotsData = (model.get("_node_snapshots_data") as Record<string, DataView>) || {};
 
     root.render(
       createElement(WidgetViewer, {
@@ -113,6 +114,7 @@ function render({ model, el }: { model: AnyWidgetModel; el: HTMLElement }) {
         onMeasurementChange: handleMeasurementChange,
         pipeline: pipelineEnabled,
         pipelineJson: pipelineJson,
+        nodeSnapshotsData: nodeSnapshotsData,
         onPipelineChange: handlePipelineChange,
       }),
     );
@@ -161,7 +163,11 @@ function render({ model, el }: { model: AnyWidgetModel; el: HTMLElement }) {
     renderApp();
   });
 
-  model.on("change:pipeline", () => {
+  model.on("change:_pipeline_enabled", () => {
+    renderApp();
+  });
+
+  model.on("change:_node_snapshots_data", () => {
     renderApp();
   });
 

--- a/tests/python/test_pipeline.py
+++ b/tests/python/test_pipeline.py
@@ -1,0 +1,318 @@
+"""Tests for the Python pipeline builder."""
+
+from pathlib import Path
+
+import pytest
+
+from megane.pipeline import (
+    AddBonds,
+    AddLabels,
+    AddPolyhedra,
+    Filter,
+    LoadStructure,
+    LoadTrajectory,
+    LoadVector,
+    Modify,
+    Pipeline,
+    VectorOverlay,
+)
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+
+class TestNodeClasses:
+    """Node classes store parameters correctly."""
+
+    def test_load_structure(self):
+        n = LoadStructure("test.pdb")
+        assert n.path == "test.pdb"
+        assert n._node_type == "load_structure"
+
+    def test_filter(self):
+        n = Filter(query="element == 'C'")
+        assert n.query == "element == 'C'"
+        assert n._node_type == "filter"
+
+    def test_modify_defaults(self):
+        n = Modify()
+        assert n.scale == 1.0
+        assert n.opacity == 1.0
+        assert n._node_type == "modify"
+
+    def test_modify_custom(self):
+        n = Modify(scale=1.5, opacity=0.3)
+        assert n.scale == 1.5
+        assert n.opacity == 0.3
+
+    def test_add_bonds_default(self):
+        n = AddBonds()
+        assert n.source == "distance"
+        assert n._node_type == "add_bond"
+
+    def test_add_bonds_structure(self):
+        n = AddBonds(source="structure")
+        assert n.source == "structure"
+
+    def test_add_labels(self):
+        n = AddLabels(source="resname")
+        assert n.source == "resname"
+        assert n._node_type == "label_generator"
+
+    def test_add_polyhedra(self):
+        n = AddPolyhedra(center_elements=[26], ligand_elements=[8, 7])
+        assert n.center_elements == [26]
+        assert n.ligand_elements == [8, 7]
+        assert n.max_distance == 2.5
+        assert n._node_type == "polyhedron_generator"
+
+    def test_add_polyhedra_defaults(self):
+        n = AddPolyhedra(center_elements=[26])
+        assert n.ligand_elements == [8]
+        assert n.opacity == 0.5
+        assert n.show_edges is False
+
+    def test_load_vector(self):
+        n = LoadVector("vectors.dat")
+        assert n.path == "vectors.dat"
+        assert n._node_type == "load_vector"
+
+    def test_vector_overlay(self):
+        n = VectorOverlay(scale=2.0)
+        assert n.scale == 2.0
+        assert n._node_type == "vector_overlay"
+
+    def test_load_trajectory(self):
+        n = LoadTrajectory(xtc="traj.xtc")
+        assert n.xtc == "traj.xtc"
+        assert n._node_type == "load_trajectory"
+
+
+class TestPipelineAddNode:
+    """Pipeline.add_node() assigns IDs and stores nodes."""
+
+    def test_add_single_node(self):
+        pipe = Pipeline()
+        n = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        assert n._id is not None
+        assert n._id.startswith("load_structure-")
+
+    def test_add_multiple_nodes_unique_ids(self):
+        pipe = Pipeline()
+        n1 = pipe.add_node(Filter(query="a"))
+        n2 = pipe.add_node(Filter(query="b"))
+        assert n1._id != n2._id
+
+    def test_add_node_returns_same_instance(self):
+        pipe = Pipeline()
+        original = Filter(query="test")
+        returned = pipe.add_node(original)
+        assert returned is original
+
+
+class TestPipelineAddEdge:
+    """Pipeline.add_edge() creates edges with correct port resolution."""
+
+    def test_structure_to_filter(self):
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        f = pipe.add_node(Filter(query="element == 'C'"))
+        pipe.add_edge(s, f)
+
+        assert len(pipe._edges) == 1
+        edge = pipe._edges[0]
+        assert edge["source"] == s._id
+        assert edge["target"] == f._id
+        assert edge["sourceHandle"] == "particle"
+        assert edge["targetHandle"] == "in"
+
+    def test_filter_to_modify(self):
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        f = pipe.add_node(Filter(query="element == 'C'"))
+        m = pipe.add_node(Modify(scale=1.3))
+        pipe.add_edge(s, f)
+        pipe.add_edge(f, m)
+
+        edge = pipe._edges[1]
+        assert edge["sourceHandle"] == "out"
+        assert edge["targetHandle"] == "in"
+
+    def test_structure_to_add_bonds(self):
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        b = pipe.add_node(AddBonds(source="distance"))
+        pipe.add_edge(s, b)
+
+        edge = pipe._edges[0]
+        assert edge["sourceHandle"] == "particle"
+        assert edge["targetHandle"] == "particle"
+
+    def test_structure_to_label_generator(self):
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        lbl = pipe.add_node(AddLabels(source="element"))
+        pipe.add_edge(s, lbl)
+
+        edge = pipe._edges[0]
+        assert edge["sourceHandle"] == "particle"
+        assert edge["targetHandle"] == "particle"
+
+    def test_error_on_unadded_nodes(self):
+        pipe = Pipeline()
+        s = LoadStructure("test.pdb")
+        f = Filter(query="test")
+        with pytest.raises(ValueError, match="must be added"):
+            pipe.add_edge(s, f)
+
+
+class TestPipelineSerialization:
+    """Pipeline.to_dict() produces valid SerializedPipeline v3."""
+
+    def test_version(self):
+        pipe = Pipeline()
+        pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        result = pipe.to_dict()
+        assert result["version"] == 3
+
+    def test_viewport_auto_generated(self):
+        pipe = Pipeline()
+        pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        result = pipe.to_dict()
+
+        node_types = [n["type"] for n in result["nodes"]]
+        assert "viewport" in node_types
+
+    def test_terminal_nodes_connected_to_viewport(self):
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        result = pipe.to_dict()
+
+        # LoadStructure has unconnected particle, trajectory, cell outputs
+        # All should be connected to viewport
+        viewport_edges = [
+            e for e in result["edges"]
+            if e["target"] == "viewport-auto"
+        ]
+        assert len(viewport_edges) >= 1  # at least particle
+
+    def test_filter_modify_chain(self):
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        f = pipe.add_node(Filter(query="element == 'C'"))
+        m = pipe.add_node(Modify(scale=1.5))
+        pipe.add_edge(s, f)
+        pipe.add_edge(f, m)
+        result = pipe.to_dict()
+
+        # Verify node params are serialized correctly
+        filter_node = next(n for n in result["nodes"] if n["type"] == "filter")
+        assert filter_node["query"] == "element == 'C'"
+
+        modify_node = next(n for n in result["nodes"] if n["type"] == "modify")
+        assert modify_node["scale"] == 1.5
+
+    def test_add_bonds_serialization(self):
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        b = pipe.add_node(AddBonds(source="structure"))
+        pipe.add_edge(s, b)
+        result = pipe.to_dict()
+
+        bond_node = next(n for n in result["nodes"] if n["type"] == "add_bond")
+        assert bond_node["bondSource"] == "structure"
+
+    def test_polyhedra_serialization(self):
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        p = pipe.add_node(AddPolyhedra(
+            center_elements=[26],
+            ligand_elements=[8],
+            max_distance=3.0,
+            opacity=0.7,
+        ))
+        pipe.add_edge(s, p)
+        result = pipe.to_dict()
+
+        poly_node = next(
+            n for n in result["nodes"] if n["type"] == "polyhedron_generator"
+        )
+        assert poly_node["centerElements"] == [26]
+        assert poly_node["maxDistance"] == 3.0
+        assert poly_node["opacity"] == 0.7
+
+
+class TestPipelineDataLoading:
+    """Pipeline loads structure data into _node_data."""
+
+    def test_load_structure_populates_node_data(self):
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        assert s._id in pipe._node_data
+        assert len(pipe._node_data[s._id]) > 0
+        # Check MEGN magic bytes
+        assert pipe._node_data[s._id][:4] == b"MEGN"
+
+    def test_multiple_structures(self):
+        pipe = Pipeline()
+        s1 = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        s2 = pipe.add_node(LoadStructure(str(FIXTURES / "caffeine_water.pdb")))
+        assert s1._id in pipe._node_data
+        assert s2._id in pipe._node_data
+        assert s1._id != s2._id
+
+    def test_unsupported_format_raises(self, tmp_path):
+        # Create a dummy file with unsupported extension
+        dummy = tmp_path / "test.unknown"
+        dummy.write_text("dummy")
+        pipe = Pipeline()
+        with pytest.raises(ValueError, match="Unsupported"):
+            pipe.add_node(LoadStructure(str(dummy)))
+
+
+class TestPipelineDAG:
+    """Pipeline supports DAG branching correctly."""
+
+    def test_fan_out_from_structure(self):
+        """Multiple downstream nodes from one LoadStructure."""
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        f1 = pipe.add_node(Filter(query="element == 'C'"))
+        f2 = pipe.add_node(Filter(query="element == 'N'"))
+        b = pipe.add_node(AddBonds(source="distance"))
+        pipe.add_edge(s, f1)
+        pipe.add_edge(s, f2)
+        pipe.add_edge(s, b)
+
+        result = pipe.to_dict()
+        # Should have 3 explicit edges + viewport auto-edges
+        explicit_edges = [
+            e for e in result["edges"]
+            if e["target"] != "viewport-auto"
+        ]
+        assert len(explicit_edges) == 3
+
+    def test_chain_filter_modify_labels(self):
+        """Filter → Modify and Filter → Labels from same parent."""
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        f = pipe.add_node(Filter(query="element == 'C'"))
+        m = pipe.add_node(Modify(scale=1.3))
+        lbl = pipe.add_node(AddLabels(source="element"))
+        pipe.add_edge(s, f)
+        pipe.add_edge(f, m)
+        pipe.add_edge(f, lbl)
+
+        result = pipe.to_dict()
+        # f → m uses out → in
+        fm_edge = next(
+            e for e in result["edges"]
+            if e["source"] == f._id and e["target"] == m._id
+        )
+        assert fm_edge["sourceHandle"] == "out"
+
+        # f → lbl uses out → particle
+        fl_edge = next(
+            e for e in result["edges"]
+            if e["source"] == f._id and e["target"] == lbl._id
+        )
+        assert fl_edge["sourceHandle"] == "out"


### PR DESCRIPTION
Replace the Jupyter widget's JS pipeline editor UI with a Python-side Pipeline API that builds pipeline configurations programmatically.

Key changes:
- New python/megane/pipeline.py with node classes (LoadStructure, Filter, Modify, AddBonds, AddLabels, AddPolyhedra, etc.) and Pipeline class with add_node()/add_edge() methods
- Pipeline serializes to SerializedPipeline v3 JSON format (TS is source of truth, Python is a thin wrapper)
- LoadStructure auto-loads files via Rust parsers and stores binary snapshot data per node
- widget.py: rename pipeline traitlet to _pipeline_enabled, add _node_snapshots_data Dict traitlet, add set_pipeline() method, deprecate load()
- widget.ts: update traitlet names, add _node_snapshots_data handler
- WidgetViewer.tsx: remove PipelineEditor sidebar, add per-node snapshot decoding for multi-structure support
- 31 unit tests covering node classes, edge resolution, serialization, data loading, and DAG branching

https://claude.ai/code/session_011DrsMEGUZJEmaKSZfqbGUb