### PR TITLE
Require explicit Viewport node in Python Pipeline API

### DIFF
--- a/docs/guide/pipeline.md
+++ b/docs/guide/pipeline.md
@@ -253,9 +253,14 @@ protein = pipe.add_node(megane.LoadStructure("protein.pdb"))
 ligand = pipe.add_node(megane.LoadStructure("ligand.mol"))
 bonds_p = pipe.add_node(megane.AddBonds(source="distance"))
 bonds_l = pipe.add_node(megane.AddBonds(source="structure"))
+v = pipe.add_node(megane.Viewport())
 
 pipe.add_edge(protein, bonds_p)
 pipe.add_edge(ligand, bonds_l)
+pipe.add_edge(protein, v)
+pipe.add_edge(bonds_p, v)
+pipe.add_edge(ligand, v)
+pipe.add_edge(bonds_l, v)
 
 viewer = megane.MolecularViewer()
 viewer.set_pipeline(pipe)
@@ -278,15 +283,17 @@ Pipelines can be built programmatically in Python using the `Pipeline` class. Th
 import megane
 
 pipe = megane.Pipeline()
-node = pipe.add_node(...)   # add a node
-pipe.add_edge(src, tgt)     # connect nodes
+node = pipe.add_node(...)       # add a node
+v = pipe.add_node(megane.Viewport())  # add viewport
+pipe.add_edge(src, tgt)         # connect nodes
+pipe.add_edge(node, v)          # connect to viewport
 
 viewer = megane.MolecularViewer()
-viewer.set_pipeline(pipe)   # apply to viewer
-viewer                      # display in notebook
+viewer.set_pipeline(pipe)       # apply to viewer
+viewer                          # display in notebook
 ```
 
-The pipeline serializes to the `SerializedPipeline` v3 JSON format. A `Viewport` node is auto-generated and all unconnected outputs are automatically connected to it.
+The pipeline serializes to the `SerializedPipeline` v3 JSON format. A `Viewport` node must be explicitly added and connected for data to be rendered.
 
 ### Pipeline class
 
@@ -294,7 +301,7 @@ The pipeline serializes to the `SerializedPipeline` v3 JSON format. A `Viewport`
 |--------|-------------|
 | `add_node(node)` | Add a node to the pipeline. Returns the node for use in `add_edge()` |
 | `add_edge(source, target)` | Connect source → target. Port handles are auto-resolved |
-| `to_dict()` | Serialize to v3 JSON dict (auto-generates Viewport) |
+| `to_dict()` | Serialize to v3 JSON dict |
 
 ### Node classes
 
@@ -312,6 +319,7 @@ from megane import (
     AddLabels,
     AddPolyhedra,
     VectorOverlay,
+    Viewport,
     Pipeline,
 )
 ```
@@ -476,6 +484,22 @@ megane.VectorOverlay(*, scale: float = 1.0)
 **Inputs:** `vector`
 **Outputs:** `vector`
 
