### PR TITLE
fix: add pages:write permission to release-dry-run workflow

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  pages: write
 
 jobs:
   dry-run-npm:


### PR DESCRIPTION
## Summary

- `docs.yml` declares `pages: write` in its workflow-level `permissions` block
- `release-dry-run.yml` was only granting `contents: read` and `id-token: write`
- GitHub Actions requires the calling workflow to grant at least the same permissions as a called reusable workflow — otherwise the run fails with `startup_failure`
- Add `pages: write` to `release-dry-run.yml` to fix this

## Test plan

- [ ] Trigger `release-dry-run.yml` via `workflow_dispatch` and confirm it no longer fails with `startup_failure`
- [ ] Verify the Dry run: Docs job completes successfully (docs build passes, deploy is skipped due to `dry_run: true`)
- [ ] Verify all four dry-run jobs (npm, PyPI, VSCode, Docs) pass

https://claude.ai/code/session_01HMXjXYtGNs3emmG87FBjmh