### PR TITLE
docs: add documentation update checklist to commit skill

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -29,6 +29,15 @@ Keep the first line under 72 characters. Add details in the body if needed.
    - Python changes: `python -m pytest`
 2. Ensure the build succeeds for frontend changes: `npm run build`
 3. Do NOT commit generated files: `crates/megane-wasm/pkg/`, `dist/`, `target/`, `node_modules/`, `dev-preview/`
+4. Check if your changes require documentation updates:
+   - Review `README.md`, `CLAUDE.md`, and files under `docs/` for any descriptions affected by your changes
+   - If you added/changed/removed features, CLI options, API, commands, configuration, or architecture, update the corresponding documentation
+   - Key docs to check:
+     - `README.md` — project overview, usage examples
+     - `CLAUDE.md` — dev instructions, key commands, architecture notes
+     - `CHANGELOG.md` — notable changes
+     - `docs/` — user-facing guides and API reference
+   - Include doc updates in the same commit (or a separate `docs:` commit if the changes are substantial)
 
 ## After Committing
 


### PR DESCRIPTION
## Summary
- Added a documentation update checklist (step 4) to the "Before Committing" section in the commit skill
- Reminds to review README.md, CLAUDE.md, CHANGELOG.md, and docs/ for any descriptions affected by code changes

## Test plan
- [x] Verify the SKILL.md file is valid markdown and renders correctly
- [x] Confirm no other docs need updating (this is an internal skill change only)

https://claude.ai/code/session_01EdHiZMRjwzLKUbYyUzGxF7