### PR TITLE
docs: fix doc-code discrepancies and add Python pipeline API

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 - **1M+ Atoms at 60fps** — Billboard impostor rendering scales from small molecules to massive complexes in real time. InstancedMesh for small systems auto-switches to GPU-accelerated billboard impostors for large systems. Stream XTC trajectories over WebSocket.
 - **Runs Everywhere** — Jupyter widget, CLI server, React component, and VSCode extension. Rust-based PDB, GRO, XYZ, MOL, CIF, XTC, LAMMPS, and ASE .traj parsers shared between Python (PyO3) and browser (WASM) — parse once, run anywhere.
-- **Visual Pipeline Editor** — Build visualization workflows by wiring nodes or let the AI generator build them from natural language. 8 node types with 6 typed data channels flowing through color-coded edges. Load multiple structures with layer-based rendering to compare systems side by side.
+- **Visual Pipeline Editor** — Build visualization workflows by wiring nodes or let the AI generator build them from natural language. 11 node types with 7 typed data channels flowing through color-coded edges. Load multiple structures with layer-based rendering to compare systems side by side.
 - **Embed & Integrate** — Control the viewer from Plotly via ipywidgets events. Embed in MDX / Next.js docs. React to `frame_change`, `selection_change`, and `measurement` events. Use the framework-agnostic renderer from Vue, Svelte, or vanilla JS.
 
 ### Scale
@@ -51,7 +51,7 @@ One codebase, every environment.
 | **Jupyter** | anywidget inline viewer | `pip install megane` |
 | **Browser** | `megane serve` local server | `pip install megane` |
 | **React** | `<MeganeViewer />` component | `npm install megane-viewer` |
-| **VSCode** | Custom editor for .pdb, .gro, .xyz, .mol, .sdf | Extension |
+| **VSCode** | Custom editor for .pdb, .gro, .xyz, .mol, .sdf, .cif | Extension |
 
 The secret: PDB, GRO, XYZ, MOL, CIF, XTC, LAMMPS, and ASE .traj parsers are written in **Rust** and compiled to both **PyO3** (Python) and **WASM** (browser). Parse once, run anywhere.
 
@@ -59,9 +59,9 @@ The secret: PDB, GRO, XYZ, MOL, CIF, XTC, LAMMPS, and ASE .traj parsers are writ
 
 Wire nodes to build visualization workflows — no code required.
 
-**8 node types** across 5 categories: load data, add bonds, filter atoms by query, modify scale and opacity per-group, generate labels, render coordination polyhedra, and display in a 3D viewport.
+**11 node types** across 5 categories: load data (structure, trajectory, streaming, vector), process (filter, modify), overlay (bonds, labels, polyhedra, vectors), and display in a 3D viewport.
 
-**6 typed data channels** — particle, bond, cell, label, mesh, trajectory — flow through color-coded edges. Only matching types can connect.
+**7 typed data channels** — particle, bond, cell, label, mesh, trajectory, vector — flow through color-coded edges. Only matching types can connect.
 
 Pipelines serialize to JSON, so you can save, share, and version-control your visualization recipes.
 
@@ -98,13 +98,16 @@ npm install megane-viewer
 ```python
 import megane
 
-viewer = megane.MolecularViewer()
-viewer.load("protein.pdb")
-viewer  # display in cell
+# Build a pipeline
+pipe = megane.Pipeline()
+s = pipe.add_node(megane.LoadStructure("protein.pdb"))
+bonds = pipe.add_node(megane.AddBonds(source="distance"))
+pipe.add_edge(s, bonds)
 
-# With trajectory
-viewer.load("protein.pdb", xtc="trajectory.xtc")
-viewer.frame_index = 50
+# Display in notebook
+viewer = megane.MolecularViewer()
+viewer.set_pipeline(pipe)
+viewer
 ```
 
 ### CLI (Docker)
