### PR TITLE
Add integration tests for pip install and demo code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,31 @@ jobs:
       - name: Run notebook tests
         run: python -m pytest tests/python/test_notebooks.py -v
 
+  test-integration:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build:wasm
+      - run: npm run build:widget
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install package
+        run: pip install -e ".[dev]"
+      - name: Run integration tests
+        run: python -m pytest tests/python/test_serve_integration.py tests/python/test_demo_code.py -v
+
   build:
     name: Docker build
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-frontend install dev test test-widget test-e2e test-e2e-snapshot test-ts test-rust test-all coverage coverage-ts coverage-rust coverage-all clean preview preview-screenshot preview-video preview-clean
+.PHONY: build build-frontend install dev test test-widget test-e2e test-e2e-snapshot test-ts test-rust test-integration test-all coverage coverage-ts coverage-rust coverage-all clean preview preview-screenshot preview-video preview-clean
 
 # Build frontend assets (WASM + TypeScript)
 build-frontend:
@@ -49,8 +49,12 @@ test-notebooks:
 test-e2e-notebooks:
 	node tests/e2e/test_notebook_screenshots.mjs
 
-# Run all tests (Python + TypeScript + Rust + E2E + Notebooks)
-test-all: test test-ts test-rust test-e2e test-e2e-snapshot test-notebooks
+# Run integration tests (pip install smoke tests + demo code verification)
+test-integration:
+	python -m pytest tests/python/test_serve_integration.py tests/python/test_demo_code.py -v
+
+# Run all tests (Python + TypeScript + Rust + E2E + Notebooks + Integration)
+test-all: test test-ts test-rust test-e2e test-e2e-snapshot test-notebooks test-integration
 
 # Run TypeScript tests with coverage
 coverage-ts:

