### PR TITLE
feat: add clean environment rendering verification to post-release checklist

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -29,6 +29,7 @@ Keep the first line under 72 characters. Add details in the body if needed.
    - Python changes: `python -m pytest`
 2. Ensure the build succeeds for frontend changes: `npm run build`
 3. Do NOT commit generated files: `crates/megane-wasm/pkg/`, `dist/`, `target/`, `node_modules/`, `dev-preview/`
+   Do NOT commit plan files: any file named `plan.md` or matching `*.plan.md` (these are local planning artifacts, not part of the codebase)
 4. Check if your changes require documentation updates:
    - Review `README.md`, `CLAUDE.md`, and files under `docs/` for any descriptions affected by your changes
    - If you added/changed/removed features, CLI options, API, commands, configuration, or architecture, update the corresponding documentation

--- a/.claude/skills/post-release/SKILL.md
+++ b/.claude/skills/post-release/SKILL.md
@@ -67,7 +67,7 @@ Expected output: `X.Y.Z`
 ```bash
 ORIG_REMOTE=$(git remote get-url origin)
 git remote set-url origin https://github.com/hodakamori/megane.git
-gh run view --workflow=publish-vscode.yml --limit 1
+gh run list --workflow=publish-vscode.yml --limit 1
 git remote set-url origin "$ORIG_REMOTE"
 ```
 Confirm the extension version matches `X.Y.Z`.

--- a/.claude/skills/post-release/SKILL.md
+++ b/.claude/skills/post-release/SKILL.md
@@ -56,11 +56,11 @@ gh run view --workflow=publish-vscode.yml --limit 1
 ```
 Confirm the extension version matches `X.Y.Z`.
 
-## Phase 2.5: Clean Environment Rendering Verification
+## Phase 3: Clean Environment Rendering Verification
 
 Verify that the published packages actually work in a clean environment — not just that they exist, but that molecular structures render correctly.
 
-### 2.5.1 Python + npm: widget rendering in fresh virtualenv
+### 3.1 Python + npm: widget rendering in fresh virtualenv
 
 Install from PyPI into an isolated virtualenv (no local source files), then run the existing E2E widget test against it. This covers both the Python package (PyO3 native extension, parsers) and the npm package (megane-viewer WASM loaded by anywidget in the browser).
 
@@ -75,14 +75,14 @@ $VENV/bin/pip install megane==X.Y.Z jupyterlab
 PATH=$VENV/bin:$PATH node tests/e2e/test_widget_render.mjs
 ```
 
-Expected: all assertions pass — canvas created, non-white pixels rendered (atoms visible), no critical JS errors.
+Expected: all assertions pass — canvas created, non-white pixels rendered (atoms visible), no critical JS errors. Screenshots saved to `tests/e2e/screenshot_1crn.png` and `tests/e2e/screenshot_water_100k.png`.
 
 This test verifies:
 - PyPI install succeeds and PyO3 native extension loads
 - megane-viewer (npm) WASM is bundled correctly and loads in browser
 - Molecule rendering pipeline works end-to-end
 
-### 2.5.2 VS Code extension: rendering via code-server
+### 3.2 VS Code extension: rendering via code-server
 
 Download the VSIX from the VS Code Marketplace (the same artifact users install), run it in code-server, and verify the megane custom editor renders a molecule.
 
@@ -101,15 +101,15 @@ This test verifies:
 - Extension installs and activates correctly in code-server
 - Webview loads WASM and renders the molecular structure
 
-## Phase 3: GitHub Release Notes & Publishing
+## Phase 4: GitHub Release Notes & Publishing
 
-### 3.1 Find the previous release tag
+### 4.1 Find the previous release tag
 ```bash
 git tag --sort=-version:refname | grep '^v' | head -5
 ```
 Identify the previous tag (e.g., `vX.Y.Z-1`).
 
-### 3.2 Generate release notes from diff
+### 4.2 Generate release notes from diff
 Collect all commits between the previous tag and the new tag:
 ```bash
 git log vPREV..vX.Y.Z --oneline --no-merges
@@ -149,7 +149,7 @@ Search for "megane" in the VS Code Extensions panel
 **Full Changelog**: https://github.com/hodakamori/megane/compare/vPREV...vX.Y.Z
 ```
 
-### 3.3 Update the draft release with generated notes
+### 4.3 Update the draft release with generated notes
 ```bash
 gh release edit vX.Y.Z --notes "$(cat <<'EOF'
 ## What's Changed
@@ -179,15 +179,26 @@ EOF
 )"
 ```
 
