### PR TITLE
feat: add explicit port objects to Python pipeline API

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,19 @@ npm install megane-viewer
 ### Jupyter Notebook
 
 ```python
-import megane
+from megane import Pipeline, LoadStructure, AddBonds, Viewport, MolecularViewer
 
 # Build a pipeline
-pipe = megane.Pipeline()
-s = pipe.add_node(megane.LoadStructure("protein.pdb"))
-bonds = pipe.add_node(megane.AddBonds(source="distance"))
-pipe.add_edge(s, bonds)
+pipe = Pipeline()
+s = pipe.add_node(LoadStructure("protein.pdb"))
+bonds = pipe.add_node(AddBonds(source="distance"))
+v = pipe.add_node(Viewport())
+pipe.add_edge(s.out.particle, bonds.inp.particle)
+pipe.add_edge(s.out.particle, v.inp.particle)
+pipe.add_edge(bonds.out.bond, v.inp.bond)
 
 # Display in notebook
-viewer = megane.MolecularViewer()
+viewer = MolecularViewer()
 viewer.set_pipeline(pipe)
 viewer
 ```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -11,14 +11,17 @@ The Python API is used for:
 - **Data loading** — Parse PDB files and read XTC trajectories
 
 ```python
-import megane
+from megane import Pipeline, LoadStructure, LoadTrajectory, Viewport, MolecularViewer
 
-pipe = megane.Pipeline()
-s = pipe.add_node(megane.LoadStructure("protein.pdb"))
-t = pipe.add_node(megane.LoadTrajectory(xtc="trajectory.xtc"))
-pipe.add_edge(s, t)
+pipe = Pipeline()
+s = pipe.add_node(LoadStructure("protein.pdb"))
+t = pipe.add_node(LoadTrajectory(xtc="trajectory.xtc"))
+v = pipe.add_node(Viewport())
+pipe.add_edge(s.out.particle, t.inp.particle)
+pipe.add_edge(s.out.particle, v.inp.particle)
+pipe.add_edge(t.out.traj, v.inp.traj)
 
-viewer = megane.MolecularViewer()
+viewer = MolecularViewer()
 viewer.set_pipeline(pipe)
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,16 +24,19 @@ npm install megane-viewer
 ### Jupyter Notebook
 
 ```python
-import megane
+from megane import Pipeline, LoadStructure, AddBonds, Viewport, MolecularViewer
 
 # Build a pipeline
-pipe = megane.Pipeline()
-s = pipe.add_node(megane.LoadStructure("protein.pdb"))
-bonds = pipe.add_node(megane.AddBonds(source="distance"))
-pipe.add_edge(s, bonds)
+pipe = Pipeline()
+s = pipe.add_node(LoadStructure("protein.pdb"))
+bonds = pipe.add_node(AddBonds(source="distance"))
+v = pipe.add_node(Viewport())
+pipe.add_edge(s.out.particle, bonds.inp.particle)
+pipe.add_edge(s.out.particle, v.inp.particle)
+pipe.add_edge(bonds.out.bond, v.inp.bond)
 
 # Display in notebook
-viewer = megane.MolecularViewer()
+viewer = MolecularViewer()
 viewer.set_pipeline(pipe)
 viewer
 ```
@@ -41,12 +44,17 @@ viewer
 With a trajectory:
 
 ```python
-pipe = megane.Pipeline()
-s = pipe.add_node(megane.LoadStructure("protein.pdb"))
-t = pipe.add_node(megane.LoadTrajectory(xtc="trajectory.xtc"))
-pipe.add_edge(s, t)
+from megane import Pipeline, LoadStructure, LoadTrajectory, Viewport, MolecularViewer
 
-viewer = megane.MolecularViewer()
+pipe = Pipeline()
+s = pipe.add_node(LoadStructure("protein.pdb"))
+t = pipe.add_node(LoadTrajectory(xtc="trajectory.xtc"))
+v = pipe.add_node(Viewport())
+pipe.add_edge(s.out.particle, t.inp.particle)
+pipe.add_edge(s.out.particle, v.inp.particle)
+pipe.add_edge(t.out.traj, v.inp.traj)
+
+viewer = MolecularViewer()
 viewer.set_pipeline(pipe)
 viewer.frame_index = 50  # Jump to frame 50
 ```

--- a/docs/guide/integrations.md
+++ b/docs/guide/integrations.md
@@ -18,7 +18,10 @@ viewer = megane.MolecularViewer()
 pipe = megane.Pipeline()
 s = pipe.add_node(megane.LoadStructure("protein.pdb"))
 t = pipe.add_node(megane.LoadTrajectory(xtc="trajectory.xtc"))
-pipe.add_edge(s, t)
+v = pipe.add_node(megane.Viewport())
+pipe.add_edge(s.out.particle, t.inp.particle)
+pipe.add_edge(s.out.particle, v.inp.particle)
+pipe.add_edge(t.out.traj, v.inp.traj)
 viewer.set_pipeline(pipe)
 
 # Create a Plotly time-series chart

--- a/docs/guide/pipeline.md
+++ b/docs/guide/pipeline.md
@@ -246,23 +246,23 @@ LoadStructure (ligand.mol)  → AddBond ↗
 In Python:
 
 ```python
-import megane
+from megane import Pipeline, LoadStructure, AddBonds, Viewport, MolecularViewer
 
-pipe = megane.Pipeline()
-protein = pipe.add_node(megane.LoadStructure("protein.pdb"))
-ligand = pipe.add_node(megane.LoadStructure("ligand.mol"))
-bonds_p = pipe.add_node(megane.AddBonds(source="distance"))
-bonds_l = pipe.add_node(megane.AddBonds(source="structure"))
-v = pipe.add_node(megane.Viewport())
+pipe = Pipeline()
+protein = pipe.add_node(LoadStructure("protein.pdb"))
+ligand = pipe.add_node(LoadStructure("ligand.mol"))
+bonds_p = pipe.add_node(AddBonds(source="distance"))
+bonds_l = pipe.add_node(AddBonds(source="structure"))
+v = pipe.add_node(Viewport())
 
-pipe.add_edge(protein, bonds_p)
-pipe.add_edge(ligand, bonds_l)
-pipe.add_edge(protein, v)
-pipe.add_edge(bonds_p, v)
-pipe.add_edge(ligand, v)
-pipe.add_edge(bonds_l, v)
+pipe.add_edge(protein.out.particle, bonds_p.inp.particle)
+pipe.add_edge(ligand.out.particle, bonds_l.inp.particle)
+pipe.add_edge(protein.out.particle, v.inp.particle)
+pipe.add_edge(bonds_p.out.bond, v.inp.bond)
+pipe.add_edge(ligand.out.particle, v.inp.particle)
+pipe.add_edge(bonds_l.out.bond, v.inp.bond)
 
-viewer = megane.MolecularViewer()
+viewer = MolecularViewer()
 viewer.set_pipeline(pipe)
 viewer
 ```
@@ -280,27 +280,26 @@ Pipelines can be built programmatically in Python using the `Pipeline` class. Th
 ### Overview
 
 ```python
-import megane
+from megane import Pipeline, LoadStructure, Viewport, MolecularViewer
 
-pipe = megane.Pipeline()
-node = pipe.add_node(...)       # add a node
-v = pipe.add_node(megane.Viewport())  # add viewport
-pipe.add_edge(src, tgt)         # connect nodes
-pipe.add_edge(node, v)          # connect to viewport
+pipe = Pipeline()
+s = pipe.add_node(LoadStructure("protein.pdb"))  # returns node with .out/.inp
+v = pipe.add_node(Viewport())
+pipe.add_edge(s.out.particle, v.inp.particle)    # connect explicit ports
 
-viewer = megane.MolecularViewer()
-viewer.set_pipeline(pipe)       # apply to viewer
-viewer                          # display in notebook
+viewer = MolecularViewer()
+viewer.set_pipeline(pipe)   # apply to viewer
+viewer                      # display in notebook
 ```
 
-The pipeline serializes to the `SerializedPipeline` v3 JSON format. A `Viewport` node must be explicitly added and connected for data to be rendered.
+After `add_node()`, each node exposes `.out` and `.inp` namespaces for its ports. Pass these port objects to `add_edge()` to wire nodes together explicitly. The pipeline serializes to the `SerializedPipeline` v3 JSON format. A `Viewport` node must be explicitly added and connected for data to be rendered.
 
 ### Pipeline class
 
 | Method | Description |
 |--------|-------------|
-| `add_node(node)` | Add a node to the pipeline. Returns the node for use in `add_edge()` |
-| `add_edge(source, target)` | Connect source → target. Port handles are auto-resolved |
+| `add_node(node)` | Add a node to the pipeline. Returns the node (with `.out`/`.inp` ports) for use in `add_edge()` |
+| `add_edge(source_port, target_port)` | Connect `source.out.<name>` → `target.inp.<name>` |
 | `to_dict()` | Serialize to v3 JSON dict |
 
 ### Node classes
@@ -329,21 +328,21 @@ from megane import (
 Load a molecular structure file.
 
 ```python
-megane.LoadStructure(path: str)
+LoadStructure(path: str)
 ```
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `path` | `str` | File path. Supported: `.pdb`, `.gro`, `.xyz`, `.mol`, `.data` (LAMMPS) |
 
-**Outputs:** `particle`, `trajectory`, `cell`
+**Ports:** `out.particle`, `out.traj`, `out.cell`
 
 #### LoadTrajectory
 
 Load an external trajectory file. Requires connection from a `LoadStructure` node.
 
 ```python
-megane.LoadTrajectory(*, xtc: str | None = None, traj: str | None = None)
+LoadTrajectory(*, xtc: str | None = None, traj: str | None = None)
 ```
 
 | Parameter | Type | Default | Description |
@@ -351,54 +350,52 @@ megane.LoadTrajectory(*, xtc: str | None = None, traj: str | None = None)
 | `xtc` | `str \| None` | `None` | Path to XTC trajectory file |
 | `traj` | `str \| None` | `None` | Path to ASE .traj trajectory file |
 
-**Inputs:** `particle`
-**Outputs:** `trajectory`
+**Ports:** `inp.particle`, `out.traj`
 
 #### Streaming
 
 WebSocket-based real-time data delivery.
 
 ```python
-megane.Streaming()
+Streaming()
 ```
 
-No parameters. **Outputs:** `particle`, `bond`, `trajectory`, `cell`
+No parameters. **Ports:** `out.particle`, `out.bond`, `out.traj`, `out.cell`
 
 #### LoadVector
 
 Load per-atom vector data from a file.
 
 ```python
-megane.LoadVector(path: str)
+LoadVector(path: str)
 ```
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `path` | `str` | Path to vector data file |
 
-**Outputs:** `vector`
+**Ports:** `out.vector`
 
 #### Filter
 
 Select atoms by a query expression.
 
 ```python
