### PR TITLE
docs: update README, CHANGELOG, and docs for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
+
+## [0.4.0] - 2026-03-14
+
+### Added
+
+- **CIF format** — Crystallographic Information File (`.cif`) parser
+- **LAMMPS data format** — LAMMPS data file (`.data`, `.lammps`) parser with auto-detection of atom_style
+- **ASE .traj format** — ASE trajectory (`.traj`) parser for ULM binary format
+- **LAMMPS dump trajectory** — LAMMPS dump (`.lammpstrj`) parser
+- AI pipeline generator — describe visualizations in natural language and the node graph is built automatically
+- Pipeline error display with node-level error icons and tooltips
+- Multiple structure loading with layer-based rendering
+- Render export button on pipeline editor
+- Python `Pipeline` class — NetworkX-style graph builder API for constructing pipelines programmatically
+- VSCode extension auto-setup: opening a PDB file creates a LoadStructure + AddBond + Viewport pipeline
+- Test coverage measurement for TypeScript, Python, and Rust
+- Tests for pipeline graph/validate/types, protocol, server, and CLI modules
+
+### Fixed
+
+- React error #185 — infinite re-render loop
+- LoadStructure node now supports CIF and LAMMPS file uploads
+- Frontend fallback route when static files are not built
+- API key no longer persisted in localStorage

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@
 ## Features
 
 - **1M+ Atoms at 60fps** — Billboard impostor rendering scales from small molecules to massive complexes in real time. InstancedMesh for small systems auto-switches to GPU-accelerated billboard impostors for large systems. Stream XTC trajectories over WebSocket.
-- **Runs Everywhere** — Jupyter widget, CLI server, React component, and VSCode extension. Rust-based PDB, GRO, XYZ, MOL, and XTC parsers shared between Python (PyO3) and browser (WASM) — parse once, run anywhere.
-- **Visual Pipeline Editor** — Build visualization workflows by wiring nodes. 8 node types (load, bond, filter, modify, labels, polyhedra, viewport) with 6 typed data channels (particle, bond, cell, label, mesh, trajectory) flowing through color-coded edges.
+- **Runs Everywhere** — Jupyter widget, CLI server, React component, and VSCode extension. Rust-based PDB, GRO, XYZ, MOL, CIF, XTC, LAMMPS, and ASE .traj parsers shared between Python (PyO3) and browser (WASM) — parse once, run anywhere.
+- **Visual Pipeline Editor** — Build visualization workflows by wiring nodes or let the AI generator build them from natural language. 8 node types with 6 typed data channels flowing through color-coded edges. Load multiple structures with layer-based rendering to compare systems side by side.
 - **Embed & Integrate** — Control the viewer from Plotly via ipywidgets events. Embed in MDX / Next.js docs. React to `frame_change`, `selection_change`, and `measurement` events. Use the framework-agnostic renderer from Vue, Svelte, or vanilla JS.
 
 ### Scale
@@ -51,9 +51,9 @@ One codebase, every environment.
 | **Jupyter** | anywidget inline viewer | `pip install megane` |
 | **Browser** | `megane serve` local server | `pip install megane` |
 | **React** | `<MeganeViewer />` component | `npm install megane-viewer` |
-| **VSCode** | Custom editor for .pdb, .gro, .xyz | Extension |
+| **VSCode** | Custom editor for .pdb, .gro, .xyz, .mol, .sdf | Extension |
 
-The secret: PDB, GRO, XYZ, MOL, and XTC parsers are written in **Rust** and compiled to both **PyO3** (Python) and **WASM** (browser). Parse once, run anywhere.
+The secret: PDB, GRO, XYZ, MOL, CIF, XTC, LAMMPS, and ASE .traj parsers are written in **Rust** and compiled to both **PyO3** (Python) and **WASM** (browser). Parse once, run anywhere.
 
 ### Visual Pipelines
 