-### 3.4 Confirm the draft is ready
+### 4.4 Upload rendering verification screenshots
+
+Attach the screenshots captured in Phase 3 to the release as visual proof that rendering works correctly after install.
+
+```bash
+gh release upload vX.Y.Z \
+  tests/e2e/screenshot_1crn.png \
+  tests/e2e/screenshot_water_100k.png \
+  tests/e2e/screenshot_vscode_render.png
+```
+
+### 4.5 Confirm the draft is ready
 ```bash
 gh release view vX.Y.Z
 ```
-Verify the notes look correct. The release remains as a **draft** — hand off to the user to review and publish it manually.
+Verify the notes look correct and the screenshots are attached. The release remains as a **draft** — hand off to the user to review and publish it manually.
 
-## Phase 4: Documentation
+## Phase 5: Documentation
 
-### 4.1 GitHub Pages deployment
+### 5.1 GitHub Pages deployment
 Confirm `docs.yml` workflow succeeded:
 ```bash
 gh run list --workflow=docs.yml --limit 1
@@ -197,16 +208,16 @@ Visit the docs site and verify the version shown matches `X.Y.Z`:
 - Check the version badge or footer
 - Verify new features/APIs mentioned in the release are documented
 
-## Phase 5: Live Demo
+## Phase 6: Live Demo
 
-### 5.1 AWS ECS demo health
+### 6.1 AWS ECS demo health
 After a release, the `deploy.yml` workflow may re-deploy. Check:
 ```bash
 gh run list --workflow=deploy.yml --limit 1
 ```
 If the demo was updated, verify it loads correctly in the browser.
 
-## Phase 6: Announcement Checklist (manual)
+## Phase 7: Announcement Checklist (manual)
 
 These items require manual action outside of automated workflows:
 
@@ -224,7 +235,8 @@ Once all phases are complete, the release is done. Key verification:
 | All CI workflows | `gh run list --limit 10` |
 | PyPI version | `pip index versions megane` |
 | npm version | `npm view megane-viewer version` |
-| Python + npm rendering (clean venv) | See Phase 2.5.1 — install from PyPI, then `node tests/e2e/test_widget_render.mjs` |
+| Python + npm rendering (clean venv) | See Phase 3.1 — install from PyPI, then `node tests/e2e/test_widget_render.mjs` |
 | VS Code rendering (code-server) | `node tests/e2e/test_vscode_render.mjs X.Y.Z` |
+| Screenshots uploaded to release | `gh release view vX.Y.Z` |
 | GitHub release draft with notes ready | `gh release view vX.Y.Z` |
 | Docs site updated | `gh run list --workflow=docs.yml` |

--- a/.claude/skills/post-release/SKILL.md
+++ b/.claude/skills/post-release/SKILL.md
@@ -222,6 +222,8 @@ git remote set-url origin "$ORIG_REMOTE"
 ```
 Verify the notes look correct and the three screenshots are listed as assets. The release remains as a **draft** — hand off to the user to review and publish it manually.
 
+> **CRITICAL: Never publish the release.** Publishing (making the draft public) is a manual step performed exclusively by the user. Do NOT run `gh release edit vX.Y.Z --draft=false` or any equivalent command. Stop after confirming the draft looks correct.
+
 ## Phase 5: Documentation
 
 ### 5.1 GitHub Pages deployment