-megane.Filter(*, query: str)
+Filter(*, query: str)
 ```
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `query` | `str` | Selection expression (see [Filter DSL](#filter-dsl)) |
 
-**Inputs:** `particle` (as "in" handle)
-**Outputs:** `particle` (as "out" handle)
+**Ports:** `inp.particle`, `out.particle`
 
 #### Modify
 
 Override per-atom visual properties.
 
 ```python
-megane.Modify(*, scale: float = 1.0, opacity: float = 1.0)
+Modify(*, scale: float = 1.0, opacity: float = 1.0)
 ```
 
 | Parameter | Type | Default | Description |
@@ -406,45 +403,42 @@ megane.Modify(*, scale: float = 1.0, opacity: float = 1.0)
 | `scale` | `float` | `1.0` | Atom sphere radius multiplier (0.1–2.0) |
 | `opacity` | `float` | `1.0` | Transparency (0 = invisible, 1 = opaque) |
 
-**Inputs:** `particle` (as "in" handle)
-**Outputs:** `particle` (as "out" handle)
+**Ports:** `inp.particle`, `out.particle`
 
 #### AddBonds
 
 Compute and display bonds.
 
 ```python
-megane.AddBonds(*, source: Literal["distance", "structure"] = "distance")
+AddBonds(*, source: Literal["distance", "structure"] = "distance")
 ```
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `source` | `str` | `"distance"` | `"distance"` for VDW-based inference, `"structure"` for file-based bonds |
 
-**Inputs:** `particle`
-**Outputs:** `bond`
+**Ports:** `inp.particle`, `out.bond`
 
 #### AddLabels
 
 Generate text labels at atom positions.
 
 ```python
-megane.AddLabels(*, source: Literal["element", "resname", "index"] = "element")
+AddLabels(*, source: Literal["element", "resname", "index"] = "element")
 ```
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `source` | `str` | `"element"` | Label source: `"element"`, `"resname"`, or `"index"` |
 
-**Inputs:** `particle`
-**Outputs:** `label`
+**Ports:** `inp.particle`, `out.label`
 
 #### AddPolyhedra
 
 Generate coordination polyhedra mesh.
 
 ```python
