### PR TITLE
feat: add dry-run support to release workflows

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -47,9 +47,21 @@ jobs:
       - name: Build widget for npm
         run: npm run build:lib
 
-      - name: Verify package contents (dry run)
+      - name: Check version not already published
         if: inputs.dry_run
-        run: npm pack --dry-run
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "Checking if ${PKG_NAME}@${PKG_VERSION} already exists on npm..."
+          if npm view "${PKG_NAME}@${PKG_VERSION}" version 2>/dev/null; then
+            echo "::error::Version ${PKG_VERSION} already exists on npm"
+            exit 1
+          fi
+          echo "Version ${PKG_VERSION} is available"
+
+      - name: Verify publish (dry run)
+        if: inputs.dry_run
+        run: npm publish --dry-run --access public
 
       - name: Publish to npm
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,6 +4,18 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (build only, skip publish)"
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      dry_run:
+        description: "Dry run (build only, skip publish)"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -35,7 +47,12 @@ jobs:
       - name: Build widget for npm
         run: npm run build:lib
 
+      - name: Verify package contents (dry run)
+        if: inputs.dry_run
+        run: npm pack --dry-run
+
       - name: Publish to npm
+        if: ${{ !inputs.dry_run }}
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -4,6 +4,18 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (build only, skip publish)"
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      dry_run:
+        description: "Dry run (build only, skip publish)"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -90,6 +102,7 @@ jobs:
 
   publish:
     name: Publish to PyPI
+    if: ${{ !inputs.dry_run }}
     needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest
     environment: pypi
@@ -108,3 +121,23 @@ jobs:
           path: dist/
 
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  dry-run-summary:
+    name: Dry run summary
+    if: ${{ inputs.dry_run }}
+    needs: [build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheel-*
+          path: dist/
+          merge-multiple: true
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist/
+
+      - name: List built artifacts
+        run: ls -lh dist/

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -128,6 +128,12 @@ jobs:
     needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
       - uses: actions/download-artifact@v4
         with:
           pattern: wheel-*
@@ -141,3 +147,23 @@ jobs:
 
       - name: List built artifacts
         run: ls -lh dist/
+
+      - name: Validate package metadata
+        run: |
+          pip install twine
+          twine check dist/*
+
+      - name: Check version not already published
+        run: |
+          PKG_VERSION=$(python -c "
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              print(tomllib.load(f)['project']['version'])
+          ")
+          echo "Checking if megane==${PKG_VERSION} already exists on PyPI..."
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/megane/${PKG_VERSION}/json")
+          if [ "$STATUS" = "200" ]; then
+            echo "::error::Version ${PKG_VERSION} already exists on PyPI"
+            exit 1
+          fi
+          echo "Version ${PKG_VERSION} is available"

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -66,7 +66,40 @@ jobs:
 
       - name: Verify VSIX package (dry run)
         if: inputs.dry_run
-        run: ls -lh vscode-megane/*.vsix
+        run: |
+          ls -lh vscode-megane/*.vsix
+          cd vscode-megane
+          npx vsce ls
+
+      - name: Check version not already published
+        if: inputs.dry_run
+        run: |
+          PKG_VERSION=$(node -p "require('./vscode-megane/package.json').version")
+          echo "Checking if hodakamori.vscode-megane@${PKG_VERSION} already exists on Marketplace..."
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X POST "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery" \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json;api-version=6.0-preview.1" \
+            -d "{\"filters\":[{\"criteria\":[{\"filterType\":7,\"value\":\"hodakamori.vscode-megane\"}]}],\"flags\":0}")
+          LATEST=$(curl -s \
+            -X POST "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery" \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json;api-version=6.0-preview.1" \
+            -d "{\"filters\":[{\"criteria\":[{\"filterType\":7,\"value\":\"hodakamori.vscode-megane\"}]}],\"flags\":1}" \
+            | python3 -c "
+          import sys, json
+          data = json.load(sys.stdin)
+          exts = data.get('results', [{}])[0].get('extensions', [])
+          if exts:
+              versions = exts[0].get('versions', [])
+              if versions:
+                  print(versions[0].get('version', ''))
+          " 2>/dev/null || echo "")
+          if [ "$LATEST" = "$PKG_VERSION" ]; then
+            echo "::error::Version ${PKG_VERSION} already exists on VS Code Marketplace"
+            exit 1
+          fi
+          echo "Version ${PKG_VERSION} is available (latest published: ${LATEST:-none})"
 
       - name: Publish to VS Code Marketplace
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -4,6 +4,18 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (build only, skip publish)"
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      dry_run:
+        description: "Dry run (build only, skip publish)"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -37,6 +49,7 @@ jobs:
         run: cd vscode-megane && npm ci
 
       - name: Set version from tag
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
           cd vscode-megane
@@ -51,7 +64,12 @@ jobs:
       - name: Package VSIX
         run: cd vscode-megane && npx vsce package
 
+      - name: Verify VSIX package (dry run)
+        if: inputs.dry_run
+        run: ls -lh vscode-megane/*.vsix
+
       - name: Publish to VS Code Marketplace
+        if: ${{ !inputs.dry_run }}
         run: cd vscode-megane && npx vsce publish
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,49 @@
+name: Release Dry Run
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  dry-run-npm:
+    name: "Dry run: npm"
+    uses: ./.github/workflows/publish-npm.yml
+    with:
+      dry_run: true
+
+  dry-run-pypi:
+    name: "Dry run: PyPI"
+    uses: ./.github/workflows/publish-pypi.yml
+    with:
+      dry_run: true
+
+  dry-run-vscode:
+    name: "Dry run: VS Code Marketplace"
+    uses: ./.github/workflows/publish-vscode.yml
+    with:
+      dry_run: true
+
+  summary:
+    name: Dry run summary
+    needs: [dry-run-npm, dry-run-pypi, dry-run-vscode]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check results
+        run: |
+          echo "## Release Dry Run Results"
+          echo ""
+          echo "- npm:    ${{ needs.dry-run-npm.result }}"
+          echo "- PyPI:   ${{ needs.dry-run-pypi.result }}"
+          echo "- VSCode: ${{ needs.dry-run-vscode.result }}"
+          echo ""
+          if [ "${{ needs.dry-run-npm.result }}" != "success" ] || \
+             [ "${{ needs.dry-run-pypi.result }}" != "success" ] || \
+             [ "${{ needs.dry-run-vscode.result }}" != "success" ]; then
+            echo "::error::One or more dry runs failed. Do not proceed with release."
+            exit 1
+          fi
+          echo "All dry runs passed. Safe to release."


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` and `workflow_call` triggers with `dry_run` input to all three publish workflows (npm, PyPI, VS Code Marketplace)
- In dry-run mode, full builds run but actual publish steps are skipped
- Add unified `release-dry-run.yml` workflow that triggers all three in parallel, reporting pass/fail for each

## Motivation

Previously, pushing a `v*` tag immediately triggered publishing to all three registries. If one failed, versions could get out of sync. Now you can:

1. **Run individually**: Go to Actions > "Publish to npm/PyPI/VS Code" > Run workflow (dry_run defaults to `true`)
2. **Run all at once**: Go to Actions > "Release Dry Run" > Run workflow — validates the entire pipeline before tagging

## Test plan

- [ ] Trigger "Release Dry Run" workflow manually and verify all three sub-workflows complete successfully
- [ ] Verify that tag-triggered releases still work normally (dry_run is false by default for tag pushes)

https://claude.ai/code/session_01Pk33mUVahtPEU63w7SEoW9