### PR TITLE
refactor: improve Python code quality across all modules

### DIFF
--- a/python/megane/parsers/common.py
+++ b/python/megane/parsers/common.py
@@ -1,0 +1,39 @@
+"""Shared trajectory types used by multiple parser modules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class InMemoryTrajectory:
+    """In-memory trajectory with frame-by-frame access.
+
+    Compatible interface with :class:`megane.parsers.xtc.Trajectory`.
+    """
+
+    _frames: list[np.ndarray]  # list of (N, 3) float32 arrays
+    n_frames: int
+    n_atoms: int
+    timestep_ps: float
+    box: np.ndarray  # (3, 3) float32
+
+    def get_frame(self, index: int) -> np.ndarray:
+        """Get positions for a specific frame.
+
+        Args:
+            index: Frame index (0-based).
+
+        Returns:
+            (N, 3) float32 array of atom positions in Angstroms.
+
+        Raises:
+            ValueError: If *index* is out of range.
+        """
+        if not (0 <= index < self.n_frames):
+            raise ValueError(
+                f"Frame index {index} is out of range for trajectory with {self.n_frames} frames."
+            )
+        return self._frames[index]

--- a/python/megane/parsers/common.py
+++ b/python/megane/parsers/common.py
@@ -33,7 +33,5 @@ class InMemoryTrajectory:
             ValueError: If *index* is out of range.
         """
         if not (0 <= index < self.n_frames):
-            raise ValueError(
-                f"Frame index {index} is out of range for trajectory with {self.n_frames} frames."
-            )
+            raise ValueError(f"Frame index {index} is out of range for trajectory with {self.n_frames} frames.")
         return self._frames[index]

--- a/python/megane/parsers/lammps_data.py
+++ b/python/megane/parsers/lammps_data.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 
 from megane import megane_parser
 from megane.parsers.pdb import Structure
+
+logger = logging.getLogger(__name__)
 
 
 def load_lammps_data(path: str) -> Structure:
@@ -14,10 +18,12 @@ def load_lammps_data(path: str) -> Structure:
     Supports atom_style: atomic, charge, and full (real).
     Auto-detects style from comment hint or field count.
     """
+    logger.debug("Loading LAMMPS data file: %s", path)
     with open(path) as f:
         text = f.read()
 
     result = megane_parser.parse_lammps_data(text)
+    logger.info("Loaded LAMMPS data: %d atoms, %d bonds", result.n_atoms, len(result.bonds))
 
     return Structure(
         n_atoms=result.n_atoms,

--- a/python/megane/parsers/lammpstrj.py
+++ b/python/megane/parsers/lammpstrj.py
@@ -2,31 +2,57 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 import numpy as np
 
+from megane.parsers.common import InMemoryTrajectory
+
+__all__ = ["load_lammpstrj", "InMemoryTrajectory"]
+
+logger = logging.getLogger(__name__)
+
 
 @dataclass
-class InMemoryTrajectory:
-    """In-memory trajectory with frame-by-frame access.
+class _ColumnSpec:
+    """Column indices detected from the ATOMS header line."""
 
-    Compatible interface with :class:`megane.parsers.xtc.Trajectory`.
-    """
+    id_col: int
+    x_col: int
+    y_col: int
+    z_col: int
+    coord_type: str  # "unscaled", "scaled", or "unwrapped"
 
-    _frames: list[np.ndarray]  # list of (N, 3) float32 arrays
-    n_frames: int
-    n_atoms: int
-    timestep_ps: float
-    box: np.ndarray  # (3, 3) float32
 
-    def get_frame(self, index: int) -> np.ndarray:
-        """Get positions for a specific frame.
-
-        Returns:
-            (N, 3) float32 array of atom positions in Angstroms.
-        """
-        return self._frames[index]
+def _parse_column_spec(col_names: list[str]) -> _ColumnSpec:
+    """Detect coordinate column indices and type from LAMMPS ATOMS header."""
+    id_col = col_names.index("id")
+    if "x" in col_names:
+        return _ColumnSpec(
+            id_col=id_col,
+            x_col=col_names.index("x"),
+            y_col=col_names.index("y"),
+            z_col=col_names.index("z"),
+            coord_type="unscaled",
+        )
+    if "xs" in col_names:
+        return _ColumnSpec(
+            id_col=id_col,
+            x_col=col_names.index("xs"),
+            y_col=col_names.index("ys"),
+            z_col=col_names.index("zs"),
+            coord_type="scaled",
+        )
+    if "xu" in col_names:
+        return _ColumnSpec(
+            id_col=id_col,
+            x_col=col_names.index("xu"),
+            y_col=col_names.index("yu"),
+            z_col=col_names.index("zu"),
+            coord_type="unwrapped",
+        )
+    raise ValueError("Cannot find coordinate columns in ATOMS header")
 
 
 def load_lammpstrj(dump_path: str) -> InMemoryTrajectory:
@@ -38,6 +64,7 @@ def load_lammpstrj(dump_path: str) -> InMemoryTrajectory:
     Returns:
         InMemoryTrajectory with frame-by-frame access.
     """