-megane.AddPolyhedra(
+AddPolyhedra(
     *,
     center_elements: list[int],
     ligand_elements: list[int] | None = None,
@@ -466,30 +460,28 @@ megane.AddPolyhedra(
 | `edge_color` | `str` | `"#dddddd"` | Wireframe edge color (hex) |
 | `edge_width` | `float` | `3.0` | Wireframe edge width (px) |
 
-**Inputs:** `particle`
-**Outputs:** `mesh`
+**Ports:** `inp.particle`, `out.mesh`
 
 #### VectorOverlay
 
 Configure per-atom vector visualization (e.g. forces, velocities).
 
 ```python
-megane.VectorOverlay(*, scale: float = 1.0)
+VectorOverlay(*, scale: float = 1.0)
 ```
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `scale` | `float` | `1.0` | Vector arrow length multiplier |
 
-**Inputs:** `vector`
-**Outputs:** `vector`
+**Ports:** `inp.vector`, `out.vector`
 
 #### Viewport
 
 3D rendering output node. All data to be rendered must be explicitly connected to this node.
 
 ```python
-megane.Viewport(*, perspective: bool = False, cell_axes_visible: bool = True)
+Viewport(*, perspective: bool = False, cell_axes_visible: bool = True)
 ```
 
 | Parameter | Type | Default | Description |
@@ -497,33 +489,32 @@ megane.Viewport(*, perspective: bool = False, cell_axes_visible: bool = True)
 | `perspective` | `bool` | `False` | Toggle perspective / orthographic projection |
 | `cell_axes_visible` | `bool` | `True` | Show simulation cell axes with labels |
 
-**Inputs:** `particle`, `bond`, `cell`, `trajectory`, `label`, `mesh`, `vector`
-**Outputs:** —
+**Ports:** `inp.particle`, `inp.bond`, `inp.cell`, `inp.traj`, `inp.label`, `inp.mesh`, `inp.vector`
 
-### Port Resolution
+### Ports
 
-Edges are auto-resolved: `add_edge(source, target)` automatically picks the correct port handles based on node types. For example:
+After `add_node()`, each node exposes two port namespaces:
 
-- `LoadStructure → Filter` connects `particle → in`
-- `Filter → Modify` connects `out → in`
-- `LoadStructure → AddBonds` connects `particle → particle`
-- `AddBonds → Viewport` connects `bond → bond`
+- `node.out.<name>` — output port (pass as first arg to `add_edge`)
+- `node.inp.<name>` — input port (pass as second arg to `add_edge`)
+
+The port name `.traj` maps to the `"trajectory"` wire handle internally. Accessing an undefined port raises `AttributeError` with a helpful message listing available ports.
 
 ### Example: Basic Structure with Bonds
 
 ```python
-import megane
+from megane import Pipeline, LoadStructure, AddBonds, Viewport, MolecularViewer
 
-pipe = megane.Pipeline()
-s = pipe.add_node(megane.LoadStructure("protein.pdb"))
-bonds = pipe.add_node(megane.AddBonds(source="distance"))
-v = pipe.add_node(megane.Viewport())
+pipe = Pipeline()
+s = pipe.add_node(LoadStructure("protein.pdb"))
+bonds = pipe.add_node(AddBonds(source="distance"))
+v = pipe.add_node(Viewport())
 
-pipe.add_edge(s, bonds)
-pipe.add_edge(s, v)
-pipe.add_edge(bonds, v)
+pipe.add_edge(s.out.particle, bonds.inp.particle)
+pipe.add_edge(s.out.particle, v.inp.particle)
+pipe.add_edge(bonds.out.bond, v.inp.bond)
 
-viewer = megane.MolecularViewer()
+viewer = MolecularViewer()
 viewer.set_pipeline(pipe)
 viewer
 ```
@@ -531,22 +522,22 @@ viewer
 ### Example: Filter and Modify
 
 ```python
-import megane
+from megane import Pipeline, LoadStructure, Filter, Modify, AddBonds, Viewport, MolecularViewer
 
-pipe = megane.Pipeline()
-s = pipe.add_node(megane.LoadStructure("protein.pdb"))
-carbons = pipe.add_node(megane.Filter(query="element == 'C'"))
-big = pipe.add_node(megane.Modify(scale=1.5, opacity=0.8))
-bonds = pipe.add_node(megane.AddBonds(source="distance"))
-v = pipe.add_node(megane.Viewport())
+pipe = Pipeline()
+s = pipe.add_node(LoadStructure("protein.pdb"))
+carbons = pipe.add_node(Filter(query="element == 'C'"))
+big = pipe.add_node(Modify(scale=1.5, opacity=0.8))
+bonds = pipe.add_node(AddBonds(source="distance"))
+v = pipe.add_node(Viewport())
 
-pipe.add_edge(s, carbons)
-pipe.add_edge(carbons, big)
-pipe.add_edge(s, bonds)
-pipe.add_edge(big, v)
-pipe.add_edge(bonds, v)
+pipe.add_edge(s.out.particle, carbons.inp.particle)
+pipe.add_edge(carbons.out.particle, big.inp.particle)
+pipe.add_edge(s.out.particle, bonds.inp.particle)
+pipe.add_edge(big.out.particle, v.inp.particle)
+pipe.add_edge(bonds.out.bond, v.inp.bond)
 
-viewer = megane.MolecularViewer()
+viewer = MolecularViewer()
 viewer.set_pipeline(pipe)
 viewer
 ```
@@ -554,21 +545,21 @@ viewer
 ### Example: Trajectory Playback
 
 ```python
-import megane
+from megane import Pipeline, LoadStructure, LoadTrajectory, AddBonds, Viewport, MolecularViewer
 
-pipe = megane.Pipeline()
-s = pipe.add_node(megane.LoadStructure("protein.pdb"))
-t = pipe.add_node(megane.LoadTrajectory(xtc="trajectory.xtc"))
-bonds = pipe.add_node(megane.AddBonds(source="structure"))
-v = pipe.add_node(megane.Viewport())
+pipe = Pipeline()
+s = pipe.add_node(LoadStructure("protein.pdb"))
+t = pipe.add_node(LoadTrajectory(xtc="trajectory.xtc"))
+bonds = pipe.add_node(AddBonds(source="structure"))
+v = pipe.add_node(Viewport())
 
-pipe.add_edge(s, t)
-pipe.add_edge(s, bonds)
-pipe.add_edge(s, v)
-pipe.add_edge(t, v)
-pipe.add_edge(bonds, v)
+pipe.add_edge(s.out.particle, t.inp.particle)
+pipe.add_edge(s.out.particle, bonds.inp.particle)
+pipe.add_edge(s.out.particle, v.inp.particle)
+pipe.add_edge(t.out.traj, v.inp.traj)
+pipe.add_edge(bonds.out.bond, v.inp.bond)
 
-viewer = megane.MolecularViewer()
+viewer = MolecularViewer()
 viewer.set_pipeline(pipe)
 viewer.frame_index = 50  # jump to frame 50
 ```
@@ -576,26 +567,26 @@ viewer.frame_index = 50  # jump to frame 50
 ### Example: Make Solvent Translucent
 
 ```python
-import megane
+from megane import Pipeline, LoadStructure, Filter, Modify, AddBonds, Viewport, MolecularViewer
 
-pipe = megane.Pipeline()
-s = pipe.add_node(megane.LoadStructure("protein.pdb"))
+pipe = Pipeline()
+s = pipe.add_node(LoadStructure("protein.pdb"))
 
 # Filter water molecules and make them translucent
-water = pipe.add_node(megane.Filter(query='resname == "HOH"'))
-transparent = pipe.add_node(megane.Modify(scale=0.5, opacity=0.2))
+water = pipe.add_node(Filter(query='resname == "HOH"'))
+transparent = pipe.add_node(Modify(scale=0.5, opacity=0.2))
 
-bonds = pipe.add_node(megane.AddBonds(source="distance"))
-v = pipe.add_node(megane.Viewport())
+bonds = pipe.add_node(AddBonds(source="distance"))
+v = pipe.add_node(Viewport())
 
-pipe.add_edge(s, water)
-pipe.add_edge(water, transparent)
-pipe.add_edge(s, bonds)
-pipe.add_edge(s, v)           # protein particle + cell
-pipe.add_edge(transparent, v) # translucent water
-pipe.add_edge(bonds, v)
+pipe.add_edge(s.out.particle, water.inp.particle)
+pipe.add_edge(water.out.particle, transparent.inp.particle)
+pipe.add_edge(s.out.particle, bonds.inp.particle)
+pipe.add_edge(s.out.particle, v.inp.particle)       # protein particle + cell
+pipe.add_edge(transparent.out.particle, v.inp.particle)  # translucent water
+pipe.add_edge(bonds.out.bond, v.inp.bond)
 
-viewer = megane.MolecularViewer()
+viewer = MolecularViewer()
 viewer.set_pipeline(pipe)
 viewer
 ```
@@ -603,27 +594,27 @@ viewer
 ### Example: TiO₆ Coordination Polyhedra
 
 ```python
-import megane
+from megane import Pipeline, LoadStructure, AddBonds, AddPolyhedra, Viewport, MolecularViewer
 
-pipe = megane.Pipeline()
-s = pipe.add_node(megane.LoadStructure("SrTiO3_supercell.pdb"))
-bonds = pipe.add_node(megane.AddBonds(source="distance"))
-polyhedra = pipe.add_node(megane.AddPolyhedra(
+pipe = Pipeline()
+s = pipe.add_node(LoadStructure("SrTiO3_supercell.pdb"))
+bonds = pipe.add_node(AddBonds(source="distance"))
+polyhedra = pipe.add_node(AddPolyhedra(
     center_elements=[22],     # Ti
     ligand_elements=[8],      # O
     max_distance=2.5,
     opacity=0.5,
     show_edges=True,
 ))
-v = pipe.add_node(megane.Viewport())
+v = pipe.add_node(Viewport())
 
-pipe.add_edge(s, bonds)
-pipe.add_edge(s, polyhedra)
-pipe.add_edge(s, v)
-pipe.add_edge(bonds, v)
-pipe.add_edge(polyhedra, v)
+pipe.add_edge(s.out.particle, bonds.inp.particle)
+pipe.add_edge(s.out.particle, polyhedra.inp.particle)
+pipe.add_edge(s.out.particle, v.inp.particle)
+pipe.add_edge(bonds.out.bond, v.inp.bond)
+pipe.add_edge(polyhedra.out.mesh, v.inp.mesh)
 
-viewer = megane.MolecularViewer()
+viewer = MolecularViewer()
 viewer.set_pipeline(pipe)
 viewer
 ```
@@ -631,28 +622,28 @@ viewer
 ### Example: DAG Branching (Multiple Filters)
 
 ```python
-import megane
+from megane import Pipeline, LoadStructure, Filter, AddLabels, AddBonds, Viewport, MolecularViewer
 
-pipe = megane.Pipeline()
-s = pipe.add_node(megane.LoadStructure("protein.pdb"))
+pipe = Pipeline()
+s = pipe.add_node(LoadStructure("protein.pdb"))
 
 # Two independent filters from the same source
-carbon = pipe.add_node(megane.Filter(query="element == 'C'"))
-nitrogen = pipe.add_node(megane.Filter(query="element == 'N'"))
-labels = pipe.add_node(megane.AddLabels(source="element"))
-bonds = pipe.add_node(megane.AddBonds(source="distance"))
-v = pipe.add_node(megane.Viewport())
+carbon = pipe.add_node(Filter(query="element == 'C'"))
+nitrogen = pipe.add_node(Filter(query="element == 'N'"))
+labels = pipe.add_node(AddLabels(source="element"))
+bonds = pipe.add_node(AddBonds(source="distance"))
+v = pipe.add_node(Viewport())
 
-pipe.add_edge(s, carbon)
-pipe.add_edge(s, nitrogen)
-pipe.add_edge(s, labels)
-pipe.add_edge(s, bonds)
-pipe.add_edge(carbon, v)
-pipe.add_edge(nitrogen, v)
-pipe.add_edge(labels, v)
-pipe.add_edge(bonds, v)
+pipe.add_edge(s.out.particle, carbon.inp.particle)
+pipe.add_edge(s.out.particle, nitrogen.inp.particle)
+pipe.add_edge(s.out.particle, labels.inp.particle)
+pipe.add_edge(s.out.particle, bonds.inp.particle)
+pipe.add_edge(carbon.out.particle, v.inp.particle)
+pipe.add_edge(nitrogen.out.particle, v.inp.particle)
+pipe.add_edge(labels.out.label, v.inp.label)
+pipe.add_edge(bonds.out.bond, v.inp.bond)
 
-viewer = megane.MolecularViewer()
+viewer = MolecularViewer()
 viewer.set_pipeline(pipe)
 viewer
 ```
@@ -660,18 +651,18 @@ viewer
 ### Example: ASE .traj Trajectory
 
 ```python
-import megane
+from megane import Pipeline, LoadStructure, LoadTrajectory, Viewport, MolecularViewer
 
-pipe = megane.Pipeline()
-s = pipe.add_node(megane.LoadStructure("structure.pdb"))
-t = pipe.add_node(megane.LoadTrajectory(traj="simulation.traj"))
-v = pipe.add_node(megane.Viewport())
+pipe = Pipeline()
+s = pipe.add_node(LoadStructure("structure.pdb"))
+t = pipe.add_node(LoadTrajectory(traj="simulation.traj"))
+v = pipe.add_node(Viewport())
 
-pipe.add_edge(s, t)
-pipe.add_edge(s, v)
-pipe.add_edge(t, v)
+pipe.add_edge(s.out.particle, t.inp.particle)
+pipe.add_edge(s.out.particle, v.inp.particle)
+pipe.add_edge(t.out.traj, v.inp.traj)
 
-viewer = megane.MolecularViewer()
+viewer = MolecularViewer()
 viewer.set_pipeline(pipe)
 viewer
 ```

--- a/examples/pipeline.ipynb
+++ b/examples/pipeline.ipynb
@@ -35,17 +35,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "pipe = megane.Pipeline()\n",
-    "s = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/1crn.pdb\"))\n",
-    "v = pipe.add_node(megane.Viewport())\n",
-    "\n",
-    "pipe.add_edge(s, v)\n",
-    "\n",
-    "viewer = megane.MolecularViewer()\n",
-    "viewer.set_pipeline(pipe)\n",
-    "viewer"
-   ]
+   "source": "pipe = megane.Pipeline()\ns = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/1crn.pdb\"))\nv = pipe.add_node(megane.Viewport())\n\npipe.add_edge(s.out.particle, v.inp.particle)\n\nviewer = megane.MolecularViewer()\nviewer.set_pipeline(pipe)\nviewer"
   },
   {
    "cell_type": "markdown",
@@ -61,20 +51,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "pipe = megane.Pipeline()\n",
-    "s = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/caffeine_water.pdb\"))\n",
-    "bonds = pipe.add_node(megane.AddBonds(source=\"distance\"))\n",
-    "v = pipe.add_node(megane.Viewport())\n",
-    "\n",
-    "pipe.add_edge(s, bonds)\n",
-    "pipe.add_edge(s, v)\n",
-    "pipe.add_edge(bonds, v)\n",
-    "\n",
-    "viewer = megane.MolecularViewer()\n",
-    "viewer.set_pipeline(pipe)\n",
-    "viewer"
-   ]
+   "source": "pipe = megane.Pipeline()\ns = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/caffeine_water.pdb\"))\nbonds = pipe.add_node(megane.AddBonds(source=\"distance\"))\nv = pipe.add_node(megane.Viewport())\n\npipe.add_edge(s.out.particle, bonds.inp.particle)\npipe.add_edge(s.out.particle, v.inp.particle)\npipe.add_edge(bonds.out.bond, v.inp.bond)\n\nviewer = megane.MolecularViewer()\nviewer.set_pipeline(pipe)\nviewer"
   },
   {
    "cell_type": "markdown",
@@ -90,24 +67,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "pipe = megane.Pipeline()\n",
-    "s = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/1crn.pdb\"))\n",
-    "carbons = pipe.add_node(megane.Filter(query=\"element == 'C'\"))\n",
-    "big = pipe.add_node(megane.Modify(scale=1.5, opacity=0.8))\n",
-    "bonds = pipe.add_node(megane.AddBonds(source=\"distance\"))\n",
-    "v = pipe.add_node(megane.Viewport())\n",
-    "\n",
-    "pipe.add_edge(s, carbons)\n",
-    "pipe.add_edge(carbons, big)\n",
-    "pipe.add_edge(s, bonds)\n",
-    "pipe.add_edge(big, v)\n",
-    "pipe.add_edge(bonds, v)\n",
-    "\n",
-    "viewer = megane.MolecularViewer()\n",
-    "viewer.set_pipeline(pipe)\n",
-    "viewer"
-   ]
+   "source": "pipe = megane.Pipeline()\ns = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/1crn.pdb\"))\ncarbons = pipe.add_node(megane.Filter(query=\"element == 'C'\"))\nbig = pipe.add_node(megane.Modify(scale=1.5, opacity=0.8))\nbonds = pipe.add_node(megane.AddBonds(source=\"distance\"))\nv = pipe.add_node(megane.Viewport())\n\npipe.add_edge(s.out.particle, carbons.inp.particle)\npipe.add_edge(carbons.out.particle, big.inp.particle)\npipe.add_edge(s.out.particle, bonds.inp.particle)\npipe.add_edge(big.out.particle, v.inp.particle)\npipe.add_edge(bonds.out.bond, v.inp.bond)\n\nviewer = megane.MolecularViewer()\nviewer.set_pipeline(pipe)\nviewer"
   },
   {
    "cell_type": "markdown",
@@ -123,24 +83,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "pipe = megane.Pipeline()\n",
-    "s = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/caffeine_water.pdb\"))\n",
-    "t = pipe.add_node(megane.LoadTrajectory(xtc=\"../tests/fixtures/caffeine_water_vibration.xtc\"))\n",
-    "bonds = pipe.add_node(megane.AddBonds(source=\"structure\"))\n",
-    "v = pipe.add_node(megane.Viewport())\n",
-    "\n",
-    "pipe.add_edge(s, t)\n",
-    "pipe.add_edge(s, bonds)\n",
-    "pipe.add_edge(s, v)\n",
-    "pipe.add_edge(t, v)\n",
-    "pipe.add_edge(bonds, v)\n",
-    "\n",
-    "viewer = megane.MolecularViewer()\n",
-    "viewer.set_pipeline(pipe)\n",
-    "print(f\"Loaded trajectory: {viewer.total_frames} frames\")\n",
-    "viewer"
-   ]
+   "source": "pipe = megane.Pipeline()\ns = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/caffeine_water.pdb\"))\nt = pipe.add_node(megane.LoadTrajectory(xtc=\"../tests/fixtures/caffeine_water_vibration.xtc\"))\nbonds = pipe.add_node(megane.AddBonds(source=\"structure\"))\nv = pipe.add_node(megane.Viewport())\n\npipe.add_edge(s.out.particle, t.inp.particle)\npipe.add_edge(s.out.particle, bonds.inp.particle)\npipe.add_edge(s.out.particle, v.inp.particle)\npipe.add_edge(t.out.traj, v.inp.traj)\npipe.add_edge(bonds.out.bond, v.inp.bond)\n\nviewer = megane.MolecularViewer()\nviewer.set_pipeline(pipe)\nprint(f\"Loaded trajectory: {viewer.total_frames} frames\")\nviewer"
   },
   {
    "cell_type": "code",
@@ -166,25 +109,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "pipe = megane.Pipeline()\n",
-    "s1 = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/1crn.pdb\"))\n",
-    "s2 = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/caffeine_water.pdb\"))\n",
-    "b1 = pipe.add_node(megane.AddBonds(source=\"distance\"))\n",
-    "b2 = pipe.add_node(megane.AddBonds(source=\"distance\"))\n",
-    "v = pipe.add_node(megane.Viewport())\n",
-    "\n",
-    "pipe.add_edge(s1, b1)\n",
-    "pipe.add_edge(s2, b2)\n",
-    "pipe.add_edge(s1, v)\n",
-    "pipe.add_edge(b1, v)\n",
-    "pipe.add_edge(s2, v)\n",
-    "pipe.add_edge(b2, v)\n",
-    "\n",
-    "viewer = megane.MolecularViewer()\n",
-    "viewer.set_pipeline(pipe)\n",
-    "viewer"
-   ]
+   "source": "pipe = megane.Pipeline()\ns1 = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/1crn.pdb\"))\ns2 = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/caffeine_water.pdb\"))\nb1 = pipe.add_node(megane.AddBonds(source=\"distance\"))\nb2 = pipe.add_node(megane.AddBonds(source=\"distance\"))\nv = pipe.add_node(megane.Viewport())\n\npipe.add_edge(s1.out.particle, b1.inp.particle)\npipe.add_edge(s2.out.particle, b2.inp.particle)\npipe.add_edge(s1.out.particle, v.inp.particle)\npipe.add_edge(b1.out.bond, v.inp.bond)\npipe.add_edge(s2.out.particle, v.inp.particle)\npipe.add_edge(b2.out.bond, v.inp.bond)\n\nviewer = megane.MolecularViewer()\nviewer.set_pipeline(pipe)\nviewer"
   },
   {
    "cell_type": "markdown",
@@ -200,23 +125,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "pipe = megane.Pipeline()\n",
-    "s = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/caffeine_water.pdb\"))\n",
-    "bonds = pipe.add_node(megane.AddBonds(source=\"distance\"))\n",
-    "labels = pipe.add_node(megane.AddLabels(source=\"element\"))\n",
-    "v = pipe.add_node(megane.Viewport())\n",
-    "\n",
-    "pipe.add_edge(s, bonds)\n",
-    "pipe.add_edge(s, labels)\n",
-    "pipe.add_edge(s, v)\n",
-    "pipe.add_edge(bonds, v)\n",
-    "pipe.add_edge(labels, v)\n",
-    "\n",
-    "viewer = megane.MolecularViewer()\n",
-    "viewer.set_pipeline(pipe)\n",
-    "viewer"
-   ]
+   "source": "pipe = megane.Pipeline()\ns = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/caffeine_water.pdb\"))\nbonds = pipe.add_node(megane.AddBonds(source=\"distance\"))\nlabels = pipe.add_node(megane.AddLabels(source=\"element\"))\nv = pipe.add_node(megane.Viewport())\n\npipe.add_edge(s.out.particle, bonds.inp.particle)\npipe.add_edge(s.out.particle, labels.inp.particle)\npipe.add_edge(s.out.particle, v.inp.particle)\npipe.add_edge(bonds.out.bond, v.inp.bond)\npipe.add_edge(labels.out.label, v.inp.label)\n\nviewer = megane.MolecularViewer()\nviewer.set_pipeline(pipe)\nviewer"
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,3 +124,8 @@ replace = '__version__ = "{new_version}"'
 filename = "docs/scripts/prepare-notebooks.py"
 search = 'megane v{current_version}'
 replace = 'megane v{new_version}'
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+]

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -10,7 +10,7 @@ to be rendered.
 
 Example::
 