--- a/.claude/skills/post-release/SKILL.md
+++ b/.claude/skills/post-release/SKILL.md
@@ -56,6 +56,51 @@ gh run view --workflow=publish-vscode.yml --limit 1
 ```
 Confirm the extension version matches `X.Y.Z`.
 
+## Phase 2.5: Clean Environment Rendering Verification
+
+Verify that the published packages actually work in a clean environment — not just that they exist, but that molecular structures render correctly.
+
+### 2.5.1 Python + npm: widget rendering in fresh virtualenv
+
+Install from PyPI into an isolated virtualenv (no local source files), then run the existing E2E widget test against it. This covers both the Python package (PyO3 native extension, parsers) and the npm package (megane-viewer WASM loaded by anywidget in the browser).
+
+```bash
+# Create isolated virtualenv and install from PyPI only
+VENV=/tmp/megane-verify-X.Y.Z
+python -m venv $VENV
+$VENV/bin/pip install megane==X.Y.Z jupyterlab
+
+# Run the widget E2E test using the PyPI-installed megane
+# PATH override ensures local dev installation is NOT used
+PATH=$VENV/bin:$PATH node tests/e2e/test_widget_render.mjs
+```
+
+Expected: all assertions pass — canvas created, non-white pixels rendered (atoms visible), no critical JS errors.
+
+This test verifies:
+- PyPI install succeeds and PyO3 native extension loads
+- megane-viewer (npm) WASM is bundled correctly and loads in browser
+- Molecule rendering pipeline works end-to-end
+
+### 2.5.2 VS Code extension: rendering via code-server
+
+Download the VSIX from the VS Code Marketplace (the same artifact users install), run it in code-server, and verify the megane custom editor renders a molecule.
+
+```bash
+# Run the VS Code rendering E2E test
+# Downloads VSIX from Marketplace, installs in code-server, verifies canvas render
+node tests/e2e/test_vscode_render.mjs X.Y.Z
+```
+
+Expected: `PASS` for all assertions — canvas created in webview, non-white pixels rendered, no critical JS errors. Screenshot saved to `tests/e2e/screenshot_vscode_render.png`.
+
+If code-server is not installed, the script installs it automatically via `npm install -g code-server`.
+
+This test verifies:
+- VSIX is available on VS Code Marketplace at version X.Y.Z
+- Extension installs and activates correctly in code-server
+- Webview loads WASM and renders the molecular structure
+
 ## Phase 3: GitHub Release Notes & Publishing
 
 ### 3.1 Find the previous release tag
@@ -179,5 +224,7 @@ Once all phases are complete, the release is done. Key verification:
 | All CI workflows | `gh run list --limit 10` |
 | PyPI version | `pip index versions megane` |
 | npm version | `npm view megane-viewer version` |
+| Python + npm rendering (clean venv) | See Phase 2.5.1 — install from PyPI, then `node tests/e2e/test_widget_render.mjs` |
+| VS Code rendering (code-server) | `node tests/e2e/test_vscode_render.mjs X.Y.Z` |
 | GitHub release draft with notes ready | `gh release view vX.Y.Z` |
 | Docs site updated | `gh run list --workflow=docs.yml` |

--- a/.claude/skills/post-release/SKILL.md
+++ b/.claude/skills/post-release/SKILL.md
@@ -6,11 +6,22 @@ description: Post-release checklist for megane. Run after pushing a release tag 
 
 Run this skill after pushing a release tag (`vX.Y.Z`). Verify every item before declaring the release complete.
 
+> **Note on `gh` commands:** The git remote points to a local proxy, not GitHub directly. Wrap all `gh` commands that reference the repository with the remote URL swap from the `github-cli` skill:
+> ```bash
+> ORIG_REMOTE=$(git remote get-url origin)
+> git remote set-url origin https://github.com/hodakamori/megane.git
+> gh <command>
+> git remote set-url origin "$ORIG_REMOTE"
+> ```
+
 ## Phase 1: CI Workflow Status
 
 ### 1.1 Monitor all publish workflows
 ```bash
+ORIG_REMOTE=$(git remote get-url origin)
+git remote set-url origin https://github.com/hodakamori/megane.git
 gh run list --limit 10
+git remote set-url origin "$ORIG_REMOTE"
 ```
 Wait for all tag-triggered workflows to finish. Expected workflows:
 - `publish-pypi.yml` — Python wheels to PyPI
@@ -21,7 +32,10 @@ Wait for all tag-triggered workflows to finish. Expected workflows:
 
 To inspect a failing workflow:
 ```bash
+ORIG_REMOTE=$(git remote get-url origin)
+git remote set-url origin https://github.com/hodakamori/megane.git
 gh run view <run-id> --log-failed
+git remote set-url origin "$ORIG_REMOTE"
 ```
 
 All workflows must show `success` before proceeding.
@@ -50,9 +64,11 @@ npm view megane-viewer@X.Y.Z version
 Expected output: `X.Y.Z`
 
 ### 2.3 VS Code Marketplace
-Check the extension page on the marketplace, or verify via:
 ```bash
+ORIG_REMOTE=$(git remote get-url origin)
+git remote set-url origin https://github.com/hodakamori/megane.git
 gh run view --workflow=publish-vscode.yml --limit 1
