### PR TITLE
docs: add Python API update reminder for pipeline node changes

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -38,6 +38,11 @@ Keep the first line under 72 characters. Add details in the body if needed.
      - `CHANGELOG.md` — notable changes
      - `docs/` — user-facing guides and API reference
    - Include doc updates in the same commit (or a separate `docs:` commit if the changes are substantial)
+5. If you changed pipeline nodes (`src/pipeline/`), ensure the Python API is also updated:
+   - Node classes in `python/megane/pipeline.py` (add/update corresponding `PipelineNode` subclass)
+   - Port mappings in `_SOURCE_OUTPUT_MAP` / `_TARGET_PORT_MAP`
+   - Public exports in `python/megane/__init__.py`
+   - Default parameters must match TypeScript `defaultParams()` in `src/pipeline/types.ts`
 
 ## After Committing
 


### PR DESCRIPTION
## Summary
- Added a checklist item to the commit skill reminding developers to update the Python API whenever pipeline nodes in `src/pipeline/` are changed
- Covers: node classes in `pipeline.py`, port mappings, public exports in `__init__.py`, and default parameter consistency with TypeScript

## Test plan
- [x] Verify `.claude/skills/commit/SKILL.md` contains the new checklist item
- [x] Confirm existing content is unchanged

https://claude.ai/code/session_01X2zQFShLKL2i2VLqtTxZM5