-    from megane import Pipeline, LoadStructure, Filter, Modify, AddBonds, Viewport
+    from megane import Pipeline, LoadStructure, Filter, Modify, AddBonds, Viewport, MolecularViewer
 
     pipe = Pipeline()
     s = pipe.add_node(LoadStructure("protein.pdb"))
@@ -25,6 +25,7 @@ Example::
     pipe.add_edge(m.out.particle, v.inp.particle)
     pipe.add_edge(b.out.bond, v.inp.bond)
 
+    viewer = MolecularViewer()
     viewer.set_pipeline(pipe)
 """
 
@@ -469,8 +470,15 @@ class Pipeline:
             pipe.add_edge(s.out.particle, f.inp.particle)
             pipe.add_edge(s.out.traj, v.inp.traj)
         """
-        if source._node._id is None or target._node._id is None:
-            raise ValueError("Both nodes must be added to the pipeline before connecting.")
+        if not isinstance(source, NodePort) or not isinstance(target, NodePort):
+            raise TypeError(
+                "add_edge() requires NodePort arguments. "
+                "Use node.out.<name> and node.inp.<name>, "
+                "e.g. pipe.add_edge(s.out.particle, f.inp.particle)."
+            )
+        node_ids = {n._id for n, _ in self._nodes}
+        if source._node._id not in node_ids or target._node._id not in node_ids:
+            raise ValueError("Both nodes must be added to this pipeline before connecting.")
         self._edges.append(
             {
                 "source": source._node._id,

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -66,10 +66,7 @@ class PortNamespace:
         node: PipelineNode = object.__getattribute__(self, "_node")
         if name not in port_map:
             available = ", ".join(sorted(port_map)) or "(none)"
-            raise AttributeError(
-                f"No port {name!r} on {node._node_type!r} node. "
-                f"Available: {available}"
-            )
+            raise AttributeError(f"No port {name!r} on {node._node_type!r} node. Available: {available}")
         return NodePort(node, port_map[name])
 
     def __dir__(self) -> list[str]:

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -1,36 +1,81 @@
 """NetworkX-style pipeline builder for megane molecular viewer.
 
 Nodes are class instances added via ``add_node()``, connections via
-``add_edge()`` with ports auto-resolved from types.  The pipeline
-serializes to the same ``SerializedPipeline`` v3 JSON format used by
-the TypeScript pipeline engine, which remains the source of truth.
+``add_edge()`` with explicit port objects.  The pipeline serializes to
+the same ``SerializedPipeline`` v3 JSON format used by the TypeScript
+pipeline engine, which remains the source of truth.
 
 A ``Viewport`` node must be explicitly added and connected for data
 to be rendered.
 
 Example::
 
-    from megane.pipeline import Pipeline, LoadStructure, Filter, Modify, AddBonds, Viewport
+    from megane import Pipeline, LoadStructure, Filter, Modify, AddBonds, Viewport
 
     pipe = Pipeline()
     s = pipe.add_node(LoadStructure("protein.pdb"))
-    carbons = pipe.add_node(Filter(query="element == 'C'"))
+    f = pipe.add_node(Filter(query="element == 'C'"))
     m = pipe.add_node(Modify(scale=1.3))
-    bonds = pipe.add_node(AddBonds(source="distance"))
+    b = pipe.add_node(AddBonds())
     v = pipe.add_node(Viewport())
 
-    pipe.add_edge(s, carbons)
-    pipe.add_edge(carbons, m)
-    pipe.add_edge(s, bonds)
-    pipe.add_edge(m, v)
-    pipe.add_edge(bonds, v)
+    pipe.add_edge(s.out.particle, f.inp.particle)
+    pipe.add_edge(f.out.particle, m.inp.particle)
+    pipe.add_edge(s.out.particle, b.inp.particle)
+    pipe.add_edge(m.out.particle, v.inp.particle)
+    pipe.add_edge(b.out.bond, v.inp.bond)
 
     viewer.set_pipeline(pipe)
 """
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    pass
+
+# ─── Port Objects ────────────────────────────────────────────────────
+
+
+class NodePort:
+    """A single typed I/O port on a pipeline node.
+
+    Returned by ``node.out.<name>`` and ``node.inp.<name>``.
+    Pass to ``Pipeline.add_edge()`` to connect nodes explicitly.
+    """
+
+    def __init__(self, node: PipelineNode, handle: str) -> None:
+        self._node = node
+        self.handle = handle  # JSON wire name, e.g. "particle", "trajectory", "in"
+
+
+class PortNamespace:
+    """Attribute-access namespace that returns :class:`NodePort` instances.
+
+    Example: ``node.out.particle`` → ``NodePort(node, 'particle')``.
+    """
+
+    def __init__(self, node: PipelineNode, port_map: dict[str, str]) -> None:
+        # Use object.__setattr__ to avoid triggering our own __getattr__.
+        object.__setattr__(self, "_node", node)
+        object.__setattr__(self, "_port_map", port_map)
+
+    def __getattr__(self, name: str) -> NodePort:
+        port_map: dict[str, str] = object.__getattribute__(self, "_port_map")
+        node: PipelineNode = object.__getattribute__(self, "_node")
+        if name not in port_map:
+            available = ", ".join(sorted(port_map)) or "(none)"
+            raise AttributeError(
+                f"No port {name!r} on {node._node_type!r} node. "
+                f"Available: {available}"
+            )
+        return NodePort(node, port_map[name])
+
+    def __dir__(self) -> list[str]:
+        port_map: dict[str, str] = object.__getattribute__(self, "_port_map")
+        return sorted(port_map)
+
 
 # ─── Node Classes ───────────────────────────────────────────────────
 
@@ -39,18 +84,29 @@ class PipelineNode:
     """Base class for all pipeline node types."""
 
     _node_type: str = ""
+    _out_ports: dict[str, str] = {}
+    _inp_ports: dict[str, str] = {}
 
     def __init__(self) -> None:
         self._id: str | None = None
+        self.out = PortNamespace(self, self.__class__._out_ports)
+        self.inp = PortNamespace(self, self.__class__._inp_ports)
 
 
 class LoadStructure(PipelineNode):
     """Load a molecular structure from a file.
 
     Supported formats: PDB, GRO, XYZ, MOL, LAMMPS data.
+
+    Ports:
+        out.particle — atom data
+        out.traj     — trajectory channel
+        out.cell     — simulation cell
     """
 
     _node_type = "load_structure"
+    _out_ports = {"particle": "particle", "traj": "trajectory", "cell": "cell"}
+    _inp_ports: dict[str, str] = {}
 
     def __init__(self, path: str) -> None:
         super().__init__()
@@ -60,15 +116,22 @@ class LoadStructure(PipelineNode):
 class LoadTrajectory(PipelineNode):
     """Load an external trajectory file (XTC or ASE .traj).
 
-    Requires connection from a ``LoadStructure`` node.
+    Requires connection from a ``LoadStructure`` node via
+    ``pipe.add_edge(s.out.particle, t.inp.particle)``.
     Frames are loaded lazily when ``frame_index`` changes.
 
     Args:
         xtc: Path to XTC trajectory file.
         traj: Path to ASE .traj file.
+
+    Ports:
+        inp.particle — atom topology source
+        out.traj     — trajectory frames
     """
 
     _node_type = "load_trajectory"
+    _out_ports = {"traj": "trajectory"}
+    _inp_ports = {"particle": "particle"}
 
     def __init__(
         self,
@@ -86,18 +149,37 @@ class Streaming(PipelineNode):
 
     Connects to the server via WebSocket and provides particle,
     trajectory, and cell data from the streaming connection.
+
+    Ports:
+        out.particle — atom data
+        out.bond     — bond data
+        out.traj     — trajectory channel
+        out.cell     — simulation cell
     """
 
     _node_type = "streaming"
+    _out_ports = {
+        "particle": "particle",
+        "bond": "bond",
+        "traj": "trajectory",
+        "cell": "cell",
+    }
+    _inp_ports: dict[str, str] = {}
 
     def __init__(self) -> None:
         super().__init__()
 
 
 class LoadVector(PipelineNode):
-    """Load per-atom vector data from a file."""
+    """Load per-atom vector data from a file.
+
+    Ports:
+        out.vector — vector field
+    """
 
     _node_type = "load_vector"
+    _out_ports = {"vector": "vector"}
+    _inp_ports: dict[str, str] = {}
 
     def __init__(self, path: str) -> None:
         super().__init__()
@@ -113,9 +195,15 @@ class Filter(PipelineNode):
         element == 'O' and x > 5.0
         resname == 'ALA'
         index >= 100 and index < 200
+
+    Ports:
+        inp.particle — atom data in
+        out.particle — filtered atom data
     """
 
     _node_type = "filter"
+    _out_ports = {"particle": "out"}
+    _inp_ports = {"particle": "in"}
 
     def __init__(self, *, query: str) -> None:
         super().__init__()
@@ -123,9 +211,16 @@ class Filter(PipelineNode):
 
 
 class Modify(PipelineNode):
-    """Modify per-atom visual properties (scale, opacity)."""
+    """Modify per-atom visual properties (scale, opacity).
+
+    Ports:
+        inp.particle — atom data in
+        out.particle — modified atom data
+    """
 
     _node_type = "modify"
+    _out_ports = {"particle": "out"}
+    _inp_ports = {"particle": "in"}
 
     def __init__(
         self,
@@ -144,9 +239,15 @@ class AddBonds(PipelineNode):
     Args:
         source: ``"distance"`` for VDW-based inference,
                 ``"structure"`` to use bonds from the file.
+
+    Ports:
+        inp.particle — atom data
+        out.bond     — computed bonds
     """
 
     _node_type = "add_bond"
+    _out_ports = {"bond": "bond"}
+    _inp_ports = {"particle": "particle"}
 
     def __init__(
         self,
@@ -162,9 +263,15 @@ class AddLabels(PipelineNode):
 
     Args:
         source: ``"element"``, ``"resname"``, or ``"index"``.
+
+    Ports:
+        inp.particle — atom data
+        out.label    — label data
     """
 
     _node_type = "label_generator"
+    _out_ports = {"label": "label"}
+    _inp_ports = {"particle": "particle"}
 
     def __init__(
         self,
@@ -176,9 +283,16 @@ class AddLabels(PipelineNode):
 
 
 class AddPolyhedra(PipelineNode):
-    """Generate coordination polyhedra mesh."""
+    """Generate coordination polyhedra mesh.
+
+    Ports:
+        inp.particle — atom data
+        out.mesh     — polyhedra mesh
+    """
 
     _node_type = "polyhedron_generator"
+    _out_ports = {"mesh": "mesh"}
+    _inp_ports = {"particle": "particle"}
 
     def __init__(
         self,
@@ -202,9 +316,16 @@ class AddPolyhedra(PipelineNode):
 
 
 class VectorOverlay(PipelineNode):
-    """Configure per-atom vector visualization (e.g. forces)."""
+    """Configure per-atom vector visualization (e.g. forces).
+
+    Ports:
+        inp.vector — vector field in
+        out.vector — configured vector field
+    """
 
     _node_type = "vector_overlay"
+    _out_ports = {"vector": "vector"}
+    _inp_ports = {"vector": "vector"}
 
     def __init__(self, *, scale: float = 1.0) -> None:
         super().__init__()
@@ -215,9 +336,28 @@ class Viewport(PipelineNode):
     """3D rendering output node.
 
     All data to be rendered must be explicitly connected to this node.
+
+    Ports:
+        inp.particle — atom data
+        inp.bond     — bond data
+        inp.cell     — simulation cell
+        inp.traj     — trajectory frames
+        inp.label    — text labels
+        inp.mesh     — polyhedra mesh
+        inp.vector   — vector field
     """
 
     _node_type = "viewport"
+    _out_ports: dict[str, str] = {}
+    _inp_ports = {
+        "particle": "particle",
+        "bond": "bond",
+        "cell": "cell",
+        "traj": "trajectory",
+        "label": "label",
+        "mesh": "mesh",
+        "vector": "vector",
+    }
 
     def __init__(
         self,
@@ -228,65 +368,6 @@ class Viewport(PipelineNode):
         super().__init__()
         self.perspective = perspective
         self.cell_axes_visible = cell_axes_visible
-
-
-# ─── Port Resolution ────────────────────────────────────────────────
-
-# target_node_type → (default source_handle, target_handle)
-_TARGET_PORT_MAP: dict[str, tuple[str, str]] = {
-    "load_trajectory": ("particle", "particle"),
-    "filter": ("particle", "in"),
-    "modify": ("particle", "in"),
-    "add_bond": ("particle", "particle"),
-    "label_generator": ("particle", "particle"),
-    "polyhedron_generator": ("particle", "particle"),
-    "vector_overlay": ("vector", "vector"),
-    "viewport": ("particle", "particle"),  # fallback; actual handle varies
-}
-
-# source_node_type → default output handle
-_SOURCE_OUTPUT_MAP: dict[str, str] = {
-    "filter": "out",
-    "modify": "out",
-    "load_vector": "vector",
-    "vector_overlay": "vector",
-    "add_bond": "bond",
-    "label_generator": "label",
-    "polyhedron_generator": "mesh",
-}
-
-
-def _resolve_ports(
-    source: PipelineNode,
-    target: PipelineNode,
-) -> tuple[str, str]:
-    """Resolve source and target port handles from node types."""
-    # Source handle: use the source node's known output, or infer
-    # from what the target expects.
-    source_handle = _SOURCE_OUTPUT_MAP.get(source._node_type)
-    if source_handle is None:
-        # LoadStructure or other multi-output node: use what the
-        # target expects as its input type.
-        source_handle = _TARGET_PORT_MAP.get(target._node_type, ("particle", "particle"))[0]
-
-    # For viewport targets, the target handle matches the source output type.
-    if isinstance(target, Viewport):
-        # Map source output handles to viewport input handles.
-        _viewport_handle = {
-            "particle": "particle",
-            "out": "particle",
-            "bond": "bond",
-            "cell": "cell",
-            "trajectory": "trajectory",
-            "label": "label",
-            "mesh": "mesh",
-            "vector": "vector",
-        }
-        target_handle = _viewport_handle.get(source_handle, "particle")
-    else:
-        target_handle = _TARGET_PORT_MAP.get(target._node_type, ("particle", "particle"))[1]
-
-    return source_handle, target_handle
 
 
 # ─── Pipeline ───────────────────────────────────────────────────────
@@ -338,6 +419,15 @@ class Pipeline:
     Build a DAG of processing nodes and serialize to the
     ``SerializedPipeline`` v3 JSON format understood by the
     TypeScript pipeline engine.
+
+    Example::
+
+        from megane import Pipeline, LoadStructure, Viewport
+
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure("protein.pdb"))
+        v = pipe.add_node(Viewport())
+        pipe.add_edge(s.out.particle, v.inp.particle)
     """
 
     def __init__(self) -> None:
@@ -353,8 +443,11 @@ class Pipeline:
     def add_node(self, node: PipelineNode) -> PipelineNode:
         """Add a node to the pipeline.
 
-        Returns the same node instance so it can be used in
-        ``add_edge()`` calls.
+        Returns the same node instance so its ports can be used in
+        ``add_edge()`` calls::
+
+            s = pipe.add_node(LoadStructure("protein.pdb"))
+            pipe.add_edge(s.out.particle, ...)
         """
         self._counter += 1
         node._id = f"{node._node_type}-{self._counter}"
@@ -369,29 +462,31 @@ class Pipeline:
 
     def add_edge(
         self,
-        source: PipelineNode,
-        target: PipelineNode,
+        source: NodePort,
+        target: NodePort,
     ) -> None:
-        """Connect *source* → *target*.
+        """Connect *source* port to *target* port.
 
-        Port handles are auto-resolved from the node types.
+        Both ports must belong to nodes already added to this pipeline::
+
+            pipe.add_edge(s.out.particle, f.inp.particle)
+            pipe.add_edge(s.out.traj, v.inp.traj)
         """
-        if source._id is None or target._id is None:
+        if source._node._id is None or target._node._id is None:
             raise ValueError("Both nodes must be added to the pipeline before connecting.")
-        source_handle, target_handle = _resolve_ports(source, target)
         self._edges.append(
             {
-                "source": source._id,
-                "target": target._id,
-                "sourceHandle": source_handle,
-                "targetHandle": target_handle,
+                "source": source._node._id,
+                "target": target._node._id,
+                "sourceHandle": source.handle,
+                "targetHandle": target.handle,
             }
         )
 
         # Trigger lazy trajectory loading when connecting
         # LoadStructure → LoadTrajectory.
-        if isinstance(target, LoadTrajectory) and isinstance(source, LoadStructure):
-            self._load_trajectory_data(target, source)
+        if isinstance(target._node, LoadTrajectory) and isinstance(source._node, LoadStructure):
+            self._load_trajectory_data(target._node, source._node)
 
     # ── Serialization ───────────────────────────────────────
 

--- a/tests/notebooks/test_pipeline.ipynb
+++ b/tests/notebooks/test_pipeline.ipynb
@@ -35,7 +35,7 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "source": "pipe = Pipeline()\ns = pipe.add_node(LoadStructure(str(FIXTURES / \"1crn.pdb\")))\nf = pipe.add_node(Filter(query=\"element == 'C'\"))\nm = pipe.add_node(Modify(scale=1.3))\nbonds = pipe.add_node(AddBonds(source=\"distance\"))\nv = pipe.add_node(Viewport())\n\npipe.add_edge(s, f)\npipe.add_edge(f, m)\npipe.add_edge(s, bonds)\npipe.add_edge(m, v)\npipe.add_edge(bonds, v)\n\nd = pipe.to_dict()\nassert d[\"version\"] == 3, f\"Expected version 3, got {d['version']}\"\nnode_types = [n[\"type\"] for n in d[\"nodes\"]]\nassert \"load_structure\" in node_types\nassert \"filter\" in node_types\nassert \"modify\" in node_types\nassert \"add_bond\" in node_types\nassert \"viewport\" in node_types\nprint(f\"Pipeline nodes: {node_types}\")\nprint(f\"Edges: {len(d['edges'])}\")",
+   "source": "pipe = Pipeline()\ns = pipe.add_node(LoadStructure(str(FIXTURES / \"1crn.pdb\")))\nf = pipe.add_node(Filter(query=\"element == 'C'\"))\nm = pipe.add_node(Modify(scale=1.3))\nbonds = pipe.add_node(AddBonds(source=\"distance\"))\nv = pipe.add_node(Viewport())\n\npipe.add_edge(s.out.particle, f.inp.particle)\npipe.add_edge(f.out.particle, m.inp.particle)\npipe.add_edge(s.out.particle, bonds.inp.particle)\npipe.add_edge(m.out.particle, v.inp.particle)\npipe.add_edge(bonds.out.bond, v.inp.bond)\n\nd = pipe.to_dict()\nassert d[\"version\"] == 3, f\"Expected version 3, got {d['version']}\"\nnode_types = [n[\"type\"] for n in d[\"nodes\"]]\nassert \"load_structure\" in node_types\nassert \"filter\" in node_types\nassert \"modify\" in node_types\nassert \"add_bond\" in node_types\nassert \"viewport\" in node_types\nprint(f\"Pipeline nodes: {node_types}\")\nprint(f\"Edges: {len(d['edges'])}\")",
    "outputs": [],
    "execution_count": null
   },
@@ -73,7 +73,7 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "source": "pipe2 = Pipeline()\ns2 = pipe2.add_node(LoadStructure(str(FIXTURES / \"1crn.pdb\")))\nlabels = pipe2.add_node(AddLabels(source=\"element\"))\npoly = pipe2.add_node(AddPolyhedra(center_elements=[8]))\nv2_node = pipe2.add_node(Viewport())\n\npipe2.add_edge(s2, labels)\npipe2.add_edge(s2, poly)\npipe2.add_edge(s2, v2_node)\npipe2.add_edge(labels, v2_node)\npipe2.add_edge(poly, v2_node)\n\nd2 = pipe2.to_dict()\nnode_types2 = [n[\"type\"] for n in d2[\"nodes\"]]\nassert \"label_generator\" in node_types2\nassert \"polyhedron_generator\" in node_types2\nprint(f\"Labels + Polyhedra pipeline: {node_types2}\")\n\nv2 = megane.MolecularViewer()\nv2.set_pipeline(pipe2)\nv2",
+   "source": "pipe2 = Pipeline()\ns2 = pipe2.add_node(LoadStructure(str(FIXTURES / \"1crn.pdb\")))\nlabels = pipe2.add_node(AddLabels(source=\"element\"))\npoly = pipe2.add_node(AddPolyhedra(center_elements=[8]))\nv2_node = pipe2.add_node(Viewport())\n\npipe2.add_edge(s2.out.particle, labels.inp.particle)\npipe2.add_edge(s2.out.particle, poly.inp.particle)\npipe2.add_edge(s2.out.particle, v2_node.inp.particle)\npipe2.add_edge(labels.out.label, v2_node.inp.label)\npipe2.add_edge(poly.out.mesh, v2_node.inp.mesh)\n\nd2 = pipe2.to_dict()\nnode_types2 = [n[\"type\"] for n in d2[\"nodes\"]]\nassert \"label_generator\" in node_types2\nassert \"polyhedron_generator\" in node_types2\nprint(f\"Labels + Polyhedra pipeline: {node_types2}\")\n\nv2 = megane.MolecularViewer()\nv2.set_pipeline(pipe2)\nv2",
    "outputs": [],
    "execution_count": null
   },
@@ -87,7 +87,7 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "source": "pipe3 = Pipeline()\ns3 = pipe3.add_node(LoadStructure(str(FIXTURES / \"caffeine_water.pdb\")))\nt3 = pipe3.add_node(LoadTrajectory(xtc=str(FIXTURES / \"caffeine_water_vibration.xtc\")))\nv3_node = pipe3.add_node(Viewport())\npipe3.add_edge(s3, t3)\npipe3.add_edge(s3, v3_node)\npipe3.add_edge(t3, v3_node)\n\nassert len(pipe3._trajectories) > 0, \"No trajectories loaded\"\nprint(f\"Trajectories: {len(pipe3._trajectories)}\")\n\nv3 = megane.MolecularViewer()\nv3.set_pipeline(pipe3)\nassert v3.total_frames > 0, f\"Expected frames > 0, got {v3.total_frames}\"\nprint(f\"Total frames: {v3.total_frames}\")\nv3",
+   "source": "pipe3 = Pipeline()\ns3 = pipe3.add_node(LoadStructure(str(FIXTURES / \"caffeine_water.pdb\")))\nt3 = pipe3.add_node(LoadTrajectory(xtc=str(FIXTURES / \"caffeine_water_vibration.xtc\")))\nv3_node = pipe3.add_node(Viewport())\npipe3.add_edge(s3.out.particle, t3.inp.particle)\npipe3.add_edge(s3.out.particle, v3_node.inp.particle)\npipe3.add_edge(t3.out.traj, v3_node.inp.traj)\n\nassert len(pipe3._trajectories) > 0, \"No trajectories loaded\"\nprint(f\"Trajectories: {len(pipe3._trajectories)}\")\n\nv3 = megane.MolecularViewer()\nv3.set_pipeline(pipe3)\nassert v3.total_frames > 0, f\"Expected frames > 0, got {v3.total_frames}\"\nprint(f\"Total frames: {v3.total_frames}\")\nv3",
    "outputs": [],
    "execution_count": null
   },
@@ -101,7 +101,7 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "source": "pipe4 = Pipeline()\ns4 = pipe4.add_node(LoadStructure(str(FIXTURES / \"1crn.pdb\")))\nvec = pipe4.add_node(LoadVector(str(FIXTURES / \"demo_vectors.vec\")))\noverlay = pipe4.add_node(VectorOverlay(scale=2.0))\nv4_node = pipe4.add_node(Viewport())\n\npipe4.add_edge(vec, overlay)\npipe4.add_edge(s4, v4_node)\npipe4.add_edge(overlay, v4_node)\n\nd4 = pipe4.to_dict()\nnode_types4 = [n[\"type\"] for n in d4[\"nodes\"]]\nassert \"load_vector\" in node_types4\nassert \"vector_overlay\" in node_types4\nprint(f\"Vector pipeline: {node_types4}\")",
+   "source": "pipe4 = Pipeline()\ns4 = pipe4.add_node(LoadStructure(str(FIXTURES / \"1crn.pdb\")))\nvec = pipe4.add_node(LoadVector(str(FIXTURES / \"demo_vectors.vec\")))\noverlay = pipe4.add_node(VectorOverlay(scale=2.0))\nv4_node = pipe4.add_node(Viewport())\n\npipe4.add_edge(vec.out.vector, overlay.inp.vector)\npipe4.add_edge(s4.out.particle, v4_node.inp.particle)\npipe4.add_edge(overlay.out.vector, v4_node.inp.vector)\n\nd4 = pipe4.to_dict()\nnode_types4 = [n[\"type\"] for n in d4[\"nodes\"]]\nassert \"load_vector\" in node_types4\nassert \"vector_overlay\" in node_types4\nprint(f\"Vector pipeline: {node_types4}\")",
    "outputs": [],
    "execution_count": null
   }

--- a/tests/notebooks/test_render_setup.ipynb
+++ b/tests/notebooks/test_render_setup.ipynb
@@ -1,148 +1,102 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 5,
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    }
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Render Setup Test\n",
+    "\n",
+    "Verifies that the viewer state is correctly configured for rendering:\n",
+    "pipeline data, binary protocol, and frame updates.\n",
+    "\n",
+    "Actual image/video rendering happens in the browser (Three.js);\n",
+    "this notebook tests the Python-side prerequisites."
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Render Setup Test\n",
-        "\n",
-        "Verifies that the viewer state is correctly configured for rendering:\n",
-        "pipeline data, binary protocol, and frame updates.\n",
-        "\n",
-        "Actual image/video rendering happens in the browser (Three.js);\n",
-        "this notebook tests the Python-side prerequisites."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "import json\n",
-        "import pathlib\n",
-        "\n",
-        "import megane\n",
-        "from megane.pipeline import (\n",
-        "    AddBonds,\n",
-        "    AddLabels,\n",
-        "    LoadStructure,\n",
-        "    LoadTrajectory,\n",
-        "    Pipeline,\n",
-        ")\n",
-        "\n",
-        "FIXTURES = (pathlib.Path(\".\").resolve().parent / \"fixtures\")\n",
-        "assert FIXTURES.exists()\n",
-        "print(f\"megane v{megane.__version__}\")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Viewer state ready for snapshot rendering"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "pipe = Pipeline()\n",
-        "s = pipe.add_node(LoadStructure(str(FIXTURES / \"1crn.pdb\")))\n",
-        "bonds = pipe.add_node(AddBonds(source=\"distance\"))\n",
-        "labels = pipe.add_node(AddLabels(source=\"element\"))\n",
-        "pipe.add_edge(s, bonds)\n",
-        "pipe.add_edge(s, labels)\n",
-        "\n",
-        "viewer = megane.MolecularViewer()\n",
-        "viewer.set_pipeline(pipe)\n",
-        "\n",
-        "# Verify pipeline is active\n",
-        "assert viewer._pipeline_enabled is True\n",
-        "\n",
-        "# Verify pipeline JSON is valid\n",
-        "config = json.loads(viewer._pipeline_json)\n",
-        "assert config[\"version\"] == 3\n",
-        "print(f\"Pipeline config: {len(config['nodes'])} nodes, {len(config['edges'])} edges\")\n",
-        "\n",
-        "# Verify node snapshot data is populated\n",
-        "assert len(viewer._node_snapshots_data) > 0\n",
-        "print(f\"Node snapshots: {len(viewer._node_snapshots_data)} entries\")\n",
-        "\n",
-        "viewer"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Frame data updates for animation rendering"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "pipe_traj = Pipeline()\n",
-        "st = pipe_traj.add_node(LoadStructure(str(FIXTURES / \"caffeine_water.pdb\")))\n",
-        "traj = pipe_traj.add_node(LoadTrajectory(xtc=str(FIXTURES / \"caffeine_water_vibration.xtc\")))\n",
-        "pipe_traj.add_edge(st, traj)\n",
-        "\n",
-        "v_traj = megane.MolecularViewer()\n",
-        "v_traj.set_pipeline(pipe_traj)\n",
-        "\n",
-        "assert v_traj.total_frames > 1, f\"Need multiple frames, got {v_traj.total_frames}\"\n",
-        "print(f\"Total frames: {v_traj.total_frames}\")\n",
-        "\n",
-        "# Iterate frames and verify frame data changes\n",
-        "frame_data_samples = {}\n",
-        "for i in [0, 5, 10]:\n",
-        "    v_traj.frame_index = i\n",
-        "    frame_data_samples[i] = v_traj._frame_data\n",
-        "\n",
-        "assert frame_data_samples[0] != frame_data_samples[5], \"Frame data did not change between frame 0 and 5\"\n",
-        "assert frame_data_samples[5] != frame_data_samples[10], \"Frame data did not change between frame 5 and 10\"\n",
-        "print(\"Frame data updates correctly across frames\")\n",
-        "v_traj"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Binary protocol verification"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "# Verify MEGN magic bytes in node snapshot data\n",
-        "for node_id, data in viewer._node_snapshots_data.items():\n",
-        "    assert data[:4] == b\"MEGN\", f\"Node {node_id}: expected MEGN magic, got {data[:4]}\"\n",
-        "    print(f\"Node {node_id}: MEGN header OK, {len(data)} bytes\")\n",
-        "\n",
-        "# Verify frame data also has MEGN header\n",
-        "assert v_traj._frame_data[:4] == b\"MEGN\", f\"Frame data: expected MEGN magic, got {v_traj._frame_data[:4]}\"\n",
-        "print(f\"Frame data: MEGN header OK, {len(v_traj._frame_data)} bytes\")\n",
-        "\n",
-        "print(\"\\nAll binary protocol checks passed\")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    }
-  ]
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import json\n",
+    "import pathlib\n",
+    "\n",
+    "import megane\n",
+    "from megane.pipeline import (\n",
+    "    AddBonds,\n",
+    "    AddLabels,\n",
+    "    LoadStructure,\n",
+    "    LoadTrajectory,\n",
+    "    Pipeline,\n",
+    ")\n",
+    "\n",
+    "FIXTURES = (pathlib.Path(\".\").resolve().parent / \"fixtures\")\n",
+    "assert FIXTURES.exists()\n",
+    "print(f\"megane v{megane.__version__}\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Viewer state ready for snapshot rendering"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "pipe = Pipeline()\ns = pipe.add_node(LoadStructure(str(FIXTURES / \"1crn.pdb\")))\nbonds = pipe.add_node(AddBonds(source=\"distance\"))\nlabels = pipe.add_node(AddLabels(source=\"element\"))\npipe.add_edge(s.out.particle, bonds.inp.particle)\npipe.add_edge(s.out.particle, labels.inp.particle)\n\nviewer = megane.MolecularViewer()\nviewer.set_pipeline(pipe)\n\n# Verify pipeline is active\nassert viewer._pipeline_enabled is True\n\n# Verify pipeline JSON is valid\nconfig = json.loads(viewer._pipeline_json)\nassert config[\"version\"] == 3\nprint(f\"Pipeline config: {len(config['nodes'])} nodes, {len(config['edges'])} edges\")\n\n# Verify node snapshot data is populated\nassert len(viewer._node_snapshots_data) > 0\nprint(f\"Node snapshots: {len(viewer._node_snapshots_data)} entries\")\n\nviewer",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Frame data updates for animation rendering"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "pipe_traj = Pipeline()\nst = pipe_traj.add_node(LoadStructure(str(FIXTURES / \"caffeine_water.pdb\")))\ntraj = pipe_traj.add_node(LoadTrajectory(xtc=str(FIXTURES / \"caffeine_water_vibration.xtc\")))\npipe_traj.add_edge(st.out.particle, traj.inp.particle)\n\nv_traj = megane.MolecularViewer()\nv_traj.set_pipeline(pipe_traj)\n\nassert v_traj.total_frames > 1, f\"Need multiple frames, got {v_traj.total_frames}\"\nprint(f\"Total frames: {v_traj.total_frames}\")\n\n# Iterate frames and verify frame data changes\nframe_data_samples = {}\nfor i in [0, 5, 10]:\n    v_traj.frame_index = i\n    frame_data_samples[i] = v_traj._frame_data\n\nassert frame_data_samples[0] != frame_data_samples[5], \"Frame data did not change between frame 0 and 5\"\nassert frame_data_samples[5] != frame_data_samples[10], \"Frame data did not change between frame 5 and 10\"\nprint(\"Frame data updates correctly across frames\")\nv_traj",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Binary protocol verification"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Verify MEGN magic bytes in node snapshot data\n",
+    "for node_id, data in viewer._node_snapshots_data.items():\n",
+    "    assert data[:4] == b\"MEGN\", f\"Node {node_id}: expected MEGN magic, got {data[:4]}\"\n",
+    "    print(f\"Node {node_id}: MEGN header OK, {len(data)} bytes\")\n",
+    "\n",
+    "# Verify frame data also has MEGN header\n",
+    "assert v_traj._frame_data[:4] == b\"MEGN\", f\"Frame data: expected MEGN magic, got {v_traj._frame_data[:4]}\"\n",
+    "print(f\"Frame data: MEGN header OK, {len(v_traj._frame_data)} bytes\")\n",
+    "\n",
+    "print(\"\\nAll binary protocol checks passed\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ]
 }

--- a/tests/python/test_demo_code.py
+++ b/tests/python/test_demo_code.py
@@ -127,7 +127,7 @@ def test_pipeline_load_structure():
     pipe = megane.Pipeline()
     s = pipe.add_node(megane.LoadStructure(str(FIXTURES / "1crn.pdb")))
     v = pipe.add_node(megane.Viewport())
-    pipe.add_edge(s, v)
+    pipe.add_edge(s.out.particle, v.inp.particle)
 
     viewer = megane.MolecularViewer()
     viewer.set_pipeline(pipe)
@@ -144,9 +144,9 @@ def test_pipeline_with_trajectory():
         xtc=str(FIXTURES / "caffeine_water_vibration.xtc"),
     ))
     v = pipe.add_node(megane.Viewport())