+    logger.debug("Loading LAMMPS dump file: %s", dump_path)
     with open(dump_path) as f:
         lines = f.readlines()
 
@@ -64,6 +91,11 @@ def load_lammpstrj(dump_path: str) -> InMemoryTrajectory:
         frame_n_atoms = int(lines[i].strip())
         if not frames:
             n_atoms = frame_n_atoms
+        elif frame_n_atoms != n_atoms:
+            raise ValueError(
+                f"Atom count mismatch: frame {len(frames)} has {frame_n_atoms} atoms, "
+                f"but the first frame has {n_atoms} atoms."
+            )
 
         # BOX BOUNDS
         i += 1
@@ -107,24 +139,7 @@ def load_lammpstrj(dump_path: str) -> InMemoryTrajectory:
         header_parts = lines[i].split()
         # Skip "ITEM:" and "ATOMS"
         col_names = header_parts[2:]
-        id_col = col_names.index("id")
-
-        coord_type = "unscaled"
-        if "x" in col_names:
-            x_col = col_names.index("x")
-            y_col = col_names.index("y")
-            z_col = col_names.index("z")
-        elif "xs" in col_names:
-            x_col = col_names.index("xs")
-            y_col = col_names.index("ys")
-            z_col = col_names.index("zs")
-            coord_type = "scaled"
-        elif "xu" in col_names:
-            x_col = col_names.index("xu")
-            y_col = col_names.index("yu")
-            z_col = col_names.index("zu")
-        else:
-            raise ValueError("Cannot find coordinate columns in ATOMS header")
+        col_spec = _parse_column_spec(col_names)
 
         # Read atoms
         atoms = []
@@ -134,11 +149,11 @@ def load_lammpstrj(dump_path: str) -> InMemoryTrajectory:
         for _ in range(frame_n_atoms):
             i += 1
             parts = lines[i].split()
-            aid = int(parts[id_col])
-            x = float(parts[x_col])
-            y = float(parts[y_col])
-            z = float(parts[z_col])
-            if coord_type == "scaled":
+            aid = int(parts[col_spec.id_col])
+            x = float(parts[col_spec.x_col])
+            y = float(parts[col_spec.y_col])
+            z = float(parts[col_spec.z_col])
+            if col_spec.coord_type == "scaled":
                 x = x * lx_f + lo[0]
                 y = y * ly_f + lo[1]
                 z = z * lz_f + lo[2]
@@ -154,6 +169,7 @@ def load_lammpstrj(dump_path: str) -> InMemoryTrajectory:
     if len(timesteps) >= 2:
         timestep_ps = float(abs(timesteps[1] - timesteps[0]))
 