--- a/tests/python/test_demo_code.py
+++ b/tests/python/test_demo_code.py
@@ -1,0 +1,150 @@
+"""Tests that verify demo code from README and docs actually works.
+
+Each test corresponds to a documented Python usage pattern.  References to
+the source documentation are included in docstrings.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import megane
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+
+# ─── README / Getting Started: viewer.load() ────────────────────────
+
+
+def test_viewer_load_pdb():
+    """README.md / docs/getting-started.md: basic viewer.load('protein.pdb')."""
+    viewer = megane.MolecularViewer()
+    with pytest.warns(DeprecationWarning):
+        viewer.load(str(FIXTURES / "1crn.pdb"))
+    assert viewer._structure is not None
+    assert viewer._structure.n_atoms == 327
+    assert len(viewer._snapshot_data) > 0
+
+
+def test_viewer_load_with_xtc():
+    """README.md: viewer.load(pdb, xtc=xtc) loads trajectory."""
+    viewer = megane.MolecularViewer()
+    with pytest.warns(DeprecationWarning):
+        viewer.load(
+            str(FIXTURES / "caffeine_water.pdb"),
+            xtc=str(FIXTURES / "caffeine_water_vibration.xtc"),
+        )
+    assert viewer.total_frames > 0
+    assert viewer._trajectory is not None
+
+
+def test_frame_index_assignment():
+    """README.md: viewer.frame_index = 50 updates frame data."""
+    viewer = megane.MolecularViewer()
+    with pytest.warns(DeprecationWarning):
+        viewer.load(
+            str(FIXTURES / "caffeine_water.pdb"),
+            xtc=str(FIXTURES / "caffeine_water_vibration.xtc"),
+        )
+    viewer.frame_index = 5
+    assert len(viewer._frame_data) > 0
+
+
+# ─── Integrations Guide: selected_atoms & events ────────────────────
+
+
+def test_selected_atoms_trait():
+    """docs/guide/integrations.md: viewer.selected_atoms = [0, 1]."""
+    viewer = megane.MolecularViewer()
+    with pytest.warns(DeprecationWarning):
+        viewer.load(str(FIXTURES / "1crn.pdb"))
+    viewer.selected_atoms = [0, 1]
+    assert viewer.selected_atoms == [0, 1]
+
+
+def test_event_callback_frame_change():
+    """docs/guide/integrations.md: @viewer.on_event('frame_change')."""
+    viewer = megane.MolecularViewer()
+    with pytest.warns(DeprecationWarning):
+        viewer.load(
+            str(FIXTURES / "caffeine_water.pdb"),
+            xtc=str(FIXTURES / "caffeine_water_vibration.xtc"),
+        )
+    received = []
+
+    @viewer.on_event("frame_change")
+    def on_frame(data):
+        received.append(data)
+
+    viewer.frame_index = 3
+    assert len(received) == 1
+    assert received[0]["frame_index"] == 3
+
+
+def test_event_callback_off_event():
+    """docs/guide/integrations.md: viewer.off_event() removes callbacks."""
+    viewer = megane.MolecularViewer()
+    with pytest.warns(DeprecationWarning):
+        viewer.load(
+            str(FIXTURES / "caffeine_water.pdb"),
+            xtc=str(FIXTURES / "caffeine_water_vibration.xtc"),
+        )
+    received = []
+
+    @viewer.on_event("frame_change")
+    def on_frame(data):
+        received.append(data)
+
+    viewer.frame_index = 1
+    assert len(received) == 1
+
+    viewer.off_event("frame_change", on_frame)
+    viewer.frame_index = 2
+    assert len(received) == 1  # no new callback
+
+
+def test_event_callback_selection_change():
+    """docs/guide/integrations.md: selection_change event fires on selected_atoms change."""
+    viewer = megane.MolecularViewer()
+    with pytest.warns(DeprecationWarning):
+        viewer.load(str(FIXTURES / "1crn.pdb"))
+    received = []
+
+    @viewer.on_event("selection_change")
+    def on_sel(data):
+        received.append(data)
+
+    viewer.selected_atoms = [10, 20, 30, 40]
+    assert len(received) == 1
+    assert received[0]["atoms"] == [10, 20, 30, 40]
+
+
+# ─── Pipeline API ───────────────────────────────────────────────────
+
+
+def test_pipeline_load_structure():
+    """Pipeline API: LoadStructure + set_pipeline() enables pipeline mode."""
+    pipe = megane.Pipeline()
+    s = pipe.add_node(megane.LoadStructure(str(FIXTURES / "1crn.pdb")))
+
+    viewer = megane.MolecularViewer()
+    viewer.set_pipeline(pipe)
+
+    assert viewer._pipeline_enabled is True
+    assert len(viewer._node_snapshots_data) > 0
+
+
+def test_pipeline_with_trajectory():
+    """Pipeline API: LoadStructure + LoadTrajectory provides frames."""
+    pipe = megane.Pipeline()
+    s = pipe.add_node(megane.LoadStructure(str(FIXTURES / "caffeine_water.pdb")))
+    t = pipe.add_node(megane.LoadTrajectory(
+        xtc=str(FIXTURES / "caffeine_water_vibration.xtc"),
+    ))
+    pipe.add_edge(s, t)
+
+    viewer = megane.MolecularViewer()
+    viewer.set_pipeline(pipe)
+
+    assert viewer.total_frames > 0
+    assert viewer._pipeline_enabled is True

--- a/tests/python/test_serve_integration.py
+++ b/tests/python/test_serve_integration.py
@@ -1,0 +1,133 @@
+"""Integration tests for megane serve CLI command.
+
+Starts the server as a subprocess and verifies HTTP endpoints respond correctly.
+These tests validate post-pip-install functionality.
+"""
+
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+
+def _free_port() -> int:
+    """Find a free TCP port."""
+    with socket.socket() as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_health(port: int, timeout: float = 6.0) -> None:
+    """Poll GET /health until the server is ready."""
+    url = f"http://localhost:{port}/health"
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            r = httpx.get(url, timeout=1.0)
+            if r.status_code == 200:
+                return
+        except httpx.ConnectError:
+            pass
+        time.sleep(0.3)
+    raise RuntimeError(f"Server did not start on port {port} within {timeout}s")
+
+
+@pytest.fixture
+def serve(request):
+    """Factory fixture that starts megane serve and yields (process, port).
+
+    Usage in tests::
+
+        proc, port = serve("1crn.pdb")
+        proc, port = serve()  # no PDB
+        proc, port = serve("caffeine_water.pdb", "--xtc", "caffeine_water_vibration.xtc")
+    """
+    processes: list[subprocess.Popen] = []
+
+    def _start(*extra_args: str, entry_point: str | None = None) -> tuple[subprocess.Popen, int]:
+        port = _free_port()
+        if entry_point is not None:
+            cmd = [entry_point, "serve"]
+        else:
+            cmd = [sys.executable, "-m", "megane.cli", "serve"]
+        cmd.extend(extra_args)
+        cmd.extend(["--no-browser", "--port", str(port)])
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        _wait_for_health(port)
+        processes.append(proc)
+        return proc, port
+
+    yield _start
+
+    for proc in processes:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+
+# ─── Tests ───────────────────────────────────────────────────────────
+
+
+def test_serve_starts_and_responds(serve):
+    """megane serve with a PDB file starts and responds to /health."""
+    _, port = serve(str(FIXTURES / "1crn.pdb"))
+    r = httpx.get(f"http://localhost:{port}/health")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+def test_serve_entry_point(serve):
+    """The 'megane' console script entry point works after pip install."""
+    megane_bin = shutil.which("megane")
+    if megane_bin is None:
+        # Check venv bin directory (entry point may not be on PATH)
+        venv_bin = Path(sys.executable).parent / "megane"
+        if venv_bin.exists():
+            megane_bin = str(venv_bin)
+        else:
+            pytest.skip("megane entry point not found")
+    _, port = serve(str(FIXTURES / "1crn.pdb"), entry_point=megane_bin)
+    r = httpx.get(f"http://localhost:{port}/health")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+def test_serve_no_pdb_waits_for_upload(serve):
+    """megane serve without a PDB file starts and waits for upload."""
+    _, port = serve()
+    r = httpx.get(f"http://localhost:{port}/health")
+    assert r.status_code == 200
+
+
+def test_serve_with_xtc(serve):
+    """megane serve with PDB + XTC trajectory starts successfully."""
+    _, port = serve(
+        str(FIXTURES / "caffeine_water.pdb"),
+        "--xtc", str(FIXTURES / "caffeine_water_vibration.xtc"),
+    )
+    r = httpx.get(f"http://localhost:{port}/health")
+    assert r.status_code == 200
+
+
+def test_serve_upload_while_running(serve):
+    """POST /api/upload loads a structure on a running server."""
+    _, port = serve()
+    pdb_content = (FIXTURES / "1crn.pdb").read_bytes()
+    r = httpx.post(
+        f"http://localhost:{port}/api/upload",
+        files={"pdb": ("1crn.pdb", pdb_content, "chemical/x-pdb")},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["nAtoms"] == 327
+    assert data["nBonds"] > 0


### PR DESCRIPTION
## Summary
- Add `test_serve_integration.py`: starts `megane serve` as a subprocess and verifies health endpoint, entry point CLI, XTC trajectory loading, and file upload API
- Add `test_demo_code.py`: verifies Python demo code patterns from README/docs work with real fixture files (viewer.load, events, pipeline API)
- Add `test-integration` CI job and Makefile target

## Test plan
- [x] All 14 new tests pass locally (`python -m pytest tests/python/test_serve_integration.py tests/python/test_demo_code.py -v`)
- [ ] CI `test-integration` job passes on this PR
- [ ] Existing tests remain unaffected

https://claude.ai/code/session_018ivW4qAJWBCoaankFJvDJe