-    pipe.add_edge(s, t)
-    pipe.add_edge(s, v)
-    pipe.add_edge(t, v)
+    pipe.add_edge(s.out.particle, t.inp.particle)
+    pipe.add_edge(s.out.particle, v.inp.particle)
+    pipe.add_edge(t.out.traj, v.inp.traj)
 
     viewer = megane.MolecularViewer()
     viewer.set_pipeline(pipe)

--- a/tests/python/test_pipeline.py
+++ b/tests/python/test_pipeline.py
@@ -13,7 +13,9 @@ from megane.pipeline import (
     LoadTrajectory,
     LoadVector,
     Modify,
+    NodePort,
     Pipeline,
+    PortNamespace,
     VectorOverlay,
     Viewport,
 )
@@ -88,6 +90,79 @@ class TestNodeClasses:
         assert n._node_type == "load_trajectory"
 
 
+class TestPortObjects:
+    """NodePort and PortNamespace work correctly."""
+
+    def test_node_has_out_and_inp(self):
+        n = LoadStructure("test.pdb")
+        assert isinstance(n.out, PortNamespace)
+        assert isinstance(n.inp, PortNamespace)
+
+    def test_load_structure_out_ports(self):
+        n = LoadStructure("test.pdb")
+        p = n.out.particle
+        assert isinstance(p, NodePort)
+        assert p._node is n
+        assert p.handle == "particle"
+
+    def test_load_structure_out_traj(self):
+        n = LoadStructure("test.pdb")
+        p = n.out.traj
+        assert p.handle == "trajectory"
+
+    def test_load_structure_out_cell(self):
+        n = LoadStructure("test.pdb")
+        p = n.out.cell
+        assert p.handle == "cell"
+
+    def test_filter_inp_particle(self):
+        n = Filter(query="element == 'C'")
+        p = n.inp.particle
+        assert p.handle == "in"
+
+    def test_filter_out_particle(self):
+        n = Filter(query="element == 'C'")
+        p = n.out.particle
+        assert p.handle == "out"
+
+    def test_viewport_inp_traj(self):
+        v = Viewport()
+        p = v.inp.traj
+        assert p.handle == "trajectory"
+
+    def test_viewport_inp_bond(self):
+        v = Viewport()
+        p = v.inp.bond
+        assert p.handle == "bond"
+
+    def test_invalid_port_raises_attribute_error(self):
+        n = LoadStructure("test.pdb")
+        with pytest.raises(AttributeError, match="No port"):
+            _ = n.out.nonexistent
+
+    def test_invalid_inp_port_raises_attribute_error(self):
+        n = Viewport()
+        with pytest.raises(AttributeError, match="No port"):
+            _ = n.inp.nonexistent
+
+    def test_load_structure_has_no_inp_ports(self):
+        n = LoadStructure("test.pdb")
+        with pytest.raises(AttributeError):
+            _ = n.inp.particle
+
+    def test_viewport_has_no_out_ports(self):
+        v = Viewport()
+        with pytest.raises(AttributeError):
+            _ = v.out.particle
+
+    def test_port_dir_lists_available(self):
+        n = LoadStructure("test.pdb")
+        ports = dir(n.out)
+        assert "particle" in ports
+        assert "traj" in ports
+        assert "cell" in ports
+
+
 class TestPipelineAddNode:
     """Pipeline.add_node() assigns IDs and stores nodes."""
 