+git remote set-url origin "$ORIG_REMOTE"
 ```
 Confirm the extension version matches `X.Y.Z`.
 
@@ -103,6 +119,14 @@ This test verifies:
 
 ## Phase 4: GitHub Release Notes & Publishing
 
+All `gh release` commands in this phase require the remote URL workaround.
+
+```bash
+# Set once and restore after all release commands
+ORIG_REMOTE=$(git remote get-url origin)
+git remote set-url origin https://github.com/hodakamori/megane.git
+```
+
 ### 4.1 Find the previous release tag
 ```bash
 git tag --sort=-version:refname | grep '^v' | head -5
@@ -117,7 +141,6 @@ git log vPREV..vX.Y.Z --oneline --no-merges
 
 Also read the CHANGELOG entry for the new version:
 ```bash
-# Extract the section for vX.Y.Z from CHANGELOG.md
 awk '/^## \[X\.Y\.Z\]/,/^## \[/' CHANGELOG.md | head -50
 ```
 
@@ -193,15 +216,20 @@ gh release upload vX.Y.Z \
 ### 4.5 Confirm the draft is ready
 ```bash
 gh release view vX.Y.Z
+
+# Restore remote
+git remote set-url origin "$ORIG_REMOTE"
 ```
-Verify the notes look correct and the screenshots are attached. The release remains as a **draft** — hand off to the user to review and publish it manually.
+Verify the notes look correct and the three screenshots are listed as assets. The release remains as a **draft** — hand off to the user to review and publish it manually.
 
 ## Phase 5: Documentation
 
 ### 5.1 GitHub Pages deployment
-Confirm `docs.yml` workflow succeeded:
 ```bash
+ORIG_REMOTE=$(git remote get-url origin)
+git remote set-url origin https://github.com/hodakamori/megane.git
 gh run list --workflow=docs.yml --limit 1
+git remote set-url origin "$ORIG_REMOTE"
 ```
 
 Visit the docs site and verify the version shown matches `X.Y.Z`:
@@ -211,9 +239,11 @@ Visit the docs site and verify the version shown matches `X.Y.Z`:
 ## Phase 6: Live Demo
 
 ### 6.1 AWS ECS demo health
-After a release, the `deploy.yml` workflow may re-deploy. Check:
 ```bash
+ORIG_REMOTE=$(git remote get-url origin)
+git remote set-url origin https://github.com/hodakamori/megane.git
 gh run list --workflow=deploy.yml --limit 1
+git remote set-url origin "$ORIG_REMOTE"
 ```
 If the demo was updated, verify it loads correctly in the browser.
 
@@ -232,11 +262,10 @@ Once all phases are complete, the release is done. Key verification:
 
 | Item | Command |
 |---|---|
-| All CI workflows | `gh run list --limit 10` |
+| All CI workflows | `gh run list --limit 10` (with remote swap) |
 | PyPI version | `pip index versions megane` |
-| npm version | `npm view megane-viewer version` |
-| Python + npm rendering (clean venv) | See Phase 3.1 — install from PyPI, then `node tests/e2e/test_widget_render.mjs` |
+| npm version | `npm view megane-viewer@X.Y.Z version` |
+| Python + npm rendering (clean venv) | Phase 3.1: install from PyPI → `node tests/e2e/test_widget_render.mjs` |
 | VS Code rendering (code-server) | `node tests/e2e/test_vscode_render.mjs X.Y.Z` |
-| Screenshots uploaded to release | `gh release view vX.Y.Z` |
-| GitHub release draft with notes ready | `gh release view vX.Y.Z` |
-| Docs site updated | `gh run list --workflow=docs.yml` |
+| Release notes + screenshots uploaded | `gh release view vX.Y.Z` (with remote swap) |
+| Docs site updated | `gh run list --workflow=docs.yml` (with remote swap) |

--- a/tests/e2e/test_vscode_render.mjs
+++ b/tests/e2e/test_vscode_render.mjs
@@ -23,7 +23,6 @@ import { mkdirSync, writeFileSync, existsSync } from "fs";
 import { join } from "path";
 import { createWriteStream } from "fs";
 import { get as httpsGet } from "https";
-import { randomBytes } from "crypto";
 
 // Playwright is installed globally; resolve it explicitly.
 const _require = createRequire("/opt/node22/lib/node_modules/");
@@ -33,6 +32,10 @@ const VERSION = process.argv[2];
 if (!VERSION) {
   console.error("Usage: node test_vscode_render.mjs <version>");
   console.error("Example: node test_vscode_render.mjs 0.4.0");
+  process.exit(1);
+}
+if (!/^\d+\.\d+\.\d+$/.test(VERSION)) {
+  console.error(`Invalid version format: ${VERSION}. Expected semver (e.g. 0.4.0)`);
   process.exit(1);
 }
 