+    logger.info("Loaded LAMMPS dump: %d frames, %d atoms", len(frames), n_atoms)
     return InMemoryTrajectory(
         _frames=frames,
         n_frames=len(frames),

--- a/python/megane/parsers/pdb.py
+++ b/python/megane/parsers/pdb.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 import numpy as np
 
 from megane import megane_parser
+
+logger = logging.getLogger(__name__)
 
 # Bond order encoding: matches frontend constants
 BOND_SINGLE = 1
@@ -68,10 +71,12 @@ def load_pdb(path: str) -> Structure:
     Replaces the previous RDKit-based implementation for dramatically
     faster parsing. The same Rust code is used by the WASM frontend.
     """
+    logger.debug("Loading PDB file: %s", path)
     with open(path) as f:
         text = f.read()
 
     result = megane_parser.parse_pdb(text)
+    logger.info("Loaded PDB: %d atoms, %d bonds", result.n_atoms, len(result.bonds))
 
     return Structure(
         n_atoms=result.n_atoms,

--- a/python/megane/parsers/traj.py
+++ b/python/megane/parsers/traj.py
@@ -2,34 +2,17 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import logging
 
 import numpy as np
 
 from megane import megane_parser
+from megane.parsers.common import InMemoryTrajectory
 from megane.parsers.pdb import Structure
 
+__all__ = ["load_traj", "InMemoryTrajectory"]
 
-@dataclass
-class InMemoryTrajectory:
-    """In-memory trajectory with frame-by-frame access.
-
-    Compatible interface with :class:`megane.parsers.xtc.Trajectory`.
-    """
-
-    _frames: list[np.ndarray]  # list of (N, 3) float32 arrays
-    n_frames: int
-    n_atoms: int
-    timestep_ps: float
-    box: np.ndarray  # (3, 3) float32
-
-    def get_frame(self, index: int) -> np.ndarray:
-        """Get positions for a specific frame.
-
-        Returns:
-            (N, 3) float32 array of atom positions in Angstroms.
-        """
-        return self._frames[index]
+logger = logging.getLogger(__name__)
 
 
 def _atoms_to_xyz(positions: np.ndarray, symbols: list[str]) -> str:
@@ -55,6 +38,7 @@ def load_traj(path: str) -> tuple[Structure, InMemoryTrajectory]:
     """
     from ase.io import read as ase_read
 
+    logger.debug("Loading ASE .traj file: %s", path)
     frames = ase_read(path, index=":")
     if not isinstance(frames, list):
         frames = [frames]
@@ -93,4 +77,5 @@ def load_traj(path: str) -> tuple[Structure, InMemoryTrajectory]:
         box=box_matrix,
     )
 
+    logger.info("Loaded .traj: %d frames, %d atoms, %d bonds", len(frames), len(first), len(bonds))
     return structure, trajectory

--- a/python/megane/parsers/xtc.py
+++ b/python/megane/parsers/xtc.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 import numpy as np
 
 from megane.parsers.pdb import cell_params_to_matrix
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -59,6 +62,7 @@ def load_trajectory(pdb_path: str, xtc_path: str) -> Trajectory:
     n_atoms = len(universe.atoms)
     timestep_ps = universe.trajectory.dt
     box = _box_from_dimensions(universe.dimensions)