@@ -111,13 +186,13 @@ class TestPipelineAddNode:
 
 
 class TestPipelineAddEdge:
-    """Pipeline.add_edge() creates edges with correct port resolution."""
+    """Pipeline.add_edge() creates edges with correct port handles."""
 
     def test_structure_to_filter(self):
         pipe = Pipeline()
         s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
         f = pipe.add_node(Filter(query="element == 'C'"))
-        pipe.add_edge(s, f)
+        pipe.add_edge(s.out.particle, f.inp.particle)
 
         assert len(pipe._edges) == 1
         edge = pipe._edges[0]
@@ -131,8 +206,8 @@ class TestPipelineAddEdge:
         s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
         f = pipe.add_node(Filter(query="element == 'C'"))
         m = pipe.add_node(Modify(scale=1.3))
-        pipe.add_edge(s, f)
-        pipe.add_edge(f, m)
+        pipe.add_edge(s.out.particle, f.inp.particle)
+        pipe.add_edge(f.out.particle, m.inp.particle)
 
         edge = pipe._edges[1]
         assert edge["sourceHandle"] == "out"
@@ -142,7 +217,7 @@ class TestPipelineAddEdge:
         pipe = Pipeline()
         s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
         b = pipe.add_node(AddBonds(source="distance"))
-        pipe.add_edge(s, b)
+        pipe.add_edge(s.out.particle, b.inp.particle)
 
         edge = pipe._edges[0]
         assert edge["sourceHandle"] == "particle"
