### PR TITLE
chore: exclude bundled output from CodeQL scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+name: "CodeQL config"
+
+paths-ignore:
+  - "python/megane/static"


### PR DESCRIPTION
## Summary
- Add CodeQL configuration to exclude `python/megane/static/` from code scanning
- The bundled `widget.js` contains `Math.random()` calls from React and Three.js internals, triggering false positive "insecure randomness" warnings
- Source code in `src/` continues to be scanned normally

## Test plan
- [ ] Verify CodeQL no longer reports "insecure randomness" warnings for `widget.js`
- [ ] Verify source code under `src/` is still scanned by CodeQL

https://claude.ai/code/session_01H3GBHiqHHGnEhMJ3ZNCxYK