@@ -115,7 +118,7 @@ async function downloadVsixAsync(url, destPath) {
 
 function installExtension(vsixPath) {
   console.log(`Installing extension from ${vsixPath}...`);
-  execSync(`code-server --install-extension "${vsixPath}"`, { stdio: "inherit" });
+  execFileSync("code-server", ["--install-extension", vsixPath], { stdio: "inherit" });
   console.log("Extension installed");
 }
 
@@ -165,46 +168,6 @@ async function startCodeServer() {
       reject(err);
     });
   });
-}
-
-/**
- * Check if a WebGL canvas contains non-white pixels (i.e., something was rendered).
- */
-async function checkCanvasHasContent(page, canvasSelector) {
-  return page.evaluate((sel) => {
-    const canvas = document.querySelector(sel);
-    if (!canvas) return { hasContent: false, totalPixels: 0, nonWhitePixels: 0 };
-
-    const gl = canvas.getContext("webgl2") || canvas.getContext("webgl");
-    if (!gl) {
-      const ctx = canvas.getContext("2d");
-      if (!ctx) return { hasContent: false, totalPixels: 0, nonWhitePixels: 0 };
-      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-      let nonWhite = 0;
-      for (let i = 0; i < imageData.data.length; i += 4) {
-        if (imageData.data[i] < 250 || imageData.data[i + 1] < 250 || imageData.data[i + 2] < 250) {
-          nonWhite++;
-        }
-      }
-      const total = canvas.width * canvas.height;
-      return { hasContent: nonWhite > total * 0.001, totalPixels: total, nonWhitePixels: nonWhite };
-    }
-
-    const width = gl.drawingBufferWidth;
-    const height = gl.drawingBufferHeight;
-    const pixels = new Uint8Array(width * height * 4);
-    gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
-
-    let nonWhite = 0;
-    const total = width * height;
-    for (let i = 0; i < pixels.length; i += 4) {
-      if (pixels[i] < 250 || pixels[i + 1] < 250 || pixels[i + 2] < 250) {
-        nonWhite++;
-      }
-    }
-
-    return { hasContent: nonWhite > total * 0.001, totalPixels: total, nonWhitePixels: nonWhite };
-  }, canvasSelector);
 }
 
 // ---- Main ----

