### PR TITLE
Remove latest.md summary output and improve dev tooling skills/hooks

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,18 +9,13 @@ log() { echo "[session-start] $*"; }
 
 # --- GitHub CLI ---
 if ! command -v gh &>/dev/null; then
-  log "Installing GitHub CLI..."
-  GH_VERSION=$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest 2>/dev/null \
-    | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'].lstrip('v'))" 2>/dev/null)
-  if [ -n "$GH_VERSION" ]; then
-    curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" -o /tmp/gh.tar.gz \
-      && tar -xzf /tmp/gh.tar.gz -C /tmp \
-      && sudo cp "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh \
-      && rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_VERSION}_linux_amd64"
-    log "GitHub CLI installed: $(gh --version | head -1)"
-  else
-    log "WARNING: Could not fetch gh release info, skipping gh install"
-  fi
+  log "Installing GitHub CLI via apt..."
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+  sudo apt-get update -qq && sudo apt-get install -y -qq gh
+  log "GitHub CLI installed: $(gh --version | head -1)"
 else
   log "GitHub CLI already installed: $(gh --version | head -1)"
 fi

--- a/.claude/skills/commit.md
+++ b/.claude/skills/commit.md
@@ -33,3 +33,5 @@ Keep the first line under 72 characters. Add details in the body if needed.
 ## After Committing
 
 Always create a pull request after pushing your changes using `gh pr create`. Include a summary of changes and a test plan in the PR body.
+
+If additional commits are pushed after the PR is created, review the PR description and update it to accurately reflect all changes. The PR summary must always match the actual diff.

--- a/.claude/skills/commit.md
+++ b/.claude/skills/commit.md
@@ -34,4 +34,4 @@ Keep the first line under 72 characters. Add details in the body if needed.
 
 Always create a pull request after pushing your changes using `gh pr create`. Include a summary of changes and a test plan in the PR body.
 
-If additional commits are pushed after the PR is created, review the PR description and update it to accurately reflect all changes. The PR summary must always match the actual diff.
+If additional commits are pushed after the PR is created, review the PR title and description and update them to accurately reflect all changes. Both the title and summary must always match the actual diff.

--- a/.claude/skills/commit.md
+++ b/.claude/skills/commit.md
@@ -29,3 +29,7 @@ Keep the first line under 72 characters. Add details in the body if needed.
    - Python changes: `python -m pytest`
 2. Ensure the build succeeds for frontend changes: `npm run build`
 3. Do NOT commit generated files: `crates/megane-wasm/pkg/`, `dist/`, `target/`, `node_modules/`, `dev-preview/`
+
+## After Committing
+
+Always create a pull request after pushing your changes using `gh pr create`. Include a summary of changes and a test plan in the PR body.

--- a/.claude/skills/preview.md
+++ b/.claude/skills/preview.md
@@ -28,7 +28,7 @@ node scripts/dev-preview.mjs --interact
 ```
 or: `make preview`
 
-Output goes to `dev-preview/` directory with a `latest.md` markdown summary.
+Output goes to `dev-preview/` directory.
 
 ### Options
 - `--desktop-only` / `--mobile-only` — limit viewports

--- a/scripts/dev-preview.mjs
+++ b/scripts/dev-preview.mjs
@@ -25,7 +25,6 @@
  *     videos/
  *       desktop-<timestamp>.webm
  *       mobile-<timestamp>.webm
- *     latest.md           (GitHub-friendly markdown with embedded images)
  */
 
 import { spawn, execSync } from "child_process";
@@ -242,37 +241,6 @@ async function captureVideo(browser, viewport, durationMs) {
   }
 }
 
-function generateMarkdown(screenshots, videos) {
-  const lines = [
-    `# Dev Preview - ${TIMESTAMP.replace("_", " ").replace(/-/g, ":")}`,
-    "",
-  ];
-
-  if (screenshots.length > 0) {
-    lines.push("## Screenshots", "");
-    for (const { name, filename } of screenshots) {
-      lines.push(`### ${name}`);
-      lines.push(`![${name}](screenshots/${filename})`, "");
-    }
-  }
-
-  if (videos.length > 0) {
-    lines.push("## Videos", "");
-    lines.push(
-      "> Note: `.webm` videos can be viewed by opening the file in a browser",
-      "> or by clicking the file on GitHub.",
-      ""
-    );
-    for (const { name, filename } of videos) {
-      lines.push(`### ${name}`);
-      lines.push(`- [${filename}](videos/${filename})`, "");
-    }
-  }
-
-  const mdPath = join(OUTPUT_DIR, "latest.md");
-  writeFileSync(mdPath, lines.join("\n"));
-  console.log(`\nMarkdown summary: ${mdPath}`);
-}
 
 // ---- Main ----
 
@@ -311,8 +279,6 @@ try {
       }
     }
   }
-
-  generateMarkdown(screenshotResults, videoResults);
 
   console.log("\nDev preview capture complete!");
   console.log(`Output: ${OUTPUT_DIR}`);


### PR DESCRIPTION
## Summary
- Remove the `generateMarkdown` function from `scripts/dev-preview.mjs` that generated `dev-preview/latest.md` after screenshot/video capture
- Update `.claude/skills/preview.md` to remove the `latest.md` reference
- Add PR creation instruction to `.claude/skills/commit.md`
- Add PR consistency check instruction to `.claude/skills/commit.md` — require verifying both PR title and description match all actual changes
- Switch `gh` install method in `.claude/hooks/session-start.sh` from tarball to apt for reliability

## Test plan
- [ ] Run `node scripts/dev-preview.mjs --screenshot` and verify screenshots are captured without generating `latest.md`
- [ ] Verify `session-start.sh` installs `gh` correctly via apt in a fresh environment

https://claude.ai/code/session_01BMSntYaNPCqTL9WCKM1V4H