### PR TITLE
fix: ignore localhost dead links in VitePress docs build

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   title: "megane",
   description: "Spectacles for atomistic data",
   base: "/megane/",
+  ignoreDeadLinks: [/localhost/],
 
   head: [["link", { rel: "icon", href: "/megane/logo.png" }]],
 


### PR DESCRIPTION
## Summary

- VitePress was treating `http://localhost:8080` references in `getting-started.md` and `guide/cli.md` as dead links
- This caused the `Dry run: Docs / build` step in `release-dry-run.yml` to fail with exit code 1
- Fix: add `ignoreDeadLinks: [/localhost/]` to `docs/.vitepress/config.ts` to suppress false positives for localhost URLs while keeping dead link checks active for all other external links

## Test plan

- [ ] Trigger `release-dry-run.yml` workflow manually
- [ ] Confirm `Dry run: Docs / build` job passes

https://claude.ai/code/session_01VYoM1XgxwdsuhsmJPvEKZN