--- a/tests/e2e/test_vscode_render.mjs
+++ b/tests/e2e/test_vscode_render.mjs
@@ -1,0 +1,376 @@
+/**
+ * E2E rendering test for the megane VS Code extension.
+ *
+ * Downloads the VSIX from the VS Code Marketplace, installs it into
+ * code-server, opens a PDB file, and verifies that:
+ *   1. The megane custom editor activates (canvas element created)
+ *   2. No critical JS errors occur
+ *   3. The canvas contains non-white pixels (atoms rendered)
+ *
+ * Usage:
+ *   node tests/e2e/test_vscode_render.mjs <version>
+ *   node tests/e2e/test_vscode_render.mjs 0.4.0
+ *
+ * Requires:
+ *   - code-server (installed via `npm install -g code-server` if missing)
+ *   - playwright (global install at /opt/node22/lib/node_modules/)
+ *   - Internet access to download VSIX from VS Code Marketplace
+ */
+
+import { createRequire } from "module";
+import { spawn, execSync, execFileSync } from "child_process";
+import { mkdirSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+import { createWriteStream } from "fs";
+import { get as httpsGet } from "https";
+import { randomBytes } from "crypto";
+
+// Playwright is installed globally; resolve it explicitly.
+const _require = createRequire("/opt/node22/lib/node_modules/");
+const { chromium } = _require("playwright");
+
+const VERSION = process.argv[2];
+if (!VERSION) {
+  console.error("Usage: node test_vscode_render.mjs <version>");
+  console.error("Example: node test_vscode_render.mjs 0.4.0");
+  process.exit(1);
+}
+
+const PUBLISHER = "hodakamori";
+const EXTENSION_NAME = "vscode-megane";
+const MARKETPLACE_URL = `https://marketplace.visualstudio.com/_apis/public/gallery/publishers/${PUBLISHER}/vsextensions/${EXTENSION_NAME}/${VERSION}/vspackage`;
+const VSIX_PATH = `/tmp/vscode-megane-${VERSION}.vsix`;
+const WORKSPACE_DIR = `/tmp/megane-ws-${VERSION}`;
+const PORT = 38000 + Math.floor(Math.random() * 1000);
+const CWD = process.cwd();
+
+// Minimal 3-atom water molecule PDB for testing
+const TEST_PDB = `ATOM      1  O   HOH A   1       0.000   0.000   0.117  1.00  0.00           O
+ATOM      2  H1  HOH A   1       0.757   0.000  -0.469  1.00  0.00           H
+ATOM      3  H2  HOH A   1      -0.757   0.000  -0.469  1.00  0.00           H
+END
+`;
+
+// ---- Helpers ----
+
+function assert(condition, message) {
+  if (!condition) {
+    console.error(`FAIL: ${message}`);
+    process.exitCode = 1;
+    throw new Error(message);
+  }
+  console.log(`PASS: ${message}`);
+}
+
+function ensureCodeServer() {
+  try {
+    execFileSync("which", ["code-server"], { stdio: "ignore" });
+    console.log("code-server is available");
+  } catch {
+    console.log("code-server not found, installing via npm...");
+    execSync("npm install -g code-server", { stdio: "inherit" });
+    console.log("code-server installed");
+  }
+}
+
+async function downloadVsixAsync(url, destPath) {
+  if (existsSync(destPath)) {
+    console.log(`VSIX already exists at ${destPath}, skipping download`);
+    return;
+  }
+
+  console.log(`Downloading VSIX from Marketplace...`);
+
+  return new Promise((resolve, reject) => {
+    const file = createWriteStream(destPath);
+
+    function doGet(requestUrl) {
+      const lib = requestUrl.startsWith("https://") ? httpsGet : null;
+      if (!lib) {
+        reject(new Error("Only HTTPS URLs are supported"));
+        return;
+      }
+      lib(requestUrl, { headers: { "User-Agent": "megane-release-verify/1.0" } }, (response) => {
+        if (response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
+          doGet(response.headers.location);
+          return;
+        }
+        if (response.statusCode !== 200) {
+          reject(new Error(`Failed to download VSIX: HTTP ${response.statusCode} from ${requestUrl}`));
+          return;
+        }
+        response.pipe(file);
+        file.on("finish", () => {
+          file.close();
+          console.log(`VSIX downloaded to ${destPath}`);
+          resolve();
+        });
+        file.on("error", reject);
+      }).on("error", reject);
+    }
+
+    doGet(url);
+  });
+}
+
+function installExtension(vsixPath) {
+  console.log(`Installing extension from ${vsixPath}...`);
+  execSync(`code-server --install-extension "${vsixPath}"`, { stdio: "inherit" });
+  console.log("Extension installed");
+}
+
+function setupWorkspace() {
+  mkdirSync(WORKSPACE_DIR, { recursive: true });
+  const pdbPath = join(WORKSPACE_DIR, "test.pdb");
+  writeFileSync(pdbPath, TEST_PDB);
+  console.log(`Workspace created at ${WORKSPACE_DIR}`);
+  console.log(`Test PDB written to ${pdbPath}`);
+  return pdbPath;
+}
+
+async function startCodeServer() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(
+      "code-server",
+      [
+        "--auth", "none",
+        "--port", String(PORT),
+        "--disable-telemetry",
+        WORKSPACE_DIR,
+      ],
+      {
+        stdio: ["ignore", "pipe", "pipe"],
+        env: { ...process.env, HOME: "/root" },
+      }
+    );
+
+    const timer = setTimeout(
+      () => reject(new Error("code-server did not start within 30s")),
+      30000
+    );
+
+    const handler = (data) => {
+      const line = data.toString();
+      process.stdout.write(`[code-server] ${line}`);
+      if (line.includes("HTTP server listening") || line.includes(`localhost:${PORT}`)) {
+        clearTimeout(timer);
+        resolve(proc);
+      }
+    };
+
+    proc.stdout.on("data", handler);
+    proc.stderr.on("data", handler);
+    proc.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+/**
+ * Check if a WebGL canvas contains non-white pixels (i.e., something was rendered).
+ */
+async function checkCanvasHasContent(page, canvasSelector) {
+  return page.evaluate((sel) => {
+    const canvas = document.querySelector(sel);
+    if (!canvas) return { hasContent: false, totalPixels: 0, nonWhitePixels: 0 };
+
+    const gl = canvas.getContext("webgl2") || canvas.getContext("webgl");
+    if (!gl) {
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return { hasContent: false, totalPixels: 0, nonWhitePixels: 0 };
+      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      let nonWhite = 0;
+      for (let i = 0; i < imageData.data.length; i += 4) {
+        if (imageData.data[i] < 250 || imageData.data[i + 1] < 250 || imageData.data[i + 2] < 250) {
+          nonWhite++;
+        }
+      }
+      const total = canvas.width * canvas.height;
+      return { hasContent: nonWhite > total * 0.001, totalPixels: total, nonWhitePixels: nonWhite };
+    }
+
+    const width = gl.drawingBufferWidth;
+    const height = gl.drawingBufferHeight;
+    const pixels = new Uint8Array(width * height * 4);
+    gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+
+    let nonWhite = 0;
+    const total = width * height;
+    for (let i = 0; i < pixels.length; i += 4) {
+      if (pixels[i] < 250 || pixels[i + 1] < 250 || pixels[i + 2] < 250) {
+        nonWhite++;
+      }
+    }
+
+    return { hasContent: nonWhite > total * 0.001, totalPixels: total, nonWhitePixels: nonWhite };
+  }, canvasSelector);
+}
+
+// ---- Main ----
+
+let server = null;
+let browser = null;
+
+try {
+  console.log(`\n=== megane VS Code Extension Rendering Test (v${VERSION}) ===\n`);
+
+  // Step 1: Ensure code-server is available
+  ensureCodeServer();
+
+  // Step 2: Download VSIX from Marketplace
+  await downloadVsixAsync(MARKETPLACE_URL, VSIX_PATH);
+
+  // Step 3: Install extension into code-server
+  installExtension(VSIX_PATH);
+
+  // Step 4: Set up workspace with test PDB
+  setupWorkspace();
+
+  // Step 5: Start code-server
+  server = await startCodeServer();
+  console.log(`code-server running on port ${PORT}`);
+
+  // Allow code-server to fully initialize
+  await new Promise((r) => setTimeout(r, 3000));
+
+  // Step 6: Launch Playwright
+  browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 720 },
+  });
+  const page = await context.newPage();
+
+  const jsErrors = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") jsErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => jsErrors.push(err.message));
+
+  // Step 7: Open code-server and navigate to the workspace
+  const workspaceUrl = `http://localhost:${PORT}/?folder=${encodeURIComponent(WORKSPACE_DIR)}`;
+  console.log(`Navigating to: ${workspaceUrl}`);
+  await page.goto(workspaceUrl, { waitUntil: "domcontentloaded", timeout: 30000 });
+
+  // Wait for code-server UI to load (workbench)
+  await page.waitForSelector(".monaco-workbench", { timeout: 30000 });
+  console.log("code-server workbench loaded");
+
+  // Wait a bit for extensions to activate
+  await page.waitForTimeout(3000);
+
+  // Step 8: Open test.pdb via the file explorer
+  // Use the Explorer view to click on test.pdb
+  console.log("Opening test.pdb...");
+
+  // Try to open file via keyboard shortcut (Ctrl+P / Quick Open)
+  await page.keyboard.press("Control+p");
+  await page.waitForTimeout(500);
+  await page.keyboard.type("test.pdb");
+  await page.waitForTimeout(1000);
+  await page.keyboard.press("Enter");
+  console.log("File open command issued");
+
+  // Wait for the megane custom editor canvas to appear
+  // The canvas is inside a webview iframe
+  console.log("Waiting for megane custom editor to activate...");
+
+  // code-server renders webviews in iframes; wait for the webview iframe
+  let canvasFound = false;
+  let canvasResult = { hasContent: false, totalPixels: 0, nonWhitePixels: 0 };
+
+  try {
+    // Wait for a webview frame to appear (megane opens in a webview)
+    await page.waitForSelector(".webview", { timeout: 20000 });
+    console.log("Webview element detected");
+
+    // Allow WASM to load and Three.js to render
+    await page.waitForTimeout(5000);
+
+    // Access the webview iframe content
+    const frames = page.frames();
+    console.log(`Total frames: ${frames.length}`);
+
+    for (const frame of frames) {
+      try {
+        const canvas = await frame.$("canvas");
+        if (canvas) {
+          console.log(`Canvas found in frame: ${frame.url()}`);
+          canvasFound = true;
+          canvasResult = await frame.evaluate(() => {
+            const canvas = document.querySelector("canvas");
+            if (!canvas) return { hasContent: false, totalPixels: 0, nonWhitePixels: 0 };
+
+            const gl = canvas.getContext("webgl2") || canvas.getContext("webgl");
+            if (!gl) return { hasContent: false, totalPixels: 0, nonWhitePixels: 0 };
+
+            const width = gl.drawingBufferWidth;
+            const height = gl.drawingBufferHeight;
+            const pixels = new Uint8Array(width * height * 4);
+            gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+
+            let nonWhite = 0;
+            const total = width * height;
+            for (let i = 0; i < pixels.length; i += 4) {
+              if (pixels[i] < 250 || pixels[i + 1] < 250 || pixels[i + 2] < 250) {
+                nonWhite++;
+              }
+            }
+            return { hasContent: nonWhite > total * 0.001, totalPixels: total, nonWhitePixels: nonWhite };
+          });
+          break;
+        }
+      } catch {
+        // Frame may not be accessible (cross-origin); continue
+      }
+    }
+  } catch (err) {
+    console.log(`Warning: ${err.message}`);
+  }
+
+  // Take screenshot regardless of outcome
+  const screenshotPath = join(CWD, "tests", "e2e", "screenshot_vscode_render.png");
+  await page.screenshot({ path: screenshotPath });
+  console.log(`Screenshot saved: ${screenshotPath}`);
+
+  // ---- Assertions ----
+
+  assert(canvasFound, "megane custom editor canvas is created in webview");
+
+  console.log(
+    `  Canvas: ${canvasResult.nonWhitePixels}/${canvasResult.totalPixels} non-white pixels`
+  );
+  assert(
+    canvasResult.hasContent,
+    `Canvas contains rendered atoms (${canvasResult.nonWhitePixels} non-white pixels)`
+  );
+
+  const criticalErrors = jsErrors.filter(
+    (e) =>
+      (e.includes("Cannot read propert") ||
+        e.includes("acquireVsCodeApi") ||
+        e.includes("megane")) &&
+      !e.includes("Shader Error") &&
+      !e.includes("WebGLProgram")
+  );
+  assert(
+    criticalErrors.length === 0,
+    `No critical JS errors (found ${criticalErrors.length}: ${JSON.stringify(criticalErrors)})`
+  );
+
+  console.log("\n=== VS Code Extension Rendering Test: PASSED ===");
+} catch (err) {
+  console.error("\nVS Code extension rendering test FAILED:", err.message);
+  process.exitCode = 1;
+} finally {
+  if (browser) await browser.close();
+  if (server) {
+    server.kill();
+    server.stdout?.destroy();
+    server.stderr?.destroy();
+    server.unref();
+    setTimeout(() => {
+      try { server.kill("SIGKILL"); } catch {}
+    }, 3000).unref();
+  }
+}