+    logger.info("Loaded XTC trajectory: %d frames, %d atoms", n_frames, n_atoms)
 
     return Trajectory(
         _universe=universe,

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -429,7 +429,7 @@ class Pipeline:
     """
 
     def __init__(self) -> None:
-        self._nodes: list[tuple[PipelineNode, dict]] = []
+        self._nodes: dict[str, tuple[PipelineNode, dict]] = {}
         self._edges: list[dict] = []
         self._node_data: dict[str, bytes] = {}
         self._trajectories: dict[str, object] = {}
@@ -451,7 +451,7 @@ class Pipeline:
         node._id = f"{node._node_type}-{self._counter}"
 
         config = self._serialize_node(node)
-        self._nodes.append((node, config))
+        self._nodes[node._id] = (node, config)
 
         if isinstance(node, LoadStructure):
             self._load_structure_data(node)
@@ -476,8 +476,7 @@ class Pipeline:
                 "Use node.out.<name> and node.inp.<name>, "
                 "e.g. pipe.add_edge(s.out.particle, f.inp.particle)."
             )
-        node_ids = {n._id for n, _ in self._nodes}
-        if source._node._id not in node_ids or target._node._id not in node_ids:
+        if source._node._id not in self._nodes or target._node._id not in self._nodes:
             raise ValueError("Both nodes must be added to this pipeline before connecting.")
         self._edges.append(
             {
@@ -497,7 +496,7 @@ class Pipeline:
 
     def to_dict(self) -> dict:
         """Serialize to ``SerializedPipeline`` v3 format."""
-        nodes = [config for _, config in self._nodes]
+        nodes = [config for _, config in self._nodes.values()]
         edges = list(self._edges)
         return {"version": 3, "nodes": nodes, "edges": edges}
 
@@ -505,7 +504,8 @@ class Pipeline:
 
     def _serialize_node(self, node: PipelineNode) -> dict:
         """Convert a node instance to the TS SerializedPipeline node dict."""
-        assert node._id is not None
+        if node._id is None:
+            raise ValueError("Node must be added to the pipeline before serialization.")
         base: dict = {
             "id": node._id,
             "type": node._node_type,
@@ -557,16 +557,14 @@ class Pipeline:
         """Load structure file and store binary snapshot data."""
         from megane.protocol import encode_snapshot
 
-        assert node._id is not None
+        if node._id is None:
+            raise ValueError("Node must be added to the pipeline before loading data.")
         structure = _load_structure_file(node.path)
         self._structures[node._id] = structure
         self._node_data[node._id] = encode_snapshot(structure)
 
         # Re-serialize to update hasCell
-        for i, (n, _) in enumerate(self._nodes):
-            if n._id == node._id:
-                self._nodes[i] = (n, self._serialize_node(n))
-                break
+        self._nodes[node._id] = (node, self._serialize_node(node))
 
     def _load_trajectory_data(
         self,
@@ -574,17 +572,16 @@ class Pipeline:
         source: LoadStructure,
     ) -> None:
         """Load trajectory object for lazy frame loading."""
-        assert node._id is not None
+        if node._id is None:
+            raise ValueError("Node must be added to the pipeline before loading data.")
         if node.xtc is not None:
             from megane.parsers.xtc import load_trajectory
 
             self._trajectories[node._id] = load_trajectory(source.path, node.xtc)
 
             # Update parent LoadStructure's hasTrajectory flag
-            for i, (n, config) in enumerate(self._nodes):
-                if n._id == source._id:
-                    config["hasTrajectory"] = True
-                    break
+            if source._id in self._nodes:
+                self._nodes[source._id][1]["hasTrajectory"] = True
         elif node.traj is not None:
             from megane.parsers.traj import load_traj
 

--- a/python/megane/protocol.py
+++ b/python/megane/protocol.py
@@ -29,6 +29,16 @@ from typing import Protocol, runtime_checkable
 
 import numpy as np
 
+__all__ = [
+    "encode_snapshot",
+    "encode_frame",
+    "encode_metadata",
+    "StructureLike",
+    "MSG_SNAPSHOT",
+    "MSG_FRAME",
+    "MSG_METADATA",
+]
+
 MAGIC = b"MEGN"
 MSG_SNAPSHOT = 0
 MSG_FRAME = 1

--- a/python/megane/server.py
+++ b/python/megane/server.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
@@ -41,7 +41,6 @@ class ServerState:
     pdb_path: str = ""
     xtc_path: Optional[str] = None
     trajectory: Optional[Trajectory | InMemoryTrajectory] = None
-    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 _state = ServerState()
@@ -215,8 +214,12 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
             _clients.discard(websocket)
 
 
-# Resolve static files directory: override via MEGANE_STATIC_DIR env var
-_static_dir = Path(os.environ.get("MEGANE_STATIC_DIR", Path(__file__).parent / "static" / "app"))
+# Resolve static files directory: override via MEGANE_STATIC_DIR env var.
+# Empty or whitespace values are treated as unset to avoid accidentally
+# exposing the current working directory via StaticFiles.
+_default_static_dir = Path(__file__).parent / "static" / "app"
+_env_static_dir = os.environ.get("MEGANE_STATIC_DIR", "").strip()
+_static_dir = Path(_env_static_dir).resolve() if _env_static_dir else _default_static_dir
 if _static_dir.exists():
     app.mount("/", StaticFiles(directory=str(_static_dir), html=True), name="app")
 else:

--- a/python/megane/server.py
+++ b/python/megane/server.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from fastapi import FastAPI, UploadFile, WebSocket, WebSocketDisconnect
 from fastapi.staticfiles import StaticFiles
@@ -16,12 +17,19 @@ from fastapi.staticfiles import StaticFiles
 from megane.parsers.pdb import Structure, load_pdb
 from megane.protocol import encode_frame, encode_metadata, encode_snapshot
 
+if TYPE_CHECKING:
+    from megane.parsers.common import InMemoryTrajectory
+    from megane.parsers.xtc import Trajectory
+
+__all__ = ["app", "configure"]
+
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="megane")
 
 # Track connected WebSocket clients for broadcasting
 _clients: set[WebSocket] = set()
+_clients_lock = asyncio.Lock()
 
 
 @dataclass
@@ -32,7 +40,8 @@ class ServerState:
     snapshot_bytes: bytes = b""
     pdb_path: str = ""
     xtc_path: Optional[str] = None
-    trajectory: object = None  # Optional[Trajectory] - lazy import
+    trajectory: Optional[Trajectory | InMemoryTrajectory] = None
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 _state = ServerState()
@@ -104,12 +113,15 @@ def _build_metadata_bytes() -> bytes:
 async def _broadcast_snapshot() -> None:
     """Send snapshot and metadata to all connected clients."""
     meta_bytes = _build_metadata_bytes()
-    for ws in list(_clients):
+    async with _clients_lock:
+        clients_snapshot = list(_clients)
+    for ws in clients_snapshot:
         try:
             await ws.send_bytes(_state.snapshot_bytes)
             await ws.send_bytes(meta_bytes)
-        except Exception:
-            _clients.discard(ws)
+        except (WebSocketDisconnect, RuntimeError):
+            async with _clients_lock:
+                _clients.discard(ws)
 
 
 @app.get("/health")
@@ -151,7 +163,8 @@ async def upload_file(
 async def websocket_endpoint(websocket: WebSocket) -> None:
     """WebSocket endpoint for streaming molecular data."""
     await websocket.accept()
-    _clients.add(websocket)
+    async with _clients_lock:
+        _clients.add(websocket)
     try:
         # Send snapshot and metadata immediately on connection
         if _state.structure is not None:
@@ -198,11 +211,12 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
     except WebSocketDisconnect:
         logger.info("Client disconnected")
     finally:
-        _clients.discard(websocket)
+        async with _clients_lock:
+            _clients.discard(websocket)
 
 
-# Try to serve static files for the built web app
-_static_dir = Path(__file__).parent / "static" / "app"
+# Resolve static files directory: override via MEGANE_STATIC_DIR env var
+_static_dir = Path(os.environ.get("MEGANE_STATIC_DIR", Path(__file__).parent / "static" / "app"))
 if _static_dir.exists():
     app.mount("/", StaticFiles(directory=str(_static_dir), html=True), name="app")
 else:

--- a/python/megane/widget.py
+++ b/python/megane/widget.py
@@ -103,7 +103,9 @@ class MolecularViewer(anywidget.AnyWidget):
                 are read from the .traj file.
         """
         warnings.warn(
-            "MolecularViewer.load() is deprecated. Use set_pipeline() with a Pipeline instead.",
+            "MolecularViewer.load() is deprecated and will be removed in a future major release. "
+            "Use set_pipeline() with a Pipeline instead. "
+            "See the megane documentation for migration examples.",
             DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
## Summary

- **Eliminate code duplication**: Extracted shared `InMemoryTrajectory` class into new `parsers/common.py`, removing duplicate definitions from `traj.py` and `lammpstrj.py`
- **Robustness improvements**: Added bounds checking with `ValueError` in `get_frame()`, atom count consistency checks in `lammpstrj.py`, and `_ColumnSpec` dataclass to replace magic number column indices
- **Replace unsafe assertions**: All `assert` statements in `pipeline.py` replaced with explicit `ValueError` (safe under `-O` flag)
- **Performance**: `Pipeline._nodes` changed from `list` to `dict` for O(1) node lookup
- **Async safety**: `_clients` set in `server.py` now guarded with `asyncio.Lock`; narrow exception handling replaces bare `except Exception`
- **Type hints**: `ServerState.trajectory` fixed from `object` to proper union type
- **Configurability**: Static file path now overridable via `MEGANE_STATIC_DIR` env var
- **Public API**: Added `__all__` to `protocol.py` and `server.py`
- **Logging**: Module-level loggers added to all parser modules
- **Deprecation**: Strengthened `MolecularViewer.load()` deprecation message with removal notice

## Test plan

- [x] `uv run pytest tests/python/ --override-ini="addopts="` — 127 passed, 1 skipped
- [x] `cargo test -p megane-core` — 70 passed

https://claude.ai/code/session_01D58NTQBd2mUc5hH7ehaNU5