### PR TITLE
feat: add bond output to streaming node and streaming template

### DIFF
--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -487,7 +487,7 @@ class Pipeline:
             "load_structure": ["particle", "trajectory", "cell"],
             "load_trajectory": ["trajectory"],
             "load_vector": ["vector"],
-            "streaming": ["particle", "trajectory", "cell"],
+            "streaming": ["particle", "bond", "trajectory", "cell"],
             "filter": ["out"],
             "modify": ["out"],
             "add_bond": ["bond"],

--- a/src/components/nodes/StreamingNode.tsx
+++ b/src/components/nodes/StreamingNode.tsx
@@ -17,9 +17,11 @@ export function StreamingNode({ id, data }: NodeProps<Node<PipelineNodeData>>) {
   const connected = params.connected;
   const hasSnapshot = !!nodeStreamingData?.snapshot;
   const hasTrajectory = !!nodeStreamingData?.streamProvider;
+  const hasBond = !!nodeStreamingData?.snapshot?.nBonds;
   const hasCell = !!nodeStreamingData?.snapshot?.box;
 
   const disabledPorts = new Set<string>();
+  if (!hasBond) disabledPorts.add("bond");
   if (!hasTrajectory) disabledPorts.add("trajectory");
   if (!hasCell) disabledPorts.add("cell");
 
@@ -46,6 +48,7 @@ export function StreamingNode({ id, data }: NodeProps<Node<PipelineNodeData>>) {
         {hasSnapshot && (
           <div style={{ fontSize: 11, color: "#64748b", marginTop: 4 }}>
             {nodeStreamingData!.snapshot.nAtoms} atoms
+            {hasBond && `, ${nodeStreamingData!.snapshot.nBonds} bonds`}
             {hasTrajectory && `, ${nodeStreamingData!.streamProvider!.meta.nFrames} frames`}
           </div>
         )}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,9 @@ import { MeganeViewer } from "./components/MeganeViewer";
 import { useDataSource } from "./hooks/useDataSource";
 import { usePipelineStore } from "./pipeline/store";
 import { usePlaybackStore } from "./stores/usePlaybackStore";
+import { parseStructureText } from "./parsers/structure";
+import { parseXTCFile } from "./parsers/xtc";
+import { MemoryFrameProvider } from "./pipeline/types";
 import defaultPDB from "../tests/fixtures/caffeine_water.pdb?raw";
 import defaultXtcUrl from "../tests/fixtures/caffeine_water_vibration.xtc?url";
 import perovskiteXYZ from "../tests/fixtures/perovskite_srtio3_3x3x3.xyz?raw";
@@ -62,6 +65,23 @@ function App() {
         await ds.local.loadXtc(xtcFile);
       } else if (pendingTemplateId === "solid") {
         await ds.local.loadText(perovskiteXYZ, "perovskite_srtio3_3x3x3.xyz");
+      } else if (pendingTemplateId === "streaming") {
+        // Simulate streaming by parsing local data and populating nodeStreamingData
+        const result = await parseStructureText(defaultPDB, "caffeine_water.pdb");
+        const resp = await fetch(defaultXtcUrl);
+        const blob = await resp.blob();
+        const xtcFile = new File([blob], "caffeine_water_vibration.xtc");
+        const { frames, meta } = await parseXTCFile(xtcFile, result.snapshot.nAtoms);
+        const store = usePipelineStore.getState();
+        const streamNode = store.nodes.find((n) => n.type === "streaming");
+        if (streamNode) {
+          const provider = meta ? new MemoryFrameProvider(frames, meta, result.snapshot.positions) : null;
+          store.setNodeStreamingData(streamNode.id, {
+            snapshot: result.snapshot,
+            streamProvider: provider,
+          });
+          store.updateNodeParams(streamNode.id, { connected: true });
+        }
       }
       clearPendingTemplate();
     })().catch(() => {});

