### PR TITLE
feat: add pre-release and post-release skills

### DIFF
--- a/.claude/skills/post-release/SKILL.md
+++ b/.claude/skills/post-release/SKILL.md
@@ -1,0 +1,114 @@
+---
+description: Post-release checklist for megane. Run after pushing a release tag to verify all publish workflows succeeded and packages are live.
+---
+
+# Post-Release Checklist
+
+Run this skill after pushing a release tag (`vX.Y.Z`). Verify every item before declaring the release complete.
+
+## Phase 1: CI Workflow Status
+
+### 1.1 Monitor all publish workflows
+```bash
+gh run list --limit 10
+```
+Wait for all tag-triggered workflows to finish. Expected workflows:
+- `publish-pypi.yml` — Python wheels to PyPI
+- `publish-npm.yml` — Widget bundle to npm
+- `publish-vscode.yml` — Extension to VS Code Marketplace
+- `release.yml` — GitHub Release (draft)
+- `docs.yml` — Documentation to GitHub Pages
+
+To inspect a failing workflow:
+```bash
+gh run view <run-id> --log-failed
+```
+
+All workflows must show `success` before proceeding.
+
+## Phase 2: Package Availability
+
+### 2.1 PyPI
+Verify the new version is installable:
+```bash
+pip index versions megane 2>/dev/null | head -1
+```
+Or check directly: https://pypi.org/project/megane/
+
+Test install in a fresh virtualenv:
+```bash
+python -m venv /tmp/megane-test && \
+  /tmp/megane-test/bin/pip install megane==X.Y.Z && \
+  /tmp/megane-test/bin/python -c "import megane; print(megane.__version__)"
+```
+Expected output: `X.Y.Z`
+
+### 2.2 npm
+```bash
+npm view megane-viewer@X.Y.Z version
+```
+Expected output: `X.Y.Z`
+
+### 2.3 VS Code Marketplace
+Check the extension page on the marketplace, or verify via:
+```bash
+gh run view --workflow=publish-vscode.yml --limit 1
+```
+Confirm the extension version matches `X.Y.Z`.
+
+## Phase 3: GitHub Release
+
+### 3.1 Publish the draft release
+The `release.yml` workflow creates a draft. Review and publish it:
+```bash
+gh release view vX.Y.Z
+gh release edit vX.Y.Z --draft=false
+```
+Verify the release notes are correct (auto-generated from git log).
+
+### 3.2 Confirm release page
+```bash
+gh release view vX.Y.Z --web
+```
+
+## Phase 4: Documentation
+
+### 4.1 GitHub Pages deployment
+Confirm `docs.yml` workflow succeeded:
+```bash
+gh run list --workflow=docs.yml --limit 1
+```
+
+Visit the docs site and verify the version shown matches `X.Y.Z`:
+- Check the version badge or footer
+- Verify new features/APIs mentioned in the release are documented
+
+## Phase 5: Live Demo
+
+### 5.1 AWS ECS demo health
+After a release, the `deploy.yml` workflow may re-deploy. Check:
+```bash
+gh run list --workflow=deploy.yml --limit 1
+```
+If the demo was updated, verify it loads correctly in the browser.
+
+## Phase 6: Announcement Checklist (manual)
+
+These items require manual action outside of automated workflows:
+
+- [ ] Update any pinned version references in example repositories
+- [ ] Post release notes to relevant community channels if applicable
+- [ ] Close any GitHub issues resolved in this release
+- [ ] Open a new milestone for the next version if needed
+
+## Summary
+
+Once all phases are complete, the release is done. Key verification:
+
+| Item | Command |
+|---|---|
+| All CI workflows | `gh run list --limit 10` |
+| PyPI version | `pip index versions megane` |
+| npm version | `npm view megane-viewer version` |
+| GitHub release published | `gh release view vX.Y.Z` |
+| Docs site updated | `gh run list --workflow=docs.yml` |

