### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,14 +69,14 @@ dependencies = [
 
 [[package]]
 name = "megane-core"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "megane-python"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "megane-core",
  "numpy",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "megane-wasm"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "js-sys",
  "megane-core",

--- a/crates/megane-core/Cargo.toml
+++ b/crates/megane-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megane-core"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 description = "Core molecular structure parsers (PDB, GRO, XYZ, MOL, CIF, LAMMPS, XTC, .traj)"
 authors = ["hodakamori"]

--- a/crates/megane-python/Cargo.toml
+++ b/crates/megane-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megane-python"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 description = "PyO3 Python bindings for megane molecular parsers"
 authors = ["hodakamori"]

--- a/crates/megane-wasm/Cargo.toml
+++ b/crates/megane-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megane-wasm"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 description = "WASM bindings for megane molecular viewer"
 authors = ["hodakamori"]

--- a/docs/scripts/prepare-notebooks.py
+++ b/docs/scripts/prepare-notebooks.py
@@ -43,7 +43,7 @@ def inject_demo_outputs(nb: nbformat.NotebookNode) -> None:
         cell_id = cell.get("id", "")
 
         if cell_id == "cell-1" or 'print(f"megane v' in source:
-            cell.outputs = [make_stream("megane v0.3.2\n")]
+            cell.outputs = [make_stream("megane v0.4.0\n")]
 
         elif cell_id == "cell-3" or (
             source.strip().endswith("viewer")
@@ -89,7 +89,7 @@ def inject_external_events_outputs(nb: nbformat.NotebookNode) -> None:
         cell.outputs = []
 
         if 'print(f"megane v' in source:
-            cell.outputs = [make_stream("megane v0.3.2\n")]
+            cell.outputs = [make_stream("megane v0.4.0\n")]
 
         elif "viewer.load" in source and "xtc=" in source and "print" in source:
             cell.outputs = [make_stream("Loaded trajectory: 100 frames\n")]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "megane-viewer",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "megane-viewer",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "megane-viewer",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "type": "module",
   "description": "A fast, beautiful molecular viewer – anywidget-compatible",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "megane"
-version = "0.3.2"
+version = "0.4.0"
 description = "A fast, beautiful molecular viewer"
 requires-python = ">=3.10"
 license = "MIT"
@@ -85,7 +85,7 @@ show_missing = true
 skip_empty = true
 
 [tool.bumpversion]
-current_version = "0.3.2"
+current_version = "0.4.0"
 commit = false
 tag = false
 allow_dirty = true

--- a/python/megane/__init__.py
+++ b/python/megane/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "load_traj",
     "load_trajectory",
 ]
-__version__ = "0.3.2"
+__version__ = "0.4.0"


### PR DESCRIPTION
## Summary
- Bump version from 0.3.2 to 0.4.0 across all project files
- Updated: pyproject.toml, package.json, Cargo.toml (all 3 crates), python/megane/__init__.py, docs/scripts/prepare-notebooks.py, and lock files
- Aligns version strings with the existing CHANGELOG 0.4.0 entry

## Test plan
- [x] `cargo check` passes
- [x] Verified no stale 0.3.2 references remain in target files

https://claude.ai/code/session_01AnDoe9PDbQ4MW3NfugzUFH