@@ -149,6 +149,10 @@ function App() {
 | XYZ | `.xyz` | Cartesian coordinate format |
 | MOL/SDF | `.mol`, `.sdf` | MDL Molfile (V2000) |
 | XTC | `.xtc` | GROMACS compressed trajectory |
+| CIF | `.cif` | Crystallographic Information File |
+| LAMMPS data | `.data`, `.lammps` | LAMMPS data file |
+| ASE .traj | `.traj` | ASE trajectory (ULM binary format) |
+| LAMMPS dump | `.lammpstrj` | LAMMPS dump trajectory |
 
 ## Development
 
@@ -211,7 +215,7 @@ make test-all              # All tests
 src/                     TypeScript frontend
   renderer/              Three.js rendering (impostor, mesh, shaders)
   protocol/              Binary protocol decoder + web workers
-  parsers/               WASM-based file parsers (PDB, GRO, XYZ, MOL, XTC)
+  parsers/               WASM-based file parsers (PDB, GRO, XYZ, MOL, CIF, XTC, LAMMPS, .traj)
   logic/                 Bond / label / vector source logic
   components/            React UI components
   hooks/                 Custom React hooks

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,6 +88,10 @@ function App() {
 | XYZ | `.xyz` | Simple cartesian coordinate format |
 | MOL | `.mol` | MDL Molfile (V2000) — small molecules with bond information |
 | XTC | `.xtc` | GROMACS compressed trajectory |
+| CIF | `.cif` | Crystallographic Information File |
+| LAMMPS data | `.data`, `.lammps` | LAMMPS data file |
+| ASE .traj | `.traj` | ASE trajectory (ULM binary format) |
+| LAMMPS dump | `.lammpstrj` | LAMMPS dump trajectory |
 
 ## Next Steps
 

--- a/docs/guide/pipeline.md
+++ b/docs/guide/pipeline.md
@@ -8,6 +8,16 @@ A pipeline is a directed graph of **nodes** connected by **edges**. Data flows f
 
 Each edge carries a specific **data type** — particle, bond, cell, label, mesh, or trajectory — and only matching types can connect.
 
+When a node encounters an error — for example, a parse failure in LoadStructure — an error icon appears on the node with a tooltip showing the details.
+
+## AI Pipeline Generator
+
+Describe the visualization you want in natural language, and megane builds the node graph for you. Open the AI chat panel from the pipeline editor toolbar and type a prompt like:
+
+> Load protein.pdb with bonds and make water translucent
+
+The generator creates the appropriate LoadStructure, AddBond, Filter, Modify, and Viewport nodes, wires them together, and places them in the editor. You can then adjust parameters or add more nodes manually.
+
 ## Getting Started
 
 The simplest pipeline loads a structure and displays it:
@@ -35,7 +45,7 @@ Use the **Templates** dropdown to load pre-built pipelines:
 
 | Node | Description | Inputs | Outputs |
 |------|-------------|--------|---------|
-| **Load Structure** | Load a molecular structure file (PDB, GRO, XYZ, MOL) | — | particle, trajectory, cell |
+| **Load Structure** | Load a molecular structure file (PDB, GRO, XYZ, MOL, CIF, LAMMPS, .traj) | — | particle, trajectory, cell |
 | **Load Trajectory** | Load an XTC trajectory file | particle | trajectory |
 
 ### Processing

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,9 +23,9 @@ features:
   - title: "\U0001F680 1M+ Atoms at 60fps"
     details: Billboard impostor rendering scales from small molecules to massive protein complexes in real time. Stream XTC trajectories over WebSocket — scrub thousands of frames without loading everything into memory.
   - title: "\U0001F30D Runs Everywhere"
-    details: "Jupyter widget, CLI server, React component, VSCode extension. Same Rust parsers shared between Python (PyO3) and browser (WASM): parse once, run anywhere."
+    details: "Jupyter widget, CLI server, React component, VSCode extension. Rust parsers (PDB, GRO, XYZ, MOL, CIF, XTC, LAMMPS, .traj) shared between Python (PyO3) and browser (WASM): parse once, run anywhere."
   - title: "\U0001F9E9 Visual Pipeline Editor"
-    details: Build visualization workflows by wiring nodes — filter atoms, adjust styles, generate labels, render coordination polyhedra. No code required. Typed data flows through color-coded edges.
+    details: Build visualization workflows by wiring nodes — filter atoms, adjust styles, generate labels, render coordination polyhedra. No code required. Typed data flows through color-coded edges. An AI generator can build pipelines from natural language.
   - title: "\U0001F517 Embed & Integrate"
     details: Control the viewer from Plotly via ipywidgets events. Embed in MDX / Next.js docs. React to frame_change, selection_change, and measurement events. Use the framework-agnostic renderer from Vue, Svelte, or vanilla JS.
 ---
@@ -56,7 +56,7 @@ One codebase, every environment.
 | **React** | `<MeganeViewer />` component | `npm install megane-viewer` |
 | **VSCode** | Custom editor for .pdb, .gro, .xyz | Extension |
 
-The secret: PDB, GRO, XYZ, MOL, and XTC parsers are written in **Rust** and compiled to both **PyO3** (Python) and **WASM** (browser). Parse once, run anywhere.
+The secret: PDB, GRO, XYZ, MOL, CIF, XTC, LAMMPS, and ASE .traj parsers are written in **Rust** and compiled to both **PyO3** (Python) and **WASM** (browser). Parse once, run anywhere.
 
   </div>
   <div class="pillar-images single-col">


### PR DESCRIPTION
## Summary
- Create `CHANGELOG.md` documenting all changes since v0.3.2 (new formats, AI pipeline generator, bug fixes, testing improvements)
- Update file format tables in README, getting-started, and pipeline guide to include CIF, LAMMPS data, ASE .traj, and LAMMPS dump
- Update parser lists and feature descriptions across README and docs site
- Add AI Pipeline Generator section and error display documentation to pipeline guide

## Test plan
- [ ] Verify CHANGELOG.md renders correctly on GitHub
- [ ] Confirm no stale "PDB, GRO, XYZ, MOL, and XTC" references remain (`grep -rn "PDB, GRO, XYZ, MOL, and XTC"` returns 0 matches)
- [ ] Review format tables are consistent across README, getting-started, and pipeline guide
- [ ] Check VitePress docs build: `npx vitepress build docs`

https://claude.ai/code/session_012Fqkwo1ue4KGYcmigwGgjL