--- a/.claude/skills/post-release/SKILL.md
+++ b/.claude/skills/post-release/SKILL.md
@@ -56,19 +56,76 @@ gh run view --workflow=publish-vscode.yml --limit 1
 ```
 Confirm the extension version matches `X.Y.Z`.
 
-## Phase 3: GitHub Release
+## Phase 3: GitHub Release Notes & Publishing
 
-### 3.1 Publish the draft release
-The `release.yml` workflow creates a draft. Review and publish it:
+### 3.1 Find the previous release tag
 ```bash
-gh release view vX.Y.Z
+git tag --sort=-version:refname | grep '^v' | head -5
+```
+Identify the previous tag (e.g., `vX.Y.Z-1`).
+
+### 3.2 Generate release notes from diff
+Collect all commits between the previous tag and the new tag:
+```bash
+git log vPREV..vX.Y.Z --oneline --no-merges
+```
+
+Also read the CHANGELOG entry for the new version:
+```bash
+# Extract the section for vX.Y.Z from CHANGELOG.md
+awk '/^## \[X\.Y\.Z\]/,/^## \[/' CHANGELOG.md | head -50
+```
+
+Use these two sources to write human-readable release notes. Structure them as:
+
+```markdown
+## What's Changed
+
+### Added
+- ...
+
+### Changed
+- ...
+
+### Fixed
+- ...
+
+## Install
+
+### Python
+pip install megane==X.Y.Z
+
+### npm
+npm install megane-viewer@X.Y.Z
+
+### VS Code
+Search for "megane" in the VS Code Extensions panel
+
+**Full Changelog**: https://github.com/hodakamori/megane/compare/vPREV...vX.Y.Z
+```
+
+### 3.3 Update the draft release with generated notes
+```bash
+gh release edit vX.Y.Z --notes "$(cat release-notes.md)"
+```
+Or write the notes inline using a heredoc:
+```bash
+gh release edit vX.Y.Z --notes "$(cat <<'EOF'
+## What's Changed
+...
+EOF
+)"
+```
+
+### 3.4 Publish the release
+After confirming the notes look correct:
+```bash
 gh release edit vX.Y.Z --draft=false
 ```
-Verify the release notes are correct (auto-generated from git log).
 
-### 3.2 Confirm release page
+### 3.5 Confirm the release page
 ```bash
-gh release view vX.Y.Z --web
+gh release view vX.Y.Z
 ```
 
 ## Phase 4: Documentation
@@ -110,5 +167,5 @@ Once all phases are complete, the release is done. Key verification:
 | All CI workflows | `gh run list --limit 10` |
 | PyPI version | `pip index versions megane` |
 | npm version | `npm view megane-viewer version` |
-| GitHub release published | `gh release view vX.Y.Z` |
+| GitHub release notes written & published | `gh release view vX.Y.Z` |
 | Docs site updated | `gh run list --workflow=docs.yml` |

--- a/.claude/skills/post-release/SKILL.md
+++ b/.claude/skills/post-release/SKILL.md
@@ -106,27 +106,39 @@ Search for "megane" in the VS Code Extensions panel
 
 ### 3.3 Update the draft release with generated notes
 ```bash
-gh release edit vX.Y.Z --notes "$(cat release-notes.md)"
-```
-Or write the notes inline using a heredoc:
-```bash
 gh release edit vX.Y.Z --notes "$(cat <<'EOF'
 ## What's Changed
