### PR TITLE
Add ruff linter and ty type checker for Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,16 @@ permissions:
   contents: read
 
 jobs:
+  lint-python:
+    name: Python lint & type check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uvx ruff check python/
+      - run: uvx ruff format --check python/
+      - run: uvx ty check python/
+
   test-rust:
     name: Rust tests
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-frontend install dev test test-widget test-e2e test-e2e-snapshot test-ts test-rust test-integration test-all coverage coverage-ts coverage-rust coverage-all clean preview preview-screenshot preview-video preview-clean
+.PHONY: build build-frontend install dev test test-widget test-e2e test-e2e-snapshot test-ts test-rust test-integration test-all coverage coverage-ts coverage-rust coverage-all clean preview preview-screenshot preview-video preview-clean lint lint-python lint-fix
 
 # Build frontend assets (WASM + TypeScript)
 build-frontend:
@@ -91,6 +91,20 @@ preview-video:
 # Dev preview: clean previous captures
 preview-clean:
 	rm -rf dev-preview/
+
+# Lint Python code (ruff + ty)
+lint-python:
+	ruff check python/
+	ruff format --check python/
+	ty check python/
+
+# Lint all languages
+lint: lint-python
+
+# Auto-fix Python lint issues
+lint-fix:
+	ruff check --fix python/
+	ruff format python/
 
 # Clean build artifacts
 clean:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,25 @@ module-name = "megane.megane_parser"
 features = ["pyo3/extension-module"]
 include = ["python/megane/static/**", "LICENSE"]
 
