### PR TITLE
chore: ignore root-level venv artifacts in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ __pycache__/
 *.pyc
 *.egg-info/
 .venv/
+pyvenv.cfg
+/bin/
+/lib/
+/lib64
 .vite/
 *.whl
 tests/fixtures/.*.npz


### PR DESCRIPTION
## Summary

- Adds `pyvenv.cfg`, `/bin/`, `/lib/`, `/lib64` to `.gitignore` to exclude Python virtual environment files created directly in the project root (e.g. `python -m venv /home/user/megane`)
- The existing `.venv/` pattern only covers named `.venv` directories; this covers the case where a venv is created at the repo root itself

## Test plan

- [ ] Confirm `git status` shows no untracked files after creating a venv in the project root

https://claude.ai/code/session_01PNh9fKnqvsTJXSmMNP9yFC