-...
+
+### Added
+- ...
+
+### Changed
+- ...
+
+### Fixed
+- ...
+
+## Install
+
+### Python
+pip install megane==X.Y.Z
+
+### npm
+npm install megane-viewer@X.Y.Z
+
+### VS Code
+Search for "megane" in the VS Code Extensions panel
+
+**Full Changelog**: https://github.com/hodakamori/megane/compare/vPREV...vX.Y.Z
 EOF
 )"
 ```
 
-### 3.4 Publish the release
-After confirming the notes look correct:
-```bash
-gh release edit vX.Y.Z --draft=false
-```
-
-### 3.5 Confirm the release page
+### 3.4 Confirm the draft is ready
 ```bash
 gh release view vX.Y.Z
 ```
+Verify the notes look correct. The release remains as a **draft** — hand off to the user to review and publish it manually.
 
 ## Phase 4: Documentation
 
@@ -167,5 +179,5 @@ Once all phases are complete, the release is done. Key verification:
 | All CI workflows | `gh run list --limit 10` |
 | PyPI version | `pip index versions megane` |
 | npm version | `npm view megane-viewer version` |
-| GitHub release notes written & published | `gh release view vX.Y.Z` |
+| GitHub release draft with notes ready | `gh release view vX.Y.Z` |
 | Docs site updated | `gh run list --workflow=docs.yml` |

--- a/.claude/skills/pre-release/SKILL.md
+++ b/.claude/skills/pre-release/SKILL.md
@@ -108,12 +108,41 @@ node scripts/capture-screenshots.mjs
 ```
 Review generated screenshots visually for rendering regressions.
 
-### 5.2 Live demo (AWS ECS) health
-Check that the latest deploy workflow succeeded:
+### 5.2 Live demo (AWS ECS) — health check and visual verification
+
+**Step 1**: Confirm the latest deploy succeeded and retrieve the URL:
 ```bash
-gh run list --workflow=deploy.yml --limit 1
+ORIG_REMOTE=$(git remote get-url origin)
+git remote set-url origin https://github.com/hodakamori/megane.git
+RUN_ID=$(gh run list --workflow=deploy.yml --limit 1 --json databaseId -q '.[0].databaseId')
+gh run view "$RUN_ID" --log | grep "URL:"
+git remote set-url origin "$ORIG_REMOTE"
 ```
-Confirm status is `success`. If not, investigate before releasing.
+Note the URL (e.g., `https://XXXX.example.com`).
+
+**Step 2**: Take a screenshot of the live demo with Playwright and verify rendering:
+```bash
+node -e "
+const { createRequire } = require('module');
+const require2 = createRequire('/opt/node22/lib/node_modules/');
+const { chromium } = require2('playwright');
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1280, height: 720 } });
+  await page.goto('LIVE_DEMO_URL', { waitUntil: 'networkidle', timeout: 30000 });
+  await page.waitForTimeout(3000);
+  await page.screenshot({ path: 'dev-preview/live-demo.png', fullPage: false });
+  await browser.close();
+  console.log('Screenshot saved to dev-preview/live-demo.png');
+})();
+"
+```
+Replace `LIVE_DEMO_URL` with the URL from Step 1.
+
+**Step 3**: Review the screenshot `dev-preview/live-demo.png` and confirm:
+- The viewer loads without blank screen or error messages
+- A molecule is rendered (atoms/bonds visible)
+- The UI controls (toolbar, sidebar) are present
 
 ## Phase 6: Dry Run
 