+[tool.ruff]
+target-version = "py310"
+line-length = 120
+src = ["python"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["megane"]
+
+[tool.ty.environment]
+python-version = "3.10"
+
+[tool.ty.rules]
+unresolved-import = "ignore"
+unresolved-attribute = "ignore"
+
 [tool.pytest.ini_options]
 testpaths = ["tests/python"]
 addopts = "--cov=megane --cov-report=term-missing --cov-report=html:coverage/python --cov-report=json:coverage/python/coverage.json"

--- a/python/megane/cli.py
+++ b/python/megane/cli.py
@@ -23,9 +23,7 @@ def main() -> None:
     parser.add_argument("--xtc", help="Path to XTC trajectory file")
     parser.add_argument("--traj", help="Path to ASE .traj trajectory file")
     parser.add_argument("--port", type=int, default=8765, help="Server port")
-    parser.add_argument(
-        "--no-browser", action="store_true", help="Don't open browser"
-    )
+    parser.add_argument("--no-browser", action="store_true", help="Don't open browser")
     parser.add_argument(
         "--dev",
         action="store_true",
@@ -44,9 +42,7 @@ def main() -> None:
         elif args.pdb:
             configure(args.pdb, args.xtc)
         else:
-            logging.info(
-                "No PDB file specified. Waiting for file upload from browser..."
-            )
+            logging.info("No PDB file specified. Waiting for file upload from browser...")
 
         if not args.no_browser and not args.dev:
             url = f"http://localhost:{args.port}"

--- a/python/megane/parsers/lammpstrj.py
+++ b/python/megane/parsers/lammpstrj.py
@@ -6,8 +6,6 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from megane.parsers.pdb import cell_params_to_matrix
-
 
 @dataclass
 class InMemoryTrajectory:
@@ -90,11 +88,14 @@ def load_lammpstrj(dump_path: str) -> InMemoryTrajectory:
                 lx = float(hi[0] - lo[0])
                 ly = float(hi[1] - lo[1])
                 lz = float(hi[2] - lo[2])
-                box_matrix = np.array([
-                    [lx, 0.0, 0.0],
-                    [xy, ly, 0.0],
-                    [xz, yz, lz],
-                ], dtype=np.float32)
+                box_matrix = np.array(
+                    [
+                        [lx, 0.0, 0.0],
+                        [xy, ly, 0.0],
+                        [xz, yz, lz],
+                    ],
+                    dtype=np.float32,
+                )
             else:
                 lx = float(hi[0] - lo[0])
                 ly = float(hi[1] - lo[1])
@@ -145,9 +146,7 @@ def load_lammpstrj(dump_path: str) -> InMemoryTrajectory:
 
         # Sort by id
         atoms.sort(key=lambda a: a[0])
-        positions = np.array(
-            [[x, y, z] for _, x, y, z in atoms], dtype=np.float32
-        )
+        positions = np.array([[x, y, z] for _, x, y, z in atoms], dtype=np.float32)
         frames.append(positions)
         i += 1
 

--- a/python/megane/parsers/pdb.py
+++ b/python/megane/parsers/pdb.py
@@ -28,8 +28,12 @@ class Structure:
 
 
 def cell_params_to_matrix(
-    a: float, b: float, c: float,
-    alpha: float, beta: float, gamma: float,
+    a: float,
+    b: float,
+    c: float,
+    alpha: float,
+    beta: float,
+    gamma: float,
 ) -> np.ndarray:
     """Convert crystallographic cell parameters to a 3x3 matrix of cell vectors.
 

--- a/python/megane/parsers/xtc.py
+++ b/python/megane/parsers/xtc.py
@@ -27,7 +27,7 @@ class Trajectory:
         """
         import MDAnalysis as mda
 
-        universe: mda.Universe = self._universe  # type: ignore
+        universe: mda.Universe = self._universe
         universe.trajectory[index]
         return universe.atoms.positions.astype(np.float32)
 
@@ -39,8 +39,7 @@ def _box_from_dimensions(dimensions: np.ndarray | None) -> np.ndarray:
     a, b, c, alpha, beta, gamma = dimensions
     if a == 0 and b == 0 and c == 0:
         return np.zeros((3, 3), dtype=np.float32)
-    return cell_params_to_matrix(float(a), float(b), float(c),
-                                 float(alpha), float(beta), float(gamma))
+    return cell_params_to_matrix(float(a), float(b), float(c), float(alpha), float(beta), float(gamma))
 
 
 def load_trajectory(pdb_path: str, xtc_path: str) -> Trajectory:

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 from typing import Literal
 
-
 # ─── Node Classes ───────────────────────────────────────────────────
 
 
@@ -237,9 +236,7 @@ def _resolve_ports(
     target: PipelineNode,
 ) -> tuple[str, str]:
     """Resolve source and target port handles from node types."""
-    target_handle = _TARGET_PORT_MAP.get(
-        target._node_type, ("particle", "particle")
-    )[1]
+    target_handle = _TARGET_PORT_MAP.get(target._node_type, ("particle", "particle"))[1]
 
     # Source handle: use the source node's known output, or infer
     # from what the target expects.
@@ -247,9 +244,7 @@ def _resolve_ports(
     if source_handle is None:
         # LoadStructure or other multi-output node: use what the
         # target expects as its input type.
-        source_handle = _TARGET_PORT_MAP.get(
-            target._node_type, ("particle", "particle")
-        )[0]
+        source_handle = _TARGET_PORT_MAP.get(target._node_type, ("particle", "particle"))[0]
 
     return source_handle, target_handle
 
@@ -284,10 +279,7 @@ def _load_structure_file(path: str):
 
     parse_fn = parsers.get(ext)
     if parse_fn is None:
-        raise ValueError(
-            f"Unsupported structure format: {ext!r}.  "
-            f"Supported: {', '.join(sorted(parsers))}"
-        )
+        raise ValueError(f"Unsupported structure format: {ext!r}.  Supported: {', '.join(sorted(parsers))}")
 
     result = parse_fn(text)
     return Structure(
@@ -345,22 +337,20 @@ class Pipeline:
         Port handles are auto-resolved from the node types.
         """
         if source._id is None or target._id is None:
-            raise ValueError(
-                "Both nodes must be added to the pipeline before connecting."
-            )
+            raise ValueError("Both nodes must be added to the pipeline before connecting.")
         source_handle, target_handle = _resolve_ports(source, target)
-        self._edges.append({
-            "source": source._id,
-            "target": target._id,
-            "sourceHandle": source_handle,
-            "targetHandle": target_handle,
-        })
+        self._edges.append(
+            {
+                "source": source._id,
+                "target": target._id,
+                "sourceHandle": source_handle,
+                "targetHandle": target_handle,
+            }
+        )
 
         # Trigger lazy trajectory loading when connecting
         # LoadStructure → LoadTrajectory.
-        if isinstance(target, LoadTrajectory) and isinstance(
-            source, LoadStructure
-        ):
+        if isinstance(target, LoadTrajectory) and isinstance(source, LoadStructure):
             self._load_trajectory_data(target, source)
 
     # ── Serialization ───────────────────────────────────────
@@ -393,6 +383,7 @@ class Pipeline:
 
     def _serialize_node(self, node: PipelineNode) -> dict:
         """Convert a node instance to the TS SerializedPipeline node dict."""
+        assert node._id is not None
         base: dict = {
             "id": node._id,
             "type": node._node_type,
@@ -404,6 +395,7 @@ class Pipeline:
             has_cell = False
             if structure is not None:
                 import numpy as np
+
                 has_cell = bool(np.any(structure.box != 0))
             base["fileName"] = node.path
             base["hasTrajectory"] = False
@@ -440,12 +432,12 @@ class Pipeline:
         """Load structure file and store binary snapshot data."""
         from megane.protocol import encode_snapshot
 
+        assert node._id is not None
         structure = _load_structure_file(node.path)
         self._structures[node._id] = structure
         self._node_data[node._id] = encode_snapshot(structure)
 
         # Re-serialize to update hasCell
-        import numpy as np
         for i, (n, _) in enumerate(self._nodes):
             if n._id == node._id:
                 self._nodes[i] = (n, self._serialize_node(n))
@@ -457,12 +449,11 @@ class Pipeline:
         source: LoadStructure,
     ) -> None:
         """Load trajectory object for lazy frame loading."""
+        assert node._id is not None
         if node.xtc is not None:
             from megane.parsers.xtc import load_trajectory
 
-            self._trajectories[node._id] = load_trajectory(
-                source.path, node.xtc
-            )
+            self._trajectories[node._id] = load_trajectory(source.path, node.xtc)
 
             # Update parent LoadStructure's hasTrajectory flag
             for i, (n, config) in enumerate(self._nodes):
@@ -515,11 +506,13 @@ class Pipeline:
                 if (node._id, handle) not in used_outputs:
                     viewport_handle = handle_to_viewport.get(handle)
                     if viewport_handle:
-                        viewport_edges.append({
-                            "source": node._id,
-                            "target": viewport_id,
-                            "sourceHandle": handle,
-                            "targetHandle": viewport_handle,
-                        })
+                        viewport_edges.append(
+                            {
+                                "source": node._id,
+                                "target": viewport_id,
+                                "sourceHandle": handle,
+                                "targetHandle": viewport_handle,
+                            }
+                        )
 
         return viewport_edges

--- a/python/megane/protocol.py
+++ b/python/megane/protocol.py
@@ -88,15 +88,7 @@ def encode_snapshot(structure: StructureLike) -> bytes:
     # Snapshot header: n_atoms(4) + n_bonds(4) = 8 bytes
     snapshot_header = struct.pack("<II", n_atoms, n_bonds)
 
-    return (
-        header
-        + snapshot_header
-        + pos_bytes
-        + elem_bytes
-        + bond_bytes
-        + bond_order_bytes
-        + box_bytes
-    )
+    return header + snapshot_header + pos_bytes + elem_bytes + bond_bytes + bond_order_bytes + box_bytes
 
 
 def encode_frame(frame_id: int, positions: np.ndarray) -> bytes:

--- a/python/megane/server.py
+++ b/python/megane/server.py
@@ -161,9 +161,7 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
         # Handle client commands
         stream_task: asyncio.Task | None = None
 
-        async def _run_stream(
-            traj, start: int, end: int, stride: int, fps: int
-        ) -> None:
+        async def _run_stream(traj, start: int, end: int, stride: int, fps: int) -> None:
             """Stream frames at the given FPS. Runs as a cancellable task."""
             delay = 1.0 / fps
             for i in range(start, end, stride):
@@ -181,9 +179,7 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
                 frame_idx = msg["frame"]
                 if 0 <= frame_idx < traj.n_frames:
                     positions = traj.get_frame(frame_idx)
-                    await websocket.send_bytes(
-                        encode_frame(frame_idx, positions)
-                    )
+                    await websocket.send_bytes(encode_frame(frame_idx, positions))
 
             elif cmd == "stream" and traj is not None:
                 # Cancel any existing stream
@@ -193,9 +189,7 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
                 end = msg.get("end", traj.n_frames)
                 stride = msg.get("stride", 1)
                 fps = msg.get("fps", 30)
-                stream_task = asyncio.create_task(
-                    _run_stream(traj, start, end, stride, fps)
-                )
+                stream_task = asyncio.create_task(_run_stream(traj, start, end, stride, fps))
 
             elif cmd == "stop":
                 if stream_task and not stream_task.done():
@@ -210,9 +204,7 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
 # Try to serve static files for the built web app
 _static_dir = Path(__file__).parent / "static" / "app"
 if _static_dir.exists():
-    app.mount(
-        "/", StaticFiles(directory=str(_static_dir), html=True), name="app"
-    )
+    app.mount("/", StaticFiles(directory=str(_static_dir), html=True), name="app")
 else:
     logger.warning(
         "Static app directory not found at %s. "

--- a/python/megane/widget.py
+++ b/python/megane/widget.py
@@ -103,8 +103,7 @@ class MolecularViewer(anywidget.AnyWidget):
                 are read from the .traj file.
         """
         warnings.warn(
-            "MolecularViewer.load() is deprecated. "
-            "Use set_pipeline() with a Pipeline instead.",
+            "MolecularViewer.load() is deprecated. Use set_pipeline() with a Pipeline instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -147,9 +146,12 @@ class MolecularViewer(anywidget.AnyWidget):
                     self._frame_data = encode_frame(idx, positions)
                     break
 
-        self._fire_event("frame_change", {
-            "frame_index": idx,
-        })
+        self._fire_event(
+            "frame_change",
+            {
+                "frame_index": idx,
+            },
+        )
 
     @traitlets.observe("_measurement_json")
     def _on_measurement_change(self, change: dict) -> None:
@@ -164,9 +166,12 @@ class MolecularViewer(anywidget.AnyWidget):
     @traitlets.observe("selected_atoms")
     def _on_selected_atoms_change(self, change: dict) -> None:
         """Fire selection_change event."""
-        self._fire_event("selection_change", {
-            "atoms": list(change["new"]),
-        })
+        self._fire_event(
+            "selection_change",
+            {
+                "atoms": list(change["new"]),
+            },
+        )
 
     @property
     def measurement(self) -> dict | None:
@@ -216,6 +221,7 @@ class MolecularViewer(anywidget.AnyWidget):
         def decorator(fn: Callable) -> Callable:
             self._event_handlers[event_name].append(fn)
             return fn
+
         return decorator
 
     def off_event(self, event_name: str, callback: Callable | None = None):
@@ -230,9 +236,7 @@ class MolecularViewer(anywidget.AnyWidget):
             self._event_handlers.pop(event_name, None)
         else:
             handlers = self._event_handlers.get(event_name, [])
-            self._event_handlers[event_name] = [
-                h for h in handlers if h is not callback
-            ]
+            self._event_handlers[event_name] = [h for h in handlers if h is not callback]
 
     def set_pipeline(self, pipeline: Pipeline | None) -> None:
         """Apply a pipeline to this viewer.


### PR DESCRIPTION
- Configure ruff (lint + format) and ty in pyproject.toml
- Add lint-python and lint-fix targets to Makefile
- Add lint-python CI job using uvx for zero-install enforcement
- Fix all existing lint issues (unused imports, import ordering, formatting)
- Fix ty type errors (assert non-None _id before dict operations)
- Remove stale type: ignore comment in xtc.py

https://claude.ai/code/session_01Nivg6ffphVVSqB2wgPeaxx