### PR TITLE
fix: derive vscode extension version from root package.json

### DIFF
--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -48,13 +48,9 @@ jobs:
       - name: Install vscode-megane dependencies
         run: cd vscode-megane && npm ci
 
-      - name: Set version from tag or root package.json
+      - name: Set version from root package.json
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
-          else
-            VERSION=$(node -p "require('./package.json').version")
-          fi
+          VERSION=$(node -p "require('./package.json').version")
           echo "Setting vscode-megane version to ${VERSION}"
           cd vscode-megane
           npm version "$VERSION" --no-git-tag-version --allow-same-version

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -48,10 +48,14 @@ jobs:
       - name: Install vscode-megane dependencies
         run: cd vscode-megane && npm ci
 
-      - name: Set version from tag
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Set version from tag or root package.json
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          else
+            VERSION=$(node -p "require('./package.json').version")
+          fi
+          echo "Setting vscode-megane version to ${VERSION}"
           cd vscode-megane
           npm version "$VERSION" --no-git-tag-version --allow-same-version
 


### PR DESCRIPTION
## Summary

- During dry runs, the vscode extension version wasn't updated from the tag (since there's no tag), so `vscode-megane/package.json` kept the stale version `0.3.2`, causing the "already published" check to fail
- Always derive the vscode extension version from the root `package.json` instead of the git tag, unifying the version source for both dry run and release flows
- This matches how the npm publish workflow already works

## Test plan

- [ ] Trigger `release-dry-run.yml` via workflow_dispatch and verify the VS Code dry run job passes the version check
- [ ] Verify tag push (`v*`) still correctly sets the version and publishes

https://claude.ai/code/session_01R58uqrq28nrHw7y7hSTAuU