@@ -152,18 +227,54 @@ class TestPipelineAddEdge:
         pipe = Pipeline()
         s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
         lbl = pipe.add_node(AddLabels(source="element"))
-        pipe.add_edge(s, lbl)
+        pipe.add_edge(s.out.particle, lbl.inp.particle)
 
         edge = pipe._edges[0]
         assert edge["sourceHandle"] == "particle"
         assert edge["targetHandle"] == "particle"
 
+    def test_structure_to_viewport_particle(self):
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        v = pipe.add_node(Viewport())
+        pipe.add_edge(s.out.particle, v.inp.particle)
+
+        edge = pipe._edges[0]
+        assert edge["sourceHandle"] == "particle"
+        assert edge["targetHandle"] == "particle"
+
+    def test_add_bonds_to_viewport_bond(self):
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        b = pipe.add_node(AddBonds())
+        v = pipe.add_node(Viewport())
+        pipe.add_edge(s.out.particle, b.inp.particle)
+        pipe.add_edge(b.out.bond, v.inp.bond)
+
+        edge = pipe._edges[1]
+        assert edge["sourceHandle"] == "bond"
+        assert edge["targetHandle"] == "bond"
+
+    def test_trajectory_to_viewport_traj(self):
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "caffeine_water.pdb")))
+        t = pipe.add_node(LoadTrajectory(
+            xtc=str(FIXTURES / "caffeine_water_vibration.xtc"),
+        ))
+        v = pipe.add_node(Viewport())
+        pipe.add_edge(s.out.particle, t.inp.particle)
+        pipe.add_edge(t.out.traj, v.inp.traj)
+
+        traj_edge = pipe._edges[1]
+        assert traj_edge["sourceHandle"] == "trajectory"
+        assert traj_edge["targetHandle"] == "trajectory"
+
     def test_error_on_unadded_nodes(self):
         pipe = Pipeline()
         s = LoadStructure("test.pdb")