@@ -159,7 +162,7 @@ function App() {
 ### Prerequisites
 
 - Python 3.10+
-- Node.js 18+
+- Node.js 22+
 - Rust (for building the parser)
 - [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) (for building WASM bindings)
 - [uv](https://docs.astral.sh/uv/)
@@ -226,6 +229,7 @@ crates/                  Rust workspace
   megane-wasm/           WASM bindings (wasm-bindgen)
 python/megane/           Python backend
   parsers/               PDB / XTC parsers
+  pipeline.py            Pipeline builder (NetworkX-style DAG)
   protocol.py            Binary protocol encoder
   server.py              FastAPI WebSocket server
   widget.py              anywidget Jupyter widget

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -13,9 +13,13 @@ The Python API is used for:
 ```python
 import megane
 
+pipe = megane.Pipeline()
+s = pipe.add_node(megane.LoadStructure("protein.pdb"))
+t = pipe.add_node(megane.LoadTrajectory(xtc="trajectory.xtc"))
+pipe.add_edge(s, t)
+
 viewer = megane.MolecularViewer()
-structure = megane.load_pdb("protein.pdb")
-trajectory = megane.load_trajectory("protein.pdb", "trajectory.xtc")
+viewer.set_pipeline(pipe)
 ```
 
 [Python API Reference →](/api/python/)
@@ -29,7 +33,7 @@ The TypeScript API is used for:
 - **Protocol decoding** — Parse binary WebSocket messages
 
 ```ts
-import { MeganeViewer, MoleculeRenderer } from "megane";
+import { MeganeViewer, MoleculeRenderer } from "megane-viewer";
 ```
 
 [TypeScript API Reference →](/api/typescript/)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@
 ### Prerequisites
 
 - Python 3.10+
-- Node.js 18+
+- Node.js 22+
 - Rust (for building the parser)
 - [uv](https://docs.astral.sh/uv/) (Python package manager)
 
@@ -50,11 +50,12 @@ npm run dev
 ```
 megane/
 ├── crates/                    # Rust workspace
-│   ├── megane-core/           # Core parsers (PDB, GRO, XYZ, MOL, XTC)
+│   ├── megane-core/           # Core parsers (PDB, GRO, XYZ, MOL, CIF, XTC, LAMMPS, .traj, .lammpstrj)
 │   ├── megane-python/         # PyO3 bindings
 │   └── megane-wasm/           # WASM bindings
 ├── python/megane/             # Python package
 │   ├── widget.py              # Jupyter widget (anywidget)
+│   ├── pipeline.py            # Pipeline builder (NetworkX-style DAG)
 │   ├── server.py              # FastAPI WebSocket server
 │   ├── cli.py                 # CLI entry point
 │   ├── protocol.py            # Binary protocol encoder

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - Python 3.10 or later
-- Node.js 18+ (for web development)
+- Node.js 22+ (for web development)
 
 ## Installation
 
@@ -26,20 +26,28 @@ npm install megane-viewer
 ```python
 import megane
 
-# Create a viewer widget
-viewer = megane.MolecularViewer()
-
-# Load a PDB file
-viewer.load("protein.pdb")
+# Build a pipeline
+pipe = megane.Pipeline()
+s = pipe.add_node(megane.LoadStructure("protein.pdb"))
+bonds = pipe.add_node(megane.AddBonds(source="distance"))
+pipe.add_edge(s, bonds)
 
 # Display in notebook
+viewer = megane.MolecularViewer()
+viewer.set_pipeline(pipe)
 viewer
 ```
 
 With a trajectory:
 
 ```python
-viewer.load("protein.pdb", xtc="trajectory.xtc")
+pipe = megane.Pipeline()
+s = pipe.add_node(megane.LoadStructure("protein.pdb"))
+t = pipe.add_node(megane.LoadTrajectory(xtc="trajectory.xtc"))
+pipe.add_edge(s, t)
+
+viewer = megane.MolecularViewer()
+viewer.set_pipeline(pipe)
 viewer.frame_index = 50  # Jump to frame 50
 ```
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -23,7 +23,7 @@ docker run --rm -p 8080:8080 -v ./mydata:/data megane \
 ### Prerequisites
 
 - Python 3.10+
-- Node.js 18+
+- Node.js 22+
 - Rust
 - [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/)
 - [uv](https://docs.astral.sh/uv/)

--- a/docs/guide/integrations.md
+++ b/docs/guide/integrations.md
@@ -14,7 +14,12 @@ import ipywidgets as widgets
 import megane
 
 viewer = megane.MolecularViewer()
-viewer.load("protein.pdb", xtc="trajectory.xtc")
+
+pipe = megane.Pipeline()
+s = pipe.add_node(megane.LoadStructure("protein.pdb"))
+t = pipe.add_node(megane.LoadTrajectory(xtc="trajectory.xtc"))
+pipe.add_edge(s, t)
+viewer.set_pipeline(pipe)
 
 # Create a Plotly time-series chart
 fig = go.FigureWidget(
@@ -107,7 +112,10 @@ Use `on_event()` as a decorator or method call:
 import megane
 
 viewer = megane.MolecularViewer()
-viewer.load("protein.pdb")
+
+pipe = megane.Pipeline()
+s = pipe.add_node(megane.LoadStructure("protein.pdb"))
+viewer.set_pipeline(pipe)
 
 # As decorator
 @viewer.on_event("measurement")

--- a/docs/guide/jupyter.md
+++ b/docs/guide/jupyter.md
@@ -67,7 +67,8 @@ No required arguments. Inherits from `anywidget.AnyWidget`.
 
 | Method | Description |
 |--------|-------------|
-| `load(pdb_path, xtc=None)` | Load a PDB structure, optionally with an XTC trajectory |
+| `set_pipeline(pipeline)` | Apply a `Pipeline` to the viewer, or `None` to clear |
+| `load(pdb_path, xtc=None)` | *(Deprecated)* Load a PDB structure. Use `set_pipeline()` instead |
 | `on_event(name, callback=None)` | Register an event callback. Use as `@viewer.on_event("name")` decorator or `viewer.on_event("name", fn)` |
 | `off_event(name, callback=None)` | Remove a specific callback, or all callbacks for the event if `callback` is `None` |
 

--- a/docs/guide/pipeline.md
+++ b/docs/guide/pipeline.md
@@ -2,11 +2,13 @@
 
 megane's pipeline editor lets you build visualization workflows by wiring nodes — no code required. Open the pipeline panel from the sidebar to start building.
 
+Pipelines can also be built programmatically in Python using the `Pipeline` API (see [Python Pipeline API](#python-pipeline-api) below).
+
 ## Concept
 
 A pipeline is a directed graph of **nodes** connected by **edges**. Data flows from source nodes (like Load Structure) through processing nodes (like Filter or Modify) and into a Viewport node for rendering.
 
-Each edge carries a specific **data type** — particle, bond, cell, label, mesh, or trajectory — and only matching types can connect.
+Each edge carries a specific **data type** — particle, bond, cell, label, mesh, trajectory, or vector — and only matching types can connect.
 
 When a node encounters an error — for example, a parse failure in LoadStructure — an error icon appears on the node with a tooltip showing the details.
 
@@ -45,35 +47,55 @@ Use the **Templates** dropdown to load pre-built pipelines:
 
 | Node | Description | Inputs | Outputs |
 |------|-------------|--------|---------|
-| **Load Structure** | Load a molecular structure file (PDB, GRO, XYZ, MOL, CIF, LAMMPS, .traj) | — | particle, trajectory, cell |
-| **Load Trajectory** | Load an XTC trajectory file | particle | trajectory |
+| **Load Structure** | Load a molecular structure file (PDB, GRO, XYZ, MOL, LAMMPS data) | — | particle, trajectory, cell |
+| **Load Trajectory** | Load an XTC or ASE .traj trajectory file | particle | trajectory |
+| **Streaming** | WebSocket-based real-time data delivery | — | particle, bond, trajectory, cell |
+| **Load Vector** | Load per-atom vector data from a file | — | vector |
 
 ### Processing
 
 | Node | Description | Inputs | Outputs |
 |------|-------------|--------|---------|
-| **Add Bond** | Detect bonds from structure or by distance | particle | bond |
-| **Filter** | Select atoms using a query expression | particle, bond | particle, bond |
-| **Modify** | Override scale and opacity for a group of atoms | particle, bond | particle, bond |
-
-::: info Generic Ports
-Filter and Modify accept both **particle** and **bond** inputs. The output type matches the input type automatically.
-:::
+| **Filter** | Select atoms using a query expression | particle (in) | particle (out) |
+| **Modify** | Override scale and opacity for a group of atoms | particle (in) | particle (out) |
 
 ### Overlay
 
 | Node | Description | Inputs | Outputs |
 |------|-------------|--------|---------|
+| **Add Bond** | Detect bonds from structure or by distance | particle | bond |
 | **Label Generator** | Generate text labels at atom positions | particle | label |
 | **Polyhedron Generator** | Render coordination polyhedra (convex hulls) | particle | mesh |
+| **Vector Overlay** | Configure per-atom vector visualization (e.g. forces) | vector | vector |
 
 ### Output
 
 | Node | Description | Inputs | Outputs |
 |------|-------------|--------|---------|
-| **Viewport** | 3D rendering output | particle, bond, cell, trajectory, label, mesh | — |
+| **Viewport** | 3D rendering output | particle, bond, cell, trajectory, label, mesh, vector | — |
 
 ## Node Parameters
+
+### Load Structure
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| File path | string | Path to molecular structure file. Supported: `.pdb`, `.gro`, `.xyz`, `.mol`, `.data` (LAMMPS) |
+
+### Load Trajectory
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| xtc | string | Path to XTC trajectory file |
+| traj | string | Path to ASE .traj trajectory file |
+
+Requires a connection from a LoadStructure node. Frames are loaded lazily when `frame_index` changes.
+
+### Load Vector
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| File path | string | Path to vector data file (JSON with per-atom 3D vectors) |
 
 ### Add Bond
 
@@ -114,6 +136,14 @@ The input field validates your query in real time — invalid syntax is highligh
 | Max distance | number | 2.5 Å | Maximum center–ligand distance |
 | Opacity | number | 0.5 | Face transparency (0–1) |
 | Show edges | boolean | off | Display wireframe edges |
+| Edge color | string | `#dddddd` | Wireframe edge color (hex) |
+| Edge width | number | 3.0 | Wireframe edge width (px) |
+
+### Vector Overlay
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| Scale | number | 1.0 | Vector arrow length multiplier |
 
 ### Viewport
 
@@ -124,7 +154,7 @@ The input field validates your query in real time — invalid syntax is highligh
 
 ## Data Types
 
-Six typed data channels flow through color-coded edges:
+Seven typed data channels flow through color-coded edges:
 
 | Type | Color | Description |
 |------|-------|-------------|
@@ -134,6 +164,7 @@ Six typed data channels flow through color-coded edges:
 | **label** | Violet | Text labels positioned at atoms |
 | **mesh** | Gray | Triangle mesh for polyhedra rendering |
 | **trajectory** | Pink | Multi-frame coordinate data |
+| **vector** | Teal | Per-atom 3D vector data (forces, velocities, etc.) |
 
 ## Filter DSL
 
@@ -190,11 +221,369 @@ Use Filter + Modify nodes to fade out water molecules while keeping the protein 
 1. Add a `LoadStructure` node and load your PDB file
 2. Add a `Filter` node with query: `resname == "HOH"`
 3. Add a `Modify` node and set opacity to 0.2, scale to 0.5
-4. Connect: `LoadStructure.particle → Filter.particle → Modify.particle → Viewport.particle`
+4. Connect: `LoadStructure.particle → Filter.in → Modify.in → Viewport.particle`
 5. Connect the original `LoadStructure.particle → Viewport.particle` as well (for the protein)
 
 The viewport renders both streams — the protein at full opacity, and the water as translucent small spheres.
 
 ## Serialization
 
-Pipelines serialize to JSON and can be saved, loaded, and version-controlled. The serialization format includes node types, parameters, positions, and edge connections.
+Pipelines serialize to JSON (v3 format) and can be saved, loaded, and version-controlled. The serialization format includes node types, parameters, positions, and edge connections.
+
+## Python Pipeline API
+
+Pipelines can be built programmatically in Python using the `Pipeline` class. This is the recommended way to use megane in Jupyter notebooks and scripts.
+
+### Overview
+
+```python
+import megane
+
+pipe = megane.Pipeline()
+node = pipe.add_node(...)   # add a node
+pipe.add_edge(src, tgt)     # connect nodes
+
+viewer = megane.MolecularViewer()
+viewer.set_pipeline(pipe)   # apply to viewer
+viewer                      # display in notebook
+```
+
+The pipeline serializes to the `SerializedPipeline` v3 JSON format. A `Viewport` node is auto-generated and all unconnected outputs are automatically connected to it.
+
+### Pipeline class
+
+| Method | Description |
+|--------|-------------|
+| `add_node(node)` | Add a node to the pipeline. Returns the node for use in `add_edge()` |
+| `add_edge(source, target)` | Connect source → target. Port handles are auto-resolved |
+| `to_dict()` | Serialize to v3 JSON dict (auto-generates Viewport) |
+
+### Node classes
+
+All node classes are importable from `megane`:
+
+```python
+from megane import (
+    LoadStructure,
+    LoadTrajectory,
+    Streaming,
+    LoadVector,
+    Filter,
+    Modify,
+    AddBonds,
+    AddLabels,
+    AddPolyhedra,
+    VectorOverlay,
+    Pipeline,
+)
+```
+
+#### LoadStructure
+
+Load a molecular structure file.
+
+```python
+megane.LoadStructure(path: str)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `path` | `str` | File path. Supported: `.pdb`, `.gro`, `.xyz`, `.mol`, `.data` (LAMMPS) |
+
+**Outputs:** `particle`, `trajectory`, `cell`
+
+#### LoadTrajectory
+
+Load an external trajectory file. Requires connection from a `LoadStructure` node.
+
+```python
+megane.LoadTrajectory(*, xtc: str | None = None, traj: str | None = None)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `xtc` | `str \| None` | `None` | Path to XTC trajectory file |
+| `traj` | `str \| None` | `None` | Path to ASE .traj trajectory file |
+
+**Inputs:** `particle`
+**Outputs:** `trajectory`
+
+#### Streaming
+
+WebSocket-based real-time data delivery.
+
+```python
+megane.Streaming()
+```
+
+No parameters. **Outputs:** `particle`, `bond`, `trajectory`, `cell`
+
+#### LoadVector
+
+Load per-atom vector data from a file.
+
+```python
+megane.LoadVector(path: str)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `path` | `str` | Path to vector data file |
+
+**Outputs:** `vector`
+
+#### Filter
+
+Select atoms by a query expression.
+
+```python
+megane.Filter(*, query: str)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `str` | Selection expression (see [Filter DSL](#filter-dsl)) |
+
+**Inputs:** `particle` (as "in" handle)
+**Outputs:** `particle` (as "out" handle)
+
+#### Modify
+
+Override per-atom visual properties.
+
+```python
+megane.Modify(*, scale: float = 1.0, opacity: float = 1.0)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `scale` | `float` | `1.0` | Atom sphere radius multiplier (0.1–2.0) |
+| `opacity` | `float` | `1.0` | Transparency (0 = invisible, 1 = opaque) |
+
+**Inputs:** `particle` (as "in" handle)
+**Outputs:** `particle` (as "out" handle)
+
+#### AddBonds
+
+Compute and display bonds.
+
+```python
+megane.AddBonds(*, source: Literal["distance", "structure"] = "distance")
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `source` | `str` | `"distance"` | `"distance"` for VDW-based inference, `"structure"` for file-based bonds |
+
+**Inputs:** `particle`
+**Outputs:** `bond`
+
+#### AddLabels
+
+Generate text labels at atom positions.
+
+```python
+megane.AddLabels(*, source: Literal["element", "resname", "index"] = "element")
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `source` | `str` | `"element"` | Label source: `"element"`, `"resname"`, or `"index"` |
+
+**Inputs:** `particle`
+**Outputs:** `label`
+
+#### AddPolyhedra
+
+Generate coordination polyhedra mesh.
+
+```python
+megane.AddPolyhedra(
+    *,
+    center_elements: list[int],
+    ligand_elements: list[int] | None = None,
+    max_distance: float = 2.5,
+    opacity: float = 0.5,
+    show_edges: bool = False,
+    edge_color: str = "#dddddd",
+    edge_width: float = 3.0,
+)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `center_elements` | `list[int]` | *(required)* | Atomic numbers of center atoms (e.g., Ti=22) |
+| `ligand_elements` | `list[int] \| None` | `[8]` (oxygen) | Atomic numbers of ligand atoms |
+| `max_distance` | `float` | `2.5` | Maximum center–ligand distance (Å) |
+| `opacity` | `float` | `0.5` | Face transparency (0–1) |
+| `show_edges` | `bool` | `False` | Display wireframe edges |
+| `edge_color` | `str` | `"#dddddd"` | Wireframe edge color (hex) |
+| `edge_width` | `float` | `3.0` | Wireframe edge width (px) |
+
+**Inputs:** `particle`
+**Outputs:** `mesh`
+
+#### VectorOverlay
+
+Configure per-atom vector visualization (e.g. forces, velocities).
+
+```python
+megane.VectorOverlay(*, scale: float = 1.0)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `scale` | `float` | `1.0` | Vector arrow length multiplier |
+
+**Inputs:** `vector`
+**Outputs:** `vector`
+
+### Port Resolution
+
+Edges are auto-resolved: `add_edge(source, target)` automatically picks the correct port handles based on node types. For example:
+
+- `LoadStructure → Filter` connects `particle → in`
+- `Filter → Modify` connects `out → in`
+- `LoadStructure → AddBonds` connects `particle → particle`
+- `AddBonds → Viewport` connects `bond → bond`
+
+### Example: Basic Structure with Bonds
+
+```python
+import megane
+
+pipe = megane.Pipeline()
+s = pipe.add_node(megane.LoadStructure("protein.pdb"))
+bonds = pipe.add_node(megane.AddBonds(source="distance"))
+pipe.add_edge(s, bonds)
+
+viewer = megane.MolecularViewer()
+viewer.set_pipeline(pipe)
+viewer
+```
+
+### Example: Filter and Modify
+
+```python
+import megane
+
+pipe = megane.Pipeline()
+s = pipe.add_node(megane.LoadStructure("protein.pdb"))
+carbons = pipe.add_node(megane.Filter(query="element == 'C'"))
+big = pipe.add_node(megane.Modify(scale=1.5, opacity=0.8))
+bonds = pipe.add_node(megane.AddBonds(source="distance"))
+
+pipe.add_edge(s, carbons)
+pipe.add_edge(carbons, big)
+pipe.add_edge(s, bonds)
+
+viewer = megane.MolecularViewer()
+viewer.set_pipeline(pipe)
+viewer
+```
+
+### Example: Trajectory Playback
+
+```python
+import megane
+
+pipe = megane.Pipeline()
+s = pipe.add_node(megane.LoadStructure("protein.pdb"))
+t = pipe.add_node(megane.LoadTrajectory(xtc="trajectory.xtc"))
+bonds = pipe.add_node(megane.AddBonds(source="structure"))
+
+pipe.add_edge(s, t)
+pipe.add_edge(s, bonds)
+
+viewer = megane.MolecularViewer()
+viewer.set_pipeline(pipe)
+viewer.frame_index = 50  # jump to frame 50
+```
+
+### Example: Make Solvent Translucent
+
+```python
+import megane
+
+pipe = megane.Pipeline()
+s = pipe.add_node(megane.LoadStructure("protein.pdb"))
+
+# Filter water molecules and make them translucent
+water = pipe.add_node(megane.Filter(query='resname == "HOH"'))
+transparent = pipe.add_node(megane.Modify(scale=0.5, opacity=0.2))
+
+bonds = pipe.add_node(megane.AddBonds(source="distance"))
+
+pipe.add_edge(s, water)
+pipe.add_edge(water, transparent)
+pipe.add_edge(s, bonds)
+# Unconnected outputs (particle, cell from LoadStructure) auto-connect to Viewport
+
+viewer = megane.MolecularViewer()
+viewer.set_pipeline(pipe)
+viewer
+```
+
+### Example: TiO₆ Coordination Polyhedra
+
+```python
+import megane
+
+pipe = megane.Pipeline()
+s = pipe.add_node(megane.LoadStructure("SrTiO3_supercell.pdb"))
+bonds = pipe.add_node(megane.AddBonds(source="distance"))
+polyhedra = pipe.add_node(megane.AddPolyhedra(
+    center_elements=[22],     # Ti
+    ligand_elements=[8],      # O
+    max_distance=2.5,
+    opacity=0.5,
+    show_edges=True,
+))
+
+pipe.add_edge(s, bonds)
+pipe.add_edge(s, polyhedra)
+
+viewer = megane.MolecularViewer()
+viewer.set_pipeline(pipe)
+viewer
+```
+
+### Example: DAG Branching (Multiple Filters)
+
+```python
+import megane
+
+pipe = megane.Pipeline()
+s = pipe.add_node(megane.LoadStructure("protein.pdb"))
+
+# Two independent filters from the same source
+carbon = pipe.add_node(megane.Filter(query="element == 'C'"))
+nitrogen = pipe.add_node(megane.Filter(query="element == 'N'"))
+labels = pipe.add_node(megane.AddLabels(source="element"))
+bonds = pipe.add_node(megane.AddBonds(source="distance"))
+
+pipe.add_edge(s, carbon)
+pipe.add_edge(s, nitrogen)
+pipe.add_edge(s, labels)
+pipe.add_edge(s, bonds)
+
+viewer = megane.MolecularViewer()
+viewer.set_pipeline(pipe)
+viewer
+```
+
+### Example: ASE .traj Trajectory
+
+```python
+import megane
+
+pipe = megane.Pipeline()
+s = pipe.add_node(megane.LoadStructure("structure.pdb"))
+t = pipe.add_node(megane.LoadTrajectory(traj="simulation.traj"))
+
+pipe.add_edge(s, t)
+
+viewer = megane.MolecularViewer()
+viewer.set_pipeline(pipe)
+viewer
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ features:
   - title: "\U0001F30D Runs Everywhere"
     details: "Jupyter widget, CLI server, React component, VSCode extension. Rust parsers (PDB, GRO, XYZ, MOL, CIF, XTC, LAMMPS, .traj) shared between Python (PyO3) and browser (WASM): parse once, run anywhere."
   - title: "\U0001F9E9 Visual Pipeline Editor"
-    details: Build visualization workflows by wiring nodes — filter atoms, adjust styles, generate labels, render coordination polyhedra. No code required. Typed data flows through color-coded edges. An AI generator can build pipelines from natural language.
+    details: Build visualization workflows by wiring 11 node types — load data, filter atoms, adjust styles, generate labels, render coordination polyhedra, overlay vectors. No code required. 7 typed data channels flow through color-coded edges. An AI generator can build pipelines from natural language.
   - title: "\U0001F517 Embed & Integrate"
     details: Control the viewer from Plotly via ipywidgets events. Embed in MDX / Next.js docs. React to frame_change, selection_change, and measurement events. Use the framework-agnostic renderer from Vue, Svelte, or vanilla JS.
 ---
@@ -54,7 +54,7 @@ One codebase, every environment.
 | **Jupyter** | anywidget inline viewer | `pip install megane` |
 | **Browser** | `megane serve` local server | `pip install megane` |
 | **React** | `<MeganeViewer />` component | `npm install megane-viewer` |
-| **VSCode** | Custom editor for .pdb, .gro, .xyz | Extension |
+| **VSCode** | Custom editor for .pdb, .gro, .xyz, .mol, .sdf, .cif | Extension |
 
 The secret: PDB, GRO, XYZ, MOL, CIF, XTC, LAMMPS, and ASE .traj parsers are written in **Rust** and compiled to both **PyO3** (Python) and **WASM** (browser). Parse once, run anywhere.
 
@@ -75,9 +75,9 @@ The secret: PDB, GRO, XYZ, MOL, CIF, XTC, LAMMPS, and ASE .traj parsers are writ
 
 Wire nodes to build visualization workflows — no code required.
 
-**8 node types** across 5 categories: load data, add bonds, filter atoms by query, modify scale and opacity per-group, generate labels, render coordination polyhedra, and display in a 3D viewport.
+**11 node types** across 5 categories: load data (structure, trajectory, streaming, vector), process (filter, modify), overlay (bonds, labels, polyhedra, vectors), and display in a 3D viewport.
 
-**6 typed data channels** — particle, bond, cell, label, mesh, trajectory — flow through color-coded edges. Only matching types can connect.
+**7 typed data channels** — particle, bond, cell, label, mesh, trajectory, vector — flow through color-coded edges. Only matching types can connect.
 
 Pipelines serialize to JSON, so you can save, share, and version-control your visualization recipes.
 

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -42,7 +42,7 @@ class PipelineNode:
 class LoadStructure(PipelineNode):
     """Load a molecular structure from a file.
 
-    Supported formats: PDB, GRO, XYZ, MOL, LAMMPS data, CIF.
+    Supported formats: PDB, GRO, XYZ, MOL, LAMMPS data.
     """
 
     _node_type = "load_structure"


### PR DESCRIPTION
## Summary

- **Fix node/channel counts**: Updated "8 node types" → "11 node types" and "6 data channels" → "7 data channels" (adding Streaming, LoadVector, VectorOverlay nodes and vector data type) across README, docs/index.md, and pipeline guide
- **Fix deprecated API usage**: Replaced all `viewer.load()` examples with the current `Pipeline` + `set_pipeline()` API in README, getting-started, API reference, integrations, and jupyter docs
- **Fix technical inaccuracies**: Corrected Node.js version (18+ → 22+), TypeScript import path (`"megane"` → `"megane-viewer"`), Filter/Modify port descriptions, VSCode supported extensions, megane-core parser list, LoadStructure docstring (removed CIF from pipeline-supported formats)
- **Add Python Pipeline API reference**: Comprehensive section in pipeline.md documenting all 10 node classes with parameters, port specifications, and 7 usage examples (basic, filter/modify, trajectory, solvent transparency, polyhedra, DAG branching, ASE .traj)

## Test plan

- [ ] Verify all code examples in docs are syntactically correct
- [ ] Confirm node counts match actual codebase (11 nodes, 7 data types)
- [ ] Check that pipeline.md Python API matches `python/megane/pipeline.py` implementation
- [ ] Review docs build renders correctly

https://claude.ai/code/session_01Y247NiTZvUoXRErphFPdTD