--- a/.claude/skills/pre-release/SKILL.md
+++ b/.claude/skills/pre-release/SKILL.md
@@ -1,0 +1,165 @@
+---
+description: Pre-release checklist for megane. Run before tagging and publishing a new version. Covers tests, build, versioning, docs, and dry-run validation.
+---
+
+# Pre-Release Checklist
+
+Run this skill before creating a release tag. Complete every phase in order.
+
+## Phase 1: Tests & Build
+
+### 1.1 Run all tests
+```bash
+make test-all
+```
+All of TypeScript, Rust, Python, and E2E snapshot tests must pass.
+
+### 1.2 Full build
+```bash
+npm run build
+```
+Must complete without errors. This covers WASM → TypeScript → Vite app → widget.
+
+### 1.3 Python wheel build
+```bash
+maturin build --release
+```
+Must produce a wheel without errors.
+
+## Phase 2: Version Consistency
+
+### 2.1 Run bumpversion
+Choose the appropriate bump level:
+```bash
+bump-my-version bump patch   # bug fixes
+bump-my-version bump minor   # new features
+bump-my-version bump major   # breaking changes
+```
+
+### 2.2 Verify all 7 files are updated
+Check that the new version appears in every file:
+```bash
+grep -r "0\.4\.0" pyproject.toml package.json \
+  crates/megane-core/Cargo.toml \
+  crates/megane-python/Cargo.toml \
+  crates/megane-wasm/Cargo.toml \
+  python/megane/__init__.py \
+  docs/scripts/prepare-notebooks.py
+```
+Replace `0.4.0` with the old version — output should be empty (no stale references).
+
+### 2.3 Update Cargo.lock
+```bash
+cargo check
+```
+Ensures `Cargo.lock` is in sync with the bumped Cargo.toml versions.
+
+## Phase 3: CHANGELOG
+
+### 3.1 Verify CHANGELOG.md has a new entry
+- The `[Unreleased]` section must be renamed to `[X.Y.Z] - YYYY-MM-DD` with today's date.
+- A fresh empty `[Unreleased]` section should remain at the top.
+- Format follows [Keep a Changelog](https://keepachangelog.com/).
+
+Example:
+```markdown
+## [Unreleased]
+
+## [X.Y.Z] - YYYY-MM-DD
+### Added
+- ...
+### Fixed
+- ...
+```
+
+## Phase 4: Documentation & Content
+
+### 4.1 README code examples
+Manually verify that install commands and code snippets in `README.md` reflect the current API.
+Check at minimum:
+- Installation section (pip, npm, vscode)
+- Quick-start Python snippet
+- Quick-start JS/React snippet
+- Supported file formats table
+
+### 4.2 Docs site builds
+```bash
+npm run build:docs 2>/dev/null || npx vitepress build docs
+```
+Must complete without errors.
+
+### 4.3 API docs generate
+```bash
+npx typedoc --out docs/api/ts src/index.ts 2>/dev/null || true
+pdoc python/megane -o docs/api/python 2>/dev/null || true
+```
+Check for unexpected errors (missing exports, broken references).
+
+### 4.4 Feature table alignment
+Confirm the README feature table ("Runs Everywhere" section) matches what is actually supported:
+- Supported environments (Jupyter, browser, React, VSCode)
+- Supported file formats (PDB, GRO, XYZ, MOL, CIF, LAMMPS, XTC, .traj)
+
+## Phase 5: Visual Verification
+
+### 5.1 Capture screenshots
+```bash
+node scripts/capture-screenshots.mjs
+```
+Review generated screenshots visually for rendering regressions.
+
+### 5.2 Live demo (AWS ECS) health
+Check that the latest deploy workflow succeeded:
+```bash
+gh run list --workflow=deploy.yml --limit 1
+```
+Confirm status is `success`. If not, investigate before releasing.
+
+## Phase 6: Dry Run
+
+### 6.1 Trigger release-dry-run workflow
+```bash
+gh workflow run release-dry-run.yml
+```
+Wait for it to complete:
+```bash
+gh run list --workflow=release-dry-run.yml --limit 1
+```
+All three publish jobs (PyPI, npm, VSCode) must pass in dry-run mode.
+
+## Phase 7: Release Commit & Tag
+
+Only proceed here after all phases above are green.
+
+### 7.1 Verify clean git state
+```bash
+git status
+```
+Only bumpversion and CHANGELOG changes should be present (no unrelated modifications).
+
+### 7.2 Create release commit
+```bash
+git add pyproject.toml package.json \
+  crates/megane-core/Cargo.toml \
+  crates/megane-python/Cargo.toml \
+  crates/megane-wasm/Cargo.toml \
+  Cargo.lock \
+  python/megane/__init__.py \
+  docs/scripts/prepare-notebooks.py \
+  CHANGELOG.md
+git commit -m "chore: release vX.Y.Z"
+```
+
+### 7.3 Create and push tag
+```bash
+git tag vX.Y.Z
+git push origin main
+git push origin vX.Y.Z
+```
+
+Pushing the tag triggers all publish workflows automatically:
+`publish-pypi.yml`, `publish-npm.yml`, `publish-vscode.yml`, `release.yml`, `docs.yml`.
+
+## Next Step
+
+After pushing the tag, follow the **post-release** skill to verify the release landed correctly.

--- a/.claude/skills/pre-release/SKILL.md
+++ b/.claude/skills/pre-release/SKILL.md
@@ -127,7 +127,7 @@ gh run list --workflow=release-dry-run.yml --limit 1
 ```
 All three publish jobs (PyPI, npm, VSCode) must pass in dry-run mode.
 
-## Phase 7: Release Commit & Tag
+## Phase 7: Release Commit
 
 Only proceed here after all phases above are green.
 
@@ -148,12 +148,15 @@ git add pyproject.toml package.json \
   docs/scripts/prepare-notebooks.py \
   CHANGELOG.md
 git commit -m "chore: release vX.Y.Z"
+git push origin main
 ```
 
-### 7.3 Create and push tag
-```bash
+### 7.3 Hand off to user
+At this point, hand off to the user to create and push the tag manually:
+
+```
+# Run these commands yourself to trigger the publish workflows:
 git tag vX.Y.Z
-git push origin main
 git push origin vX.Y.Z
 ```
 
@@ -162,4 +165,4 @@ Pushing the tag triggers all publish workflows automatically:
 
 ## Next Step
 
-After pushing the tag, follow the **post-release** skill to verify the release landed correctly.
+After the user pushes the tag, follow the **post-release** skill to verify the release landed correctly.

--- a/.claude/skills/validate-skills/SKILL.md
+++ b/.claude/skills/validate-skills/SKILL.md
@@ -16,12 +16,14 @@ The following skills must be available in the system reminder:
 4. **build** — Build commands
 5. **testing** — Test runner instructions
 6. **preview** — Screenshot and video capture
-7. **validate-skills** — This skill (self-check)
+7. **pre-release** — Pre-release checklist (tests, versioning, dry-run, tag)
+8. **post-release** — Post-release checklist (verify packages, docs, live demo)
+9. **validate-skills** — This skill (self-check)
 
 ## Validation Steps
 
 1. Check the system reminder in the current conversation for the list of available skills.
-2. Verify that all 7 skills listed above appear in the available skills list.
+2. Verify that all 9 skills listed above appear in the available skills list.
 3. Report the result:
    - If all skills are present: confirm and proceed with the task.
    - If any skill is missing: warn the user which skills are missing and suggest restarting the session or checking `.claude/skills/` directory structure.
@@ -36,6 +38,8 @@ Skills validation: OK
   - build: loaded
   - testing: loaded
   - preview: loaded
+  - pre-release: loaded
+  - post-release: loaded
   - validate-skills: loaded
-All 7 skills are available. Ready to proceed.
+All 9 skills are available. Ready to proceed.
 ```


### PR DESCRIPTION
## Summary

- Add `.claude/skills/pre-release/SKILL.md`: step-by-step checklist covering tests, full build, version consistency across 7 files, CHANGELOG update, docs build, visual screenshot verification, dry-run workflow, and release commit/tag creation
- Add `.claude/skills/post-release/SKILL.md`: verification checklist covering CI workflow monitoring, PyPI/npm/VSCode package availability, GitHub draft release publishing, docs site check, and live demo (AWS ECS) health
- Update `validate-skills/SKILL.md` to expect 9 skills (previously 7)

## Test plan

- [ ] Invoke `validate-skills` skill and confirm all 9 skills are listed as loaded
- [ ] Invoke `pre-release` skill and confirm the checklist steps are clear and complete
- [ ] Invoke `post-release` skill and confirm the verification steps are actionable