### PR DESCRIPTION
## Summary

Add Phase 3 (Clean Environment Rendering Verification) to the post-release skill, plus a new E2E test script for VS Code extension rendering. Also harden the skill with operational guardrails.

### Phase 3: Clean Environment Rendering Verification

**3.1 Python + npm — widget rendering in fresh virtualenv**
Install `megane` from PyPI into an isolated virtualenv (no local source), then run the existing `test_widget_render.mjs` against it. Verifies the PyO3 native extension loads and the WASM bundle renders molecules in the browser canvas. Covers both the Python and npm packages in one pass.

**3.2 VS Code extension — rendering via code-server**
New script `tests/e2e/test_vscode_render.mjs`:
- Downloads VSIX directly from VS Code Marketplace
- Installs it into code-server (auto-installs code-server if missing)
- Opens a test PDB file via Playwright
- Verifies the megane custom editor renders a molecule (WebGL canvas pixel check)
- Saves screenshot to `tests/e2e/screenshot_vscode_render.png`

### Phase 4 updates
- Add step 4.4: upload Phase 3 screenshots to the GitHub Release draft as visual proof
- Add CRITICAL note: publishing the draft is a manual user action only — agents must never run `gh release edit --draft=false`

### Other changes
- All `gh` commands now include the local proxy remote URL workaround
- Phases renumbered: old 3–6 → new 4–7 to accommodate the new Phase 3
- commit skill: plan files (`plan.md`, `*.plan.md`) added to the do-not-commit list

## Test plan

- [ ] Run `node tests/e2e/test_vscode_render.mjs <version>` after a real release to confirm Marketplace download and canvas rendering pass
- [ ] Run Phase 3.1 commands with a PyPI-installed venv to confirm widget rendering works end-to-end
- [ ] Confirm `gh release upload` attaches screenshots to the draft release

https://claude.ai/code/session_011SHxQRS18XkNCDgqR3qryK