-        f = Filter(query="test")
+        f = pipe.add_node(Filter(query="test"))
         with pytest.raises(ValueError, match="must be added"):
-            pipe.add_edge(s, f)
+            pipe.add_edge(s.out.particle, f.inp.particle)
 
 
 class TestPipelineSerialization:
@@ -189,12 +300,11 @@ class TestPipelineSerialization:
         pipe = Pipeline()
         s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
         v = pipe.add_node(Viewport())
-        pipe.add_edge(s, v)
+        pipe.add_edge(s.out.particle, v.inp.particle)
         result = pipe.to_dict()
 
         node_types = [n["type"] for n in result["nodes"]]
         assert "viewport" in node_types
-        # Edge should connect structure to viewport
         viewport_edges = [
             e for e in result["edges"] if e["target"] == v._id
         ]
@@ -220,11 +330,11 @@ class TestPipelineSerialization:
         lbl = pipe.add_node(AddLabels(source="element"))
         v = pipe.add_node(Viewport())
 
-        pipe.add_edge(s, b)
-        pipe.add_edge(s, lbl)
-        pipe.add_edge(s, v)    # particle → particle
-        pipe.add_edge(b, v)    # bond → bond
-        pipe.add_edge(lbl, v)  # label → label
+        pipe.add_edge(s.out.particle, b.inp.particle)
+        pipe.add_edge(s.out.particle, lbl.inp.particle)
+        pipe.add_edge(s.out.particle, v.inp.particle)
+        pipe.add_edge(b.out.bond, v.inp.bond)
+        pipe.add_edge(lbl.out.label, v.inp.label)
 
         result = pipe.to_dict()
         viewport_edges = [
@@ -232,19 +342,18 @@ class TestPipelineSerialization:
         ]
         handles = {(e["sourceHandle"], e["targetHandle"]) for e in viewport_edges}
         assert ("particle", "particle") in handles
-        assert ("bond", "bond") in handles  # bond resolved via _SOURCE_OUTPUT_MAP
-        assert ("label", "label") in handles  # label resolved via _SOURCE_OUTPUT_MAP
+        assert ("bond", "bond") in handles
+        assert ("label", "label") in handles
 
     def test_filter_modify_chain(self):
         pipe = Pipeline()
         s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
         f = pipe.add_node(Filter(query="element == 'C'"))
         m = pipe.add_node(Modify(scale=1.5))
-        pipe.add_edge(s, f)
-        pipe.add_edge(f, m)
+        pipe.add_edge(s.out.particle, f.inp.particle)
+        pipe.add_edge(f.out.particle, m.inp.particle)
         result = pipe.to_dict()
 
-        # Verify node params are serialized correctly
         filter_node = next(n for n in result["nodes"] if n["type"] == "filter")
         assert filter_node["query"] == "element == 'C'"
 
@@ -255,7 +364,7 @@ class TestPipelineSerialization:
         pipe = Pipeline()
         s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
         b = pipe.add_node(AddBonds(source="structure"))
-        pipe.add_edge(s, b)
+        pipe.add_edge(s.out.particle, b.inp.particle)
         result = pipe.to_dict()
 
         bond_node = next(n for n in result["nodes"] if n["type"] == "add_bond")
@@ -270,7 +379,7 @@ class TestPipelineSerialization:
             max_distance=3.0,
             opacity=0.7,
         ))
-        pipe.add_edge(s, p)
+        pipe.add_edge(s.out.particle, p.inp.particle)
         result = pipe.to_dict()
 
         poly_node = next(
@@ -320,12 +429,12 @@ class TestPipelineDAG:
         f2 = pipe.add_node(Filter(query="element == 'N'"))
         b = pipe.add_node(AddBonds(source="distance"))
         v = pipe.add_node(Viewport())
-        pipe.add_edge(s, f1)
-        pipe.add_edge(s, f2)
-        pipe.add_edge(s, b)
-        pipe.add_edge(f1, v)
-        pipe.add_edge(f2, v)
-        pipe.add_edge(b, v)
+        pipe.add_edge(s.out.particle, f1.inp.particle)
+        pipe.add_edge(s.out.particle, f2.inp.particle)
+        pipe.add_edge(s.out.particle, b.inp.particle)
+        pipe.add_edge(f1.out.particle, v.inp.particle)
+        pipe.add_edge(f2.out.particle, v.inp.particle)
+        pipe.add_edge(b.out.bond, v.inp.bond)
 
         result = pipe.to_dict()
         assert len(result["edges"]) == 6
@@ -337,19 +446,19 @@ class TestPipelineDAG:
         f = pipe.add_node(Filter(query="element == 'C'"))
         m = pipe.add_node(Modify(scale=1.3))
         lbl = pipe.add_node(AddLabels(source="element"))
-        pipe.add_edge(s, f)
-        pipe.add_edge(f, m)
-        pipe.add_edge(f, lbl)
+        pipe.add_edge(s.out.particle, f.inp.particle)
+        pipe.add_edge(f.out.particle, m.inp.particle)
+        pipe.add_edge(f.out.particle, lbl.inp.particle)
 
         result = pipe.to_dict()
-        # f → m uses out → in
+        # f → m: out → in
         fm_edge = next(
             e for e in result["edges"]
             if e["source"] == f._id and e["target"] == m._id
         )
         assert fm_edge["sourceHandle"] == "out"
 
-        # f → lbl uses out → particle
+        # f → lbl: out → particle
         fl_edge = next(
             e for e in result["edges"]
             if e["source"] == f._id and e["target"] == lbl._id

--- a/tests/python/test_pipeline.py
+++ b/tests/python/test_pipeline.py
@@ -276,6 +276,25 @@ class TestPipelineAddEdge:
         with pytest.raises(ValueError, match="must be added"):
             pipe.add_edge(s.out.particle, f.inp.particle)
 
+    def test_error_on_wrong_type_raises_type_error(self):
+        """Passing PipelineNode instead of NodePort raises TypeError with guidance."""
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        f = pipe.add_node(Filter(query="element == 'C'"))
+        with pytest.raises(TypeError, match="NodePort"):
+            pipe.add_edge(s, f)  # type: ignore[arg-type]
+
+    def test_error_on_cross_pipeline_nodes(self):
+        """Ports from a different pipeline instance are rejected."""
+        pipe1 = Pipeline()
+        s1 = pipe1.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+
+        pipe2 = Pipeline()
+        f2 = pipe2.add_node(Filter(query="element == 'C'"))
+
+        with pytest.raises(ValueError, match="must be added"):
+            pipe1.add_edge(s1.out.particle, f2.inp.particle)
+
 
 class TestPipelineSerialization:
     """Pipeline.to_dict() produces valid SerializedPipeline v3."""

--- a/tests/python/test_widget.py
+++ b/tests/python/test_widget.py
@@ -16,7 +16,7 @@ def _make_pdb_pipeline(pdb_path: str) -> Pipeline:
     pipe = Pipeline()
     s = pipe.add_node(LoadStructure(pdb_path))
     b = pipe.add_node(AddBonds(source="structure"))
-    pipe.add_edge(s, b)
+    pipe.add_edge(s.out.particle, b.inp.particle)
     return pipe
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1429,6 +1429,11 @@ traj = [
     { name = "ase" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anywidget", specifier = ">=0.9.0" },
@@ -1448,6 +1453,9 @@ requires-dist = [
     { name = "websockets", specifier = ">=12.0" },
 ]
 provides-extras = ["traj", "dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.2" }]
 
 [[package]]
 name = "mistune"


### PR DESCRIPTION
## Summary

- Add `NodePort` and `PortNamespace` classes to `pipeline.py`
- Each node now exposes `.out` and `.inp` namespaces with typed ports (e.g. `s.out.particle`, `t.out.traj`, `v.inp.bond`)
- `Pipeline.add_edge()` now takes two `NodePort` arguments instead of two nodes — no more hidden auto-resolution
- Remove `_resolve_ports`, `_TARGET_PORT_MAP`, `_SOURCE_OUTPUT_MAP` (dead code)
- Python attribute name `.traj` maps to JSON handle `"trajectory"` internally
- Update all tests and docs to use the new explicit syntax
- Examples now use `from megane import LoadStructure` instead of `from megane.pipeline import …`

## Test plan

- [ ] `uv run python -m pytest tests/python/test_pipeline.py tests/python/test_demo_code.py` — all 58 tests pass
- [ ] Verify `node.out.nonexistent` raises `AttributeError` with helpful message
- [ ] Verify trajectory connection: `pipe.add_edge(s.out.particle, t.inp.particle)` then `pipe.add_edge(t.out.traj, v.inp.traj)`

https://claude.ai/code/session_012DagxYQcV8sbfYhkbJhMwE