--- a/src/pipeline/executors/streaming.ts
+++ b/src/pipeline/executors/streaming.ts
@@ -8,6 +8,7 @@ import type { Snapshot } from "../../types";
 import type {
   PipelineData,
   ParticleData,
+  BondData,
   CellData,
   TrajectoryData,
   FrameProvider,
@@ -37,6 +38,23 @@ export function executeStreaming(
     opacityOverrides: null,
   };
   outputs.set("particle", particle);
+
+  // Output bond data if bonds are available in the snapshot
+  if (snapshot.nBonds > 0) {
+    const bond: BondData = {
+      type: "bond",
+      sourceNodeId: nodeId,
+      bondIndices: snapshot.bonds,
+      bondOrders: snapshot.bondOrders,
+      nBonds: snapshot.nBonds,
+      scale: 1.0,
+      opacity: 1.0,
+      positions: null,
+      elements: null,
+      nAtoms: snapshot.nAtoms,
+    };
+    outputs.set("bond", bond);
+  }
 
   // Output trajectory data if stream provider is available
   if (streamProvider) {

--- a/src/pipeline/templates.ts
+++ b/src/pipeline/templates.ts
@@ -168,6 +168,51 @@ function createSolidTemplate(): {
   };
 }
 
+/**
+ * Streaming template: WebSocket streaming with bonds and trajectory.
+ * Streaming → Viewport (particle, bond, trajectory, cell)
+ */
+function createStreamingTemplate(): {
+  nodes: Node<PipelineNodeData>[];
+  edges: Edge[];
+} {
+  return {
+    nodes: [
+      {
+        id: "streaming-1",
+        type: "streaming",
+        position: { x: 425, y: 0 },
+        data: {
+          params: {
+            type: "streaming",
+            connected: false,
+          },
+          enabled: true,
+        },
+      },
+      {
+        id: "viewport-1",
+        type: "viewport",
+        position: { x: 425, y: 310 },
+        data: {
+          params: {
+            type: "viewport",
+            perspective: false,
+            cellAxesVisible: true,
+          },
+          enabled: true,
+        },
+      },
+    ],
+    edges: [
+      { id: "e1", source: "streaming-1", target: "viewport-1", sourceHandle: "particle", targetHandle: "particle" },
+      { id: "e2", source: "streaming-1", target: "viewport-1", sourceHandle: "bond", targetHandle: "bond" },
+      { id: "e3", source: "streaming-1", target: "viewport-1", sourceHandle: "trajectory", targetHandle: "trajectory" },
+      { id: "e4", source: "streaming-1", target: "viewport-1", sourceHandle: "cell", targetHandle: "cell" },
+    ],
+  };
+}
+
 export const PIPELINE_TEMPLATES: PipelineTemplate[] = [
   {
     id: "molecule",
@@ -180,5 +225,11 @@ export const PIPELINE_TEMPLATES: PipelineTemplate[] = [
     label: "Solid",
     description: "Perovskite with coordination polyhedra",
     create: createSolidTemplate,
+  },
+  {
+    id: "streaming",
+    label: "Streaming",
+    description: "WebSocket streaming with bonds",
+    create: createStreamingTemplate,
   },
 ];

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -232,6 +232,7 @@ export const NODE_PORTS: Record<PipelineNodeType, NodePortConfig> = {
     inputs: [],
     outputs: [
       { name: "particle", dataType: "particle", label: "Particle" },
+      { name: "bond", dataType: "bond", label: "Bond" },
       { name: "trajectory", dataType: "trajectory", label: "Trajectory" },
       { name: "cell", dataType: "cell", label: "Cell" },
     ],


### PR DESCRIPTION
## Summary
- Added `bond` output port to the streaming node, so it outputs particle, bond, trajectory, and cell data from WebSocket-streamed molecular data
- Created a new "Streaming" pipeline template (Streaming → Viewport) available in the Templates dropdown
- Demo site now simulates streaming by parsing local caffeine_water.pdb + XTC data and populating the streaming node's data store, showing "Connected" status
- Updated Python `pipeline.py` output handles to include `bond` for the streaming node

## Test plan
- [ ] Run `npm test` — all 203 TypeScript tests pass
- [ ] Run `npm run dev` and select "Streaming" template from Templates dropdown
- [ ] Verify streaming node shows green "Connected" status with atom/bond/frame counts
- [ ] Verify molecule renders with bonds visible in the viewport
- [ ] Verify trajectory playback works

https://claude.ai/code/session_0144w7NwBaFHPrRUac6HF1mZ