### PR TITLE
fix: skip environment protection rules for publish dry runs

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -25,7 +25,7 @@ jobs:
   publish:
     name: Build and publish to npm
     runs-on: ubuntu-latest
-    environment: npm
+    environment: ${{ (!inputs.dry_run) && 'npm' || '' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -24,7 +24,7 @@ jobs:
   publish:
     name: Build and publish VS Code extension
     runs-on: ubuntu-latest
-    environment: vscode
+    environment: ${{ (!inputs.dry_run) && 'vscode' || '' }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- `publish-npm.yml` and `publish-vscode.yml` had unconditional `environment:` settings (`npm` / `vscode`), causing dry run jobs triggered by `release-dry-run.yml` to get stuck waiting for environment approval — even though dry runs don't need any secrets
- Make the environment conditional: only apply protection rules when actually publishing (`!inputs.dry_run`), skip them for dry runs
- `publish-pypi.yml` already handled this correctly via separate jobs

## Test plan

- [ ] Trigger `release-dry-run.yml` via workflow_dispatch and verify all three dry run jobs (npm, PyPI, VS Code) complete without waiting for environment approval
- [ ] Verify tag push (`v*`) still correctly applies the environment protection rules for actual publishing

https://claude.ai/code/session_01R58uqrq28nrHw7y7hSTAuU