+#### Viewport
+
+3D rendering output node. All data to be rendered must be explicitly connected to this node.
+
+```python
+megane.Viewport(*, perspective: bool = False, cell_axes_visible: bool = True)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `perspective` | `bool` | `False` | Toggle perspective / orthographic projection |
+| `cell_axes_visible` | `bool` | `True` | Show simulation cell axes with labels |
+
+**Inputs:** `particle`, `bond`, `cell`, `trajectory`, `label`, `mesh`, `vector`
+**Outputs:** —
+
 ### Port Resolution
 
 Edges are auto-resolved: `add_edge(source, target)` automatically picks the correct port handles based on node types. For example:
@@ -493,7 +517,11 @@ import megane
 pipe = megane.Pipeline()
 s = pipe.add_node(megane.LoadStructure("protein.pdb"))
 bonds = pipe.add_node(megane.AddBonds(source="distance"))
+v = pipe.add_node(megane.Viewport())
+
 pipe.add_edge(s, bonds)
+pipe.add_edge(s, v)
+pipe.add_edge(bonds, v)
 
 viewer = megane.MolecularViewer()
 viewer.set_pipeline(pipe)
@@ -510,10 +538,13 @@ s = pipe.add_node(megane.LoadStructure("protein.pdb"))
 carbons = pipe.add_node(megane.Filter(query="element == 'C'"))
 big = pipe.add_node(megane.Modify(scale=1.5, opacity=0.8))
 bonds = pipe.add_node(megane.AddBonds(source="distance"))
+v = pipe.add_node(megane.Viewport())
 
 pipe.add_edge(s, carbons)
 pipe.add_edge(carbons, big)
 pipe.add_edge(s, bonds)
+pipe.add_edge(big, v)
+pipe.add_edge(bonds, v)
 
 viewer = megane.MolecularViewer()
 viewer.set_pipeline(pipe)
@@ -529,9 +560,13 @@ pipe = megane.Pipeline()
 s = pipe.add_node(megane.LoadStructure("protein.pdb"))
 t = pipe.add_node(megane.LoadTrajectory(xtc="trajectory.xtc"))
 bonds = pipe.add_node(megane.AddBonds(source="structure"))
+v = pipe.add_node(megane.Viewport())
 
 pipe.add_edge(s, t)
 pipe.add_edge(s, bonds)
+pipe.add_edge(s, v)
+pipe.add_edge(t, v)
+pipe.add_edge(bonds, v)
 
 viewer = megane.MolecularViewer()
 viewer.set_pipeline(pipe)
@@ -551,11 +586,14 @@ water = pipe.add_node(megane.Filter(query='resname == "HOH"'))
 transparent = pipe.add_node(megane.Modify(scale=0.5, opacity=0.2))
 
 bonds = pipe.add_node(megane.AddBonds(source="distance"))
+v = pipe.add_node(megane.Viewport())
 
 pipe.add_edge(s, water)
 pipe.add_edge(water, transparent)
 pipe.add_edge(s, bonds)
-# Unconnected outputs (particle, cell from LoadStructure) auto-connect to Viewport
+pipe.add_edge(s, v)           # protein particle + cell
+pipe.add_edge(transparent, v) # translucent water
+pipe.add_edge(bonds, v)
 
 viewer = megane.MolecularViewer()
 viewer.set_pipeline(pipe)
@@ -577,9 +615,13 @@ polyhedra = pipe.add_node(megane.AddPolyhedra(
     opacity=0.5,
     show_edges=True,
 ))
+v = pipe.add_node(megane.Viewport())
 
 pipe.add_edge(s, bonds)
 pipe.add_edge(s, polyhedra)
+pipe.add_edge(s, v)
+pipe.add_edge(bonds, v)
+pipe.add_edge(polyhedra, v)
 
 viewer = megane.MolecularViewer()
 viewer.set_pipeline(pipe)
@@ -599,11 +641,16 @@ carbon = pipe.add_node(megane.Filter(query="element == 'C'"))
 nitrogen = pipe.add_node(megane.Filter(query="element == 'N'"))
 labels = pipe.add_node(megane.AddLabels(source="element"))
 bonds = pipe.add_node(megane.AddBonds(source="distance"))
+v = pipe.add_node(megane.Viewport())
 
 pipe.add_edge(s, carbon)
 pipe.add_edge(s, nitrogen)
 pipe.add_edge(s, labels)
 pipe.add_edge(s, bonds)
+pipe.add_edge(carbon, v)
+pipe.add_edge(nitrogen, v)
+pipe.add_edge(labels, v)
+pipe.add_edge(bonds, v)
 
 viewer = megane.MolecularViewer()
 viewer.set_pipeline(pipe)
@@ -618,8 +665,11 @@ import megane
 pipe = megane.Pipeline()
 s = pipe.add_node(megane.LoadStructure("structure.pdb"))
 t = pipe.add_node(megane.LoadTrajectory(traj="simulation.traj"))
+v = pipe.add_node(megane.Viewport())
 
 pipe.add_edge(s, t)
+pipe.add_edge(s, v)
+pipe.add_edge(t, v)
 
 viewer = megane.MolecularViewer()
 viewer.set_pipeline(pipe)

--- a/examples/pipeline.ipynb
+++ b/examples/pipeline.ipynb
@@ -1,0 +1,235 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# megane - Pipeline API Demo\n",
+    "\n",
+    "Build visualization workflows programmatically using the Pipeline API.\n",
+    "Each pipeline is a directed graph of nodes connected by edges, ending at an explicit Viewport node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import megane\n",
+    "\n",
+    "print(f\"megane v{megane.__version__}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Basic Structure\n",
+    "\n",
+    "Load a PDB file and display it. The simplest pipeline connects `LoadStructure` to a `Viewport`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipe = megane.Pipeline()\n",
+    "s = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/1crn.pdb\"))\n",
+    "v = pipe.add_node(megane.Viewport())\n",
+    "\n",
+    "pipe.add_edge(s, v)\n",
+    "\n",
+    "viewer = megane.MolecularViewer()\n",
+    "viewer.set_pipeline(pipe)\n",
+    "viewer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Structure with Bonds\n",
+    "\n",
+    "Add distance-based bond detection with `AddBonds`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipe = megane.Pipeline()\n",
+    "s = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/caffeine_water.pdb\"))\n",
+    "bonds = pipe.add_node(megane.AddBonds(source=\"distance\"))\n",
+    "v = pipe.add_node(megane.Viewport())\n",
+    "\n",
+    "pipe.add_edge(s, bonds)\n",
+    "pipe.add_edge(s, v)\n",
+    "pipe.add_edge(bonds, v)\n",
+    "\n",
+    "viewer = megane.MolecularViewer()\n",
+    "viewer.set_pipeline(pipe)\n",
+    "viewer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Filter and Modify\n",
+    "\n",
+    "Select carbon atoms with `Filter`, then scale them up with `Modify`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipe = megane.Pipeline()\n",
+    "s = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/1crn.pdb\"))\n",
+    "carbons = pipe.add_node(megane.Filter(query=\"element == 'C'\"))\n",
+    "big = pipe.add_node(megane.Modify(scale=1.5, opacity=0.8))\n",
+    "bonds = pipe.add_node(megane.AddBonds(source=\"distance\"))\n",
+    "v = pipe.add_node(megane.Viewport())\n",
+    "\n",
+    "pipe.add_edge(s, carbons)\n",
+    "pipe.add_edge(carbons, big)\n",
+    "pipe.add_edge(s, bonds)\n",
+    "pipe.add_edge(big, v)\n",
+    "pipe.add_edge(bonds, v)\n",
+    "\n",
+    "viewer = megane.MolecularViewer()\n",
+    "viewer.set_pipeline(pipe)\n",
+    "viewer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Trajectory Playback\n",
+    "\n",
+    "Load a structure with an XTC trajectory. Use `frame_index` to navigate frames."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipe = megane.Pipeline()\n",
+    "s = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/caffeine_water.pdb\"))\n",
+    "t = pipe.add_node(megane.LoadTrajectory(xtc=\"../tests/fixtures/caffeine_water_vibration.xtc\"))\n",
+    "bonds = pipe.add_node(megane.AddBonds(source=\"structure\"))\n",
+    "v = pipe.add_node(megane.Viewport())\n",
+    "\n",
+    "pipe.add_edge(s, t)\n",
+    "pipe.add_edge(s, bonds)\n",
+    "pipe.add_edge(s, v)\n",
+    "pipe.add_edge(t, v)\n",
+    "pipe.add_edge(bonds, v)\n",
+    "\n",
+    "viewer = megane.MolecularViewer()\n",
+    "viewer.set_pipeline(pipe)\n",
+    "print(f\"Loaded trajectory: {viewer.total_frames} frames\")\n",
+    "viewer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Jump to a specific frame\n",
+    "viewer.frame_index = 50"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Multiple Structures\n",
+    "\n",
+    "Load two structures into the same viewport as independent layers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipe = megane.Pipeline()\n",
+    "s1 = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/1crn.pdb\"))\n",
+    "s2 = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/caffeine_water.pdb\"))\n",
+    "b1 = pipe.add_node(megane.AddBonds(source=\"distance\"))\n",
+    "b2 = pipe.add_node(megane.AddBonds(source=\"distance\"))\n",
+    "v = pipe.add_node(megane.Viewport())\n",
+    "\n",
+    "pipe.add_edge(s1, b1)\n",
+    "pipe.add_edge(s2, b2)\n",
+    "pipe.add_edge(s1, v)\n",
+    "pipe.add_edge(b1, v)\n",
+    "pipe.add_edge(s2, v)\n",
+    "pipe.add_edge(b2, v)\n",
+    "\n",
+    "viewer = megane.MolecularViewer()\n",
+    "viewer.set_pipeline(pipe)\n",
+    "viewer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Labels\n",
+    "\n",
+    "Add element labels to atoms with `AddLabels`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipe = megane.Pipeline()\n",
+    "s = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/caffeine_water.pdb\"))\n",
+    "bonds = pipe.add_node(megane.AddBonds(source=\"distance\"))\n",
+    "labels = pipe.add_node(megane.AddLabels(source=\"element\"))\n",
+    "v = pipe.add_node(megane.Viewport())\n",
+    "\n",
+    "pipe.add_edge(s, bonds)\n",
+    "pipe.add_edge(s, labels)\n",
+    "pipe.add_edge(s, v)\n",
+    "pipe.add_edge(bonds, v)\n",
+    "pipe.add_edge(labels, v)\n",
+    "\n",
+    "viewer = megane.MolecularViewer()\n",
+    "viewer.set_pipeline(pipe)\n",
+    "viewer"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/python/megane/__init__.py
+++ b/python/megane/__init__.py
@@ -16,6 +16,7 @@ from megane.pipeline import (
     Pipeline,
     Streaming,
     VectorOverlay,
+    Viewport,
 )
 from megane.widget import MolecularViewer
 
@@ -32,6 +33,7 @@ __all__ = [
     "Pipeline",
     "Streaming",
     "VectorOverlay",
+    "Viewport",
     "load_lammps_data",
     "load_pdb",
     "load_traj",

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -5,19 +5,25 @@ Nodes are class instances added via ``add_node()``, connections via
 serializes to the same ``SerializedPipeline`` v3 JSON format used by
 the TypeScript pipeline engine, which remains the source of truth.
 
+A ``Viewport`` node must be explicitly added and connected for data
+to be rendered.
+
 Example::
 
-    from megane.pipeline import Pipeline, LoadStructure, Filter, Modify, AddBonds
+    from megane.pipeline import Pipeline, LoadStructure, Filter, Modify, AddBonds, Viewport
 
     pipe = Pipeline()
     s = pipe.add_node(LoadStructure("protein.pdb"))
     carbons = pipe.add_node(Filter(query="element == 'C'"))
     m = pipe.add_node(Modify(scale=1.3))
     bonds = pipe.add_node(AddBonds(source="distance"))
+    v = pipe.add_node(Viewport())
 
     pipe.add_edge(s, carbons)
     pipe.add_edge(carbons, m)
     pipe.add_edge(s, bonds)
+    pipe.add_edge(m, v)
+    pipe.add_edge(bonds, v)
 
     viewer.set_pipeline(pipe)
 """
@@ -205,6 +211,25 @@ class VectorOverlay(PipelineNode):
         self.scale = scale
 
 
+class Viewport(PipelineNode):
+    """3D rendering output node.
+
+    All data to be rendered must be explicitly connected to this node.
+    """
+
+    _node_type = "viewport"
+
+    def __init__(
+        self,
+        *,
+        perspective: bool = False,
+        cell_axes_visible: bool = True,
+    ) -> None:
+        super().__init__()
+        self.perspective = perspective
+        self.cell_axes_visible = cell_axes_visible
+
+
 # ─── Port Resolution ────────────────────────────────────────────────
 
 # target_node_type → (default source_handle, target_handle)
@@ -236,8 +261,6 @@ def _resolve_ports(
     target: PipelineNode,
 ) -> tuple[str, str]:
     """Resolve source and target port handles from node types."""
-    target_handle = _TARGET_PORT_MAP.get(target._node_type, ("particle", "particle"))[1]
-
     # Source handle: use the source node's known output, or infer
     # from what the target expects.
     source_handle = _SOURCE_OUTPUT_MAP.get(source._node_type)
@@ -245,6 +268,23 @@ def _resolve_ports(
         # LoadStructure or other multi-output node: use what the
         # target expects as its input type.
         source_handle = _TARGET_PORT_MAP.get(target._node_type, ("particle", "particle"))[0]
+
+    # For viewport targets, the target handle matches the source output type.
+    if isinstance(target, Viewport):
+        # Map source output handles to viewport input handles.
+        _viewport_handle = {
+            "particle": "particle",
+            "out": "particle",
+            "bond": "bond",
+            "cell": "cell",
+            "trajectory": "trajectory",
+            "label": "label",
+            "mesh": "mesh",
+            "vector": "vector",
+        }
+        target_handle = _viewport_handle.get(source_handle, "particle")
+    else:
+        target_handle = _TARGET_PORT_MAP.get(target._node_type, ("particle", "particle"))[1]
 
     return source_handle, target_handle
 
@@ -356,27 +396,9 @@ class Pipeline:
     # ── Serialization ───────────────────────────────────────
 
     def to_dict(self) -> dict:
-        """Serialize to ``SerializedPipeline`` v3 format.
-
-        A viewport node is auto-generated and connected to all
-        unconnected output ports.
-        """
+        """Serialize to ``SerializedPipeline`` v3 format."""
         nodes = [config for _, config in self._nodes]
         edges = list(self._edges)
-
-        viewport_id = "viewport-auto"
-        viewport_node = {
-            "id": viewport_id,
-            "type": "viewport",
-            "perspective": False,
-            "cellAxesVisible": True,
-            "position": {"x": 0, "y": 0},
-        }
-        nodes.append(viewport_node)
-
-        viewport_edges = self._auto_connect_viewport(viewport_id)
-        edges.extend(viewport_edges)
-
         return {"version": 3, "nodes": nodes, "edges": edges}
 
     # ── Internal ────────────────────────────────────────────
@@ -425,6 +447,9 @@ class Pipeline:
             base["fileName"] = node.path
         elif isinstance(node, VectorOverlay):
             base["scale"] = node.scale
+        elif isinstance(node, Viewport):
+            base["perspective"] = node.perspective
+            base["cellAxesVisible"] = node.cell_axes_visible
 
         return base
 
@@ -466,53 +491,3 @@ class Pipeline:
             _, trajectory = load_traj(node.traj)
             self._trajectories[node._id] = trajectory
 
-    def _auto_connect_viewport(self, viewport_id: str) -> list[dict]:
-        """Connect all unconnected outputs to the auto-generated viewport."""
-        # Collect set of (node_id, handle) that are already used as edge sources
-        used_outputs: set[tuple[str, str]] = set()
-        for edge in self._edges:
-            used_outputs.add((edge["source"], edge["sourceHandle"]))
-
-        # Map of node_type → list of output handles
-        output_handles: dict[str, list[str]] = {
-            "load_structure": ["particle", "trajectory", "cell"],
-            "load_trajectory": ["trajectory"],
-            "load_vector": ["vector"],
-            "streaming": ["particle", "bond", "trajectory", "cell"],
-            "filter": ["out"],
-            "modify": ["out"],
-            "add_bond": ["bond"],
-            "label_generator": ["label"],
-            "polyhedron_generator": ["mesh"],
-            "vector_overlay": ["vector"],
-        }
-
-        # Map output handle name → viewport input handle name
-        handle_to_viewport: dict[str, str] = {
-            "particle": "particle",
-            "out": "particle",  # filter/modify output → viewport particle
-            "bond": "bond",
-            "cell": "cell",
-            "trajectory": "trajectory",
-            "label": "label",
-            "mesh": "mesh",
-            "vector": "vector",
-        }
-
-        viewport_edges: list[dict] = []
-        for node, _ in self._nodes:
-            handles = output_handles.get(node._node_type, [])
-            for handle in handles:
-                if (node._id, handle) not in used_outputs:
-                    viewport_handle = handle_to_viewport.get(handle)
-                    if viewport_handle:
-                        viewport_edges.append(
-                            {
-                                "source": node._id,
-                                "target": viewport_id,
-                                "sourceHandle": handle,
-                                "targetHandle": viewport_handle,
-                            }
-                        )
-
-        return viewport_edges

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -490,4 +490,3 @@ class Pipeline:
 
             _, trajectory = load_traj(node.traj)
             self._trajectories[node._id] = trajectory
-

--- a/tests/notebooks/test_pipeline.ipynb
+++ b/tests/notebooks/test_pipeline.ipynb
@@ -1,196 +1,109 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 5,
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    }
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pipeline Test\n",
+    "\n",
+    "Verifies the pipeline DAG builder: node creation, edge wiring, serialization, and viewer integration."
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Pipeline Test\n",
-        "\n",
-        "Verifies the pipeline DAG builder: node creation, edge wiring, serialization, and viewer integration."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "import json\n",
-        "import pathlib\n",
-        "\n",
-        "import megane\n",
-        "from megane.pipeline import (\n",
-        "    AddBonds,\n",
-        "    AddLabels,\n",
-        "    AddPolyhedra,\n",
-        "    Filter,\n",
-        "    LoadStructure,\n",
-        "    LoadTrajectory,\n",
-        "    LoadVector,\n",
-        "    Modify,\n",
-        "    Pipeline,\n",
-        "    VectorOverlay,\n",
-        ")\n",
-        "\n",
-        "FIXTURES = (pathlib.Path(\".\").resolve().parent / \"fixtures\")\n",
-        "assert FIXTURES.exists(), f\"Fixtures not found: {FIXTURES}\"\n",
-        "print(f\"megane v{megane.__version__}\")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Basic pipeline: LoadStructure → Filter → Modify + AddBonds"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "pipe = Pipeline()\n",
-        "s = pipe.add_node(LoadStructure(str(FIXTURES / \"1crn.pdb\")))\n",
-        "f = pipe.add_node(Filter(query=\"element == 'C'\"))\n",
-        "m = pipe.add_node(Modify(scale=1.3))\n",
-        "bonds = pipe.add_node(AddBonds(source=\"distance\"))\n",
-        "\n",
-        "pipe.add_edge(s, f)\n",
-        "pipe.add_edge(f, m)\n",
-        "pipe.add_edge(s, bonds)\n",
-        "\n",
-        "d = pipe.to_dict()\n",
-        "assert d[\"version\"] == 3, f\"Expected version 3, got {d['version']}\"\n",
-        "node_types = [n[\"type\"] for n in d[\"nodes\"]]\n",
-        "assert \"load_structure\" in node_types\n",
-        "assert \"filter\" in node_types\n",
-        "assert \"modify\" in node_types\n",
-        "assert \"add_bond\" in node_types\n",
-        "assert \"viewport\" in node_types\n",
-        "print(f\"Pipeline nodes: {node_types}\")\n",
-        "print(f\"Edges: {len(d['edges'])}\")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Apply pipeline to viewer"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "viewer = megane.MolecularViewer()\n",
-        "viewer.set_pipeline(pipe)\n",
-        "\n",
-        "assert viewer._pipeline_enabled is True, \"Pipeline not enabled\"\n",
-        "pipeline_config = json.loads(viewer._pipeline_json)\n",
-        "assert pipeline_config[\"version\"] == 3\n",
-        "assert len(viewer._node_snapshots_data) > 0, \"No node snapshot data\"\n",
-        "print(f\"Pipeline enabled, {len(viewer._node_snapshots_data)} node snapshots\")\n",
-        "viewer"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Pipeline with AddLabels and AddPolyhedra"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "pipe2 = Pipeline()\n",
-        "s2 = pipe2.add_node(LoadStructure(str(FIXTURES / \"1crn.pdb\")))\n",
-        "labels = pipe2.add_node(AddLabels(source=\"element\"))\n",
-        "poly = pipe2.add_node(AddPolyhedra(center_elements=[8]))\n",
-        "\n",
-        "pipe2.add_edge(s2, labels)\n",
-        "pipe2.add_edge(s2, poly)\n",
-        "\n",
-        "d2 = pipe2.to_dict()\n",
-        "node_types2 = [n[\"type\"] for n in d2[\"nodes\"]]\n",
-        "assert \"label_generator\" in node_types2\n",
-        "assert \"polyhedron_generator\" in node_types2\n",
-        "print(f\"Labels + Polyhedra pipeline: {node_types2}\")\n",
-        "\n",
-        "v2 = megane.MolecularViewer()\n",
-        "v2.set_pipeline(pipe2)\n",
-        "v2"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Pipeline with trajectory"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "pipe3 = Pipeline()\n",
-        "s3 = pipe3.add_node(LoadStructure(str(FIXTURES / \"caffeine_water.pdb\")))\n",
-        "t3 = pipe3.add_node(LoadTrajectory(xtc=str(FIXTURES / \"caffeine_water_vibration.xtc\")))\n",
-        "pipe3.add_edge(s3, t3)\n",
-        "\n",
-        "assert len(pipe3._trajectories) > 0, \"No trajectories loaded\"\n",
-        "print(f\"Trajectories: {len(pipe3._trajectories)}\")\n",
-        "\n",
-        "v3 = megane.MolecularViewer()\n",
-        "v3.set_pipeline(pipe3)\n",
-        "assert v3.total_frames > 0, f\"Expected frames > 0, got {v3.total_frames}\"\n",
-        "print(f\"Total frames: {v3.total_frames}\")\n",
-        "v3"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Pipeline with LoadVector and VectorOverlay"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "pipe4 = Pipeline()\n",
-        "s4 = pipe4.add_node(LoadStructure(str(FIXTURES / \"1crn.pdb\")))\n",
-        "vec = pipe4.add_node(LoadVector(str(FIXTURES / \"demo_vectors.vec\")))\n",
-        "overlay = pipe4.add_node(VectorOverlay(scale=2.0))\n",
-        "\n",
-        "pipe4.add_edge(vec, overlay)\n",
-        "\n",
-        "d4 = pipe4.to_dict()\n",
-        "node_types4 = [n[\"type\"] for n in d4[\"nodes\"]]\n",
-        "assert \"load_vector\" in node_types4\n",
-        "assert \"vector_overlay\" in node_types4\n",
-        "print(f\"Vector pipeline: {node_types4}\")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    }
-  ]
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "import json\nimport pathlib\n\nimport megane\nfrom megane.pipeline import (\n    AddBonds,\n    AddLabels,\n    AddPolyhedra,\n    Filter,\n    LoadStructure,\n    LoadTrajectory,\n    LoadVector,\n    Modify,\n    Pipeline,\n    VectorOverlay,\n    Viewport,\n)\n\nFIXTURES = (pathlib.Path(\".\").resolve().parent / \"fixtures\")\nassert FIXTURES.exists(), f\"Fixtures not found: {FIXTURES}\"\nprint(f\"megane v{megane.__version__}\")",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic pipeline: LoadStructure → Filter → Modify + AddBonds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "pipe = Pipeline()\ns = pipe.add_node(LoadStructure(str(FIXTURES / \"1crn.pdb\")))\nf = pipe.add_node(Filter(query=\"element == 'C'\"))\nm = pipe.add_node(Modify(scale=1.3))\nbonds = pipe.add_node(AddBonds(source=\"distance\"))\nv = pipe.add_node(Viewport())\n\npipe.add_edge(s, f)\npipe.add_edge(f, m)\npipe.add_edge(s, bonds)\npipe.add_edge(m, v)\npipe.add_edge(bonds, v)\n\nd = pipe.to_dict()\nassert d[\"version\"] == 3, f\"Expected version 3, got {d['version']}\"\nnode_types = [n[\"type\"] for n in d[\"nodes\"]]\nassert \"load_structure\" in node_types\nassert \"filter\" in node_types\nassert \"modify\" in node_types\nassert \"add_bond\" in node_types\nassert \"viewport\" in node_types\nprint(f\"Pipeline nodes: {node_types}\")\nprint(f\"Edges: {len(d['edges'])}\")",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Apply pipeline to viewer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "viewer = megane.MolecularViewer()\n",
+    "viewer.set_pipeline(pipe)\n",
+    "\n",
+    "assert viewer._pipeline_enabled is True, \"Pipeline not enabled\"\n",
+    "pipeline_config = json.loads(viewer._pipeline_json)\n",
+    "assert pipeline_config[\"version\"] == 3\n",
+    "assert len(viewer._node_snapshots_data) > 0, \"No node snapshot data\"\n",
+    "print(f\"Pipeline enabled, {len(viewer._node_snapshots_data)} node snapshots\")\n",
+    "viewer"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pipeline with AddLabels and AddPolyhedra"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "pipe2 = Pipeline()\ns2 = pipe2.add_node(LoadStructure(str(FIXTURES / \"1crn.pdb\")))\nlabels = pipe2.add_node(AddLabels(source=\"element\"))\npoly = pipe2.add_node(AddPolyhedra(center_elements=[8]))\nv2_node = pipe2.add_node(Viewport())\n\npipe2.add_edge(s2, labels)\npipe2.add_edge(s2, poly)\npipe2.add_edge(s2, v2_node)\npipe2.add_edge(labels, v2_node)\npipe2.add_edge(poly, v2_node)\n\nd2 = pipe2.to_dict()\nnode_types2 = [n[\"type\"] for n in d2[\"nodes\"]]\nassert \"label_generator\" in node_types2\nassert \"polyhedron_generator\" in node_types2\nprint(f\"Labels + Polyhedra pipeline: {node_types2}\")\n\nv2 = megane.MolecularViewer()\nv2.set_pipeline(pipe2)\nv2",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pipeline with trajectory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "pipe3 = Pipeline()\ns3 = pipe3.add_node(LoadStructure(str(FIXTURES / \"caffeine_water.pdb\")))\nt3 = pipe3.add_node(LoadTrajectory(xtc=str(FIXTURES / \"caffeine_water_vibration.xtc\")))\nv3_node = pipe3.add_node(Viewport())\npipe3.add_edge(s3, t3)\npipe3.add_edge(s3, v3_node)\npipe3.add_edge(t3, v3_node)\n\nassert len(pipe3._trajectories) > 0, \"No trajectories loaded\"\nprint(f\"Trajectories: {len(pipe3._trajectories)}\")\n\nv3 = megane.MolecularViewer()\nv3.set_pipeline(pipe3)\nassert v3.total_frames > 0, f\"Expected frames > 0, got {v3.total_frames}\"\nprint(f\"Total frames: {v3.total_frames}\")\nv3",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pipeline with LoadVector and VectorOverlay"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "pipe4 = Pipeline()\ns4 = pipe4.add_node(LoadStructure(str(FIXTURES / \"1crn.pdb\")))\nvec = pipe4.add_node(LoadVector(str(FIXTURES / \"demo_vectors.vec\")))\noverlay = pipe4.add_node(VectorOverlay(scale=2.0))\nv4_node = pipe4.add_node(Viewport())\n\npipe4.add_edge(vec, overlay)\npipe4.add_edge(s4, v4_node)\npipe4.add_edge(overlay, v4_node)\n\nd4 = pipe4.to_dict()\nnode_types4 = [n[\"type\"] for n in d4[\"nodes\"]]\nassert \"load_vector\" in node_types4\nassert \"vector_overlay\" in node_types4\nprint(f\"Vector pipeline: {node_types4}\")",
+   "outputs": [],
+   "execution_count": null
+  }
+ ]
 }

--- a/tests/python/test_demo_code.py
+++ b/tests/python/test_demo_code.py
@@ -123,9 +123,11 @@ def test_event_callback_selection_change():
 
 
 def test_pipeline_load_structure():
-    """Pipeline API: LoadStructure + set_pipeline() enables pipeline mode."""
+    """Pipeline API: LoadStructure + Viewport + set_pipeline() enables pipeline mode."""
     pipe = megane.Pipeline()
     s = pipe.add_node(megane.LoadStructure(str(FIXTURES / "1crn.pdb")))
+    v = pipe.add_node(megane.Viewport())
+    pipe.add_edge(s, v)
 
     viewer = megane.MolecularViewer()
     viewer.set_pipeline(pipe)
@@ -135,13 +137,16 @@ def test_pipeline_load_structure():
 
 
 def test_pipeline_with_trajectory():
-    """Pipeline API: LoadStructure + LoadTrajectory provides frames."""
+    """Pipeline API: LoadStructure + LoadTrajectory + Viewport provides frames."""
     pipe = megane.Pipeline()
     s = pipe.add_node(megane.LoadStructure(str(FIXTURES / "caffeine_water.pdb")))
     t = pipe.add_node(megane.LoadTrajectory(
         xtc=str(FIXTURES / "caffeine_water_vibration.xtc"),
     ))
+    v = pipe.add_node(megane.Viewport())
     pipe.add_edge(s, t)
+    pipe.add_edge(s, v)
+    pipe.add_edge(t, v)
 
     viewer = megane.MolecularViewer()
     viewer.set_pipeline(pipe)

--- a/tests/python/test_pipeline.py
+++ b/tests/python/test_pipeline.py
@@ -15,6 +15,7 @@ from megane.pipeline import (
     Modify,
     Pipeline,
     VectorOverlay,
+    Viewport,
 )
 
 FIXTURES = Path(__file__).parent.parent / "fixtures"
@@ -174,26 +175,65 @@ class TestPipelineSerialization:
         result = pipe.to_dict()
         assert result["version"] == 3
 
-    def test_viewport_auto_generated(self):
+    def test_no_viewport_without_explicit_node(self):
+        """Pipeline without Viewport node should not include viewport."""
         pipe = Pipeline()
         pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
         result = pipe.to_dict()
 
         node_types = [n["type"] for n in result["nodes"]]
-        assert "viewport" in node_types
+        assert "viewport" not in node_types
 
-    def test_terminal_nodes_connected_to_viewport(self):
+    def test_explicit_viewport_node(self):
+        """Viewport node appears when explicitly added."""
         pipe = Pipeline()
         s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        v = pipe.add_node(Viewport())
+        pipe.add_edge(s, v)
         result = pipe.to_dict()
 
-        # LoadStructure has unconnected particle, trajectory, cell outputs
-        # All should be connected to viewport
+        node_types = [n["type"] for n in result["nodes"]]
+        assert "viewport" in node_types
+        # Edge should connect structure to viewport
         viewport_edges = [
-            e for e in result["edges"]
-            if e["target"] == "viewport-auto"
+            e for e in result["edges"] if e["target"] == v._id
         ]
-        assert len(viewport_edges) >= 1  # at least particle
+        assert len(viewport_edges) == 1
+        assert viewport_edges[0]["sourceHandle"] == "particle"
+        assert viewport_edges[0]["targetHandle"] == "particle"
+
+    def test_viewport_serialization_params(self):
+        """Viewport parameters are serialized correctly."""
+        pipe = Pipeline()
+        v = pipe.add_node(Viewport(perspective=True, cell_axes_visible=False))
+        result = pipe.to_dict()
+
+        vp_node = next(n for n in result["nodes"] if n["type"] == "viewport")
+        assert vp_node["perspective"] is True
+        assert vp_node["cellAxesVisible"] is False
+
+    def test_viewport_port_resolution(self):
+        """add_edge resolves correct ports for various types → viewport."""
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        b = pipe.add_node(AddBonds(source="distance"))
+        lbl = pipe.add_node(AddLabels(source="element"))
+        v = pipe.add_node(Viewport())
+
+        pipe.add_edge(s, b)
+        pipe.add_edge(s, lbl)
+        pipe.add_edge(s, v)    # particle → particle
+        pipe.add_edge(b, v)    # bond → bond
+        pipe.add_edge(lbl, v)  # label → label
+
+        result = pipe.to_dict()
+        viewport_edges = [
+            e for e in result["edges"] if e["target"] == v._id
+        ]
+        handles = {(e["sourceHandle"], e["targetHandle"]) for e in viewport_edges}
+        assert ("particle", "particle") in handles
+        assert ("bond", "bond") in handles  # bond resolved via _SOURCE_OUTPUT_MAP
+        assert ("label", "label") in handles  # label resolved via _SOURCE_OUTPUT_MAP
 
     def test_filter_modify_chain(self):
         pipe = Pipeline()
@@ -279,17 +319,16 @@ class TestPipelineDAG:
         f1 = pipe.add_node(Filter(query="element == 'C'"))
         f2 = pipe.add_node(Filter(query="element == 'N'"))
         b = pipe.add_node(AddBonds(source="distance"))
+        v = pipe.add_node(Viewport())
         pipe.add_edge(s, f1)
         pipe.add_edge(s, f2)
         pipe.add_edge(s, b)
+        pipe.add_edge(f1, v)
+        pipe.add_edge(f2, v)
+        pipe.add_edge(b, v)
 
         result = pipe.to_dict()
-        # Should have 3 explicit edges + viewport auto-edges
-        explicit_edges = [
-            e for e in result["edges"]
-            if e["target"] != "viewport-auto"
-        ]
-        assert len(explicit_edges) == 3
+        assert len(result["edges"]) == 6
 
     def test_chain_filter_modify_labels(self):
         """Filter → Modify and Filter → Labels from same parent."""

--- a/uv.lock
+++ b/uv.lock
@@ -1401,7 +1401,7 @@ wheels = [
 
 [[package]]
 name = "megane"
-version = "0.3.2"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },


### PR DESCRIPTION
## Summary
- Remove auto-generated viewport from `Pipeline.to_dict()` — users must now explicitly add a `Viewport` node and connect edges to it
- Add `Viewport` class with `perspective` and `cell_axes_visible` parameters
- Update viewport port resolution to correctly map source output types (bond→bond, label→label, etc.)
- Update all documentation, tests, notebooks, and examples to use explicit Viewport

## Test plan
- [x] `uv run pytest tests/python/test_pipeline.py -v` — 33 tests pass
- [x] `uv run pytest tests/python/test_demo_code.py -v` — 9 tests pass
- [x] `uv run pytest tests/python/ -v` — 125 tests pass (1 skipped)
- [x] Verify CI passes

https://claude.ai/code/session_01FXMmNLawrUqxBWekY8wtGh