### PR TITLE
feat: extract embedded vector channels from GRO and LAMMPS dump files

### DIFF
--- a/crates/megane-core/src/cif.rs
+++ b/crates/megane-core/src/cif.rs
@@ -279,6 +279,7 @@ pub fn parse(text: &str) -> Result<ParsedStructure, String> {
         box_matrix,
         frame_positions: Vec::new(),
         atom_labels: labels,
+        vector_channels: vec![],
     })
 }
 

--- a/crates/megane-core/src/gro.rs
+++ b/crates/megane-core/src/gro.rs
@@ -16,6 +16,7 @@ use std::collections::HashSet;
 
 use crate::atomic::element_from_atom_name;
 use crate::bonds;
+use crate::trajectory::{VectorChannel, VectorFrame};
 
 pub fn parse(text: &str) -> Result<crate::parser::ParsedStructure, String> {
     let lines: Vec<&str> = text.lines().collect();
@@ -40,6 +41,9 @@ pub fn parse(text: &str) -> Result<crate::parser::ParsedStructure, String> {
     let mut positions = Vec::with_capacity(n_atoms * 3);
     let mut elements = Vec::with_capacity(n_atoms);
     let mut labels = Vec::with_capacity(n_atoms);
+    // Velocity buffer: filled only when ALL atoms have velocity columns (line.len() >= 68).
+    let mut velocities: Vec<f32> = Vec::with_capacity(n_atoms * 3);
+    let mut has_velocities = true;
 
     for i in 0..n_atoms {
         let line = lines[i + 2];
@@ -81,6 +85,22 @@ pub fn parse(text: &str) -> Result<crate::parser::ParsedStructure, String> {
         positions.push(x * 10.0);
         positions.push(y * 10.0);
         positions.push(z * 10.0);
+
+        // Optional velocity columns (nm/ps): cols 44-52, 52-60, 60-68
+        if has_velocities {
+            if line.len() >= 68 {
+                let vx: f32 = line[44..52].trim().parse().unwrap_or(0.0);
+                let vy: f32 = line[52..60].trim().parse().unwrap_or(0.0);
+                let vz: f32 = line[60..68].trim().parse().unwrap_or(0.0);
+                velocities.push(vx);
+                velocities.push(vy);
+                velocities.push(vz);
+            } else {
+                // This atom lacks velocity columns — disable the channel.
+                has_velocities = false;
+                velocities.clear();
+            }
+        }
     }
 
     // Last line: box vectors
@@ -97,6 +117,19 @@ pub fn parse(text: &str) -> Result<crate::parser::ParsedStructure, String> {
         None
     };
 
+    // Build velocity channel when all atoms had valid velocity data.
+    let vector_channels = if has_velocities && !velocities.is_empty() {
+        vec![VectorChannel {
+            name: "velocity".to_string(),
+            frames: vec![VectorFrame {
+                frame: 0,
+                vectors: velocities,
+            }],
+        }]
+    } else {
+        vec![]
+    };
+
     Ok(crate::parser::ParsedStructure {
         n_atoms,
         positions,
@@ -107,6 +140,7 @@ pub fn parse(text: &str) -> Result<crate::parser::ParsedStructure, String> {
         box_matrix,
         frame_positions: Vec::new(),
         atom_labels,
+        vector_channels,
     })
 }
 
@@ -178,5 +212,40 @@ mod tests {
         assert!((m[0] - 10.0).abs() < 0.01);
         assert!((m[4] - 20.0).abs() < 0.01);
         assert!((m[8] - 30.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_parse_gro_no_velocities() {
+        // Lines without velocity columns → no vector channels.
+        let gro = "Water\n1\n    1SOL     OW    1   0.100   0.200   0.300\n   1.00000   1.00000   1.00000\n";
+        let result = parse(gro).expect("parse failed");
+        assert!(result.vector_channels.is_empty());
+    }
+
+    #[test]
+    fn test_parse_gro_with_velocities() {
+        // Atom line is exactly 68 chars or more → velocity channel produced.
+        // GRO format: resnum(5) resname(5) atomname(5) atomnum(5) x(8) y(8) z(8) vx(8) vy(8) vz(8)
+        let gro = "MD run\n2\n    1SOL     OW    1   0.100   0.200   0.300   0.010   0.020   0.030\n    1SOL    HW1    2   0.150   0.250   0.350  -0.005   0.015  -0.025\n   1.00000   1.00000   1.00000\n";
+        let result = parse(gro).expect("parse failed");
+        assert_eq!(result.vector_channels.len(), 1);
+        let ch = &result.vector_channels[0];
+        assert_eq!(ch.name, "velocity");
+        assert_eq!(ch.frames.len(), 1);
+        assert_eq!(ch.frames[0].frame, 0);
+        let v = &ch.frames[0].vectors;
+        assert_eq!(v.len(), 6); // 2 atoms × 3
+        assert!((v[0] - 0.010).abs() < 0.001); // vx of atom 0
+        assert!((v[1] - 0.020).abs() < 0.001); // vy of atom 0
+        assert!((v[2] - 0.030).abs() < 0.001); // vz of atom 0
+        assert!((v[3] - (-0.005)).abs() < 0.001); // vx of atom 1
+    }
+
+    #[test]
+    fn test_parse_gro_partial_velocities_ignored() {
+        // First atom has velocity columns, second does not → no channel emitted.
+        let gro = "test\n2\n    1SOL     OW    1   0.100   0.200   0.300   0.010   0.020   0.030\n    1SOL    HW1    2   0.150   0.250   0.350\n   1.00000   1.00000   1.00000\n";
+        let result = parse(gro).expect("parse failed");
+        assert!(result.vector_channels.is_empty());
     }
 }

--- a/crates/megane-core/src/gro.rs
+++ b/crates/megane-core/src/gro.rs
@@ -88,15 +88,20 @@ pub fn parse(text: &str) -> Result<crate::parser::ParsedStructure, String> {
 
         // Optional velocity columns (nm/ps): cols 44-52, 52-60, 60-68
         if has_velocities {
-            if line.len() >= 68 {
-                let vx: f32 = line[44..52].trim().parse().unwrap_or(0.0);
-                let vy: f32 = line[52..60].trim().parse().unwrap_or(0.0);
-                let vz: f32 = line[60..68].trim().parse().unwrap_or(0.0);
+            let parsed = if line.len() >= 68 {
+                let vx: Option<f32> = line[44..52].trim().parse().ok();
+                let vy: Option<f32> = line[52..60].trim().parse().ok();
+                let vz: Option<f32> = line[60..68].trim().parse().ok();
+                vx.zip(vy).zip(vz).map(|((x, y), z)| (x, y, z))
+            } else {
+                None
+            };
+            if let Some((vx, vy, vz)) = parsed {
                 velocities.push(vx);
                 velocities.push(vy);
                 velocities.push(vz);
             } else {
-                // This atom lacks velocity columns — disable the channel.
+                // Atom lacks velocity columns or has unparseable values — disable channel.
                 has_velocities = false;
                 velocities.clear();
             }

--- a/crates/megane-core/src/lammps_data.rs
+++ b/crates/megane-core/src/lammps_data.rs
@@ -428,6 +428,7 @@ pub fn parse(text: &str) -> Result<ParsedStructure, String> {
         box_matrix,
         frame_positions: Vec::new(),
         atom_labels,
+        vector_channels: vec![],
     })
 }
 

--- a/crates/megane-core/src/lammpstrj.rs
+++ b/crates/megane-core/src/lammpstrj.rs
@@ -371,7 +371,7 @@ pub fn parse_lammpstrj(text: &str) -> Result<LammpstrjData, String> {
     // Assemble VectorChannel entries for groups that have data in every frame.
     let vector_channels: Vec<VectorChannel> = vec_group_names
         .into_iter()
-        .zip(vec_group_frames.into_iter())
+        .zip(vec_group_frames)
         .filter(|(_, frames)| frames.len() == n_frames)
         .map(|(name, frames)| VectorChannel {
             name: name.to_string(),

--- a/crates/megane-core/src/lammpstrj.rs
+++ b/crates/megane-core/src/lammpstrj.rs
@@ -5,7 +5,8 @@
 ///
 /// Supports coordinate columns: x/y/z (unscaled), xs/ys/zs (scaled),
 /// xu/yu/zu (unwrapped). Atoms are sorted by id within each frame.
-use crate::trajectory::TrajectoryData;
+/// Also detects and extracts named vector column groups (vx/vy/vz, fx/fy/fz).
+use crate::trajectory::{TrajectoryData, VectorChannel, VectorFrame};
 
 /// Type alias kept for backwards compatibility.
 pub type LammpstrjData = TrajectoryData;
@@ -21,6 +22,15 @@ enum CoordType {
     Unwrapped,
 }
 
+/// Column indices for a named per-atom vector quantity (e.g. velocity, force).
+#[derive(Clone)]
+struct VectorColumnGroup {
+    name: &'static str,
+    x_col: usize,
+    y_col: usize,
+    z_col: usize,
+}
+
 /// Column indices for atom data.
 struct ColumnLayout {
     id_col: usize,
@@ -28,6 +38,8 @@ struct ColumnLayout {
     y_col: usize,
     z_col: usize,
     coord_type: CoordType,
+    /// Optional extra per-atom vector column groups (velocity, force, …).
+    vector_groups: Vec<VectorColumnGroup>,
 }
 
 fn parse_column_layout(header: &str) -> Result<ColumnLayout, String> {
@@ -57,12 +69,22 @@ fn parse_column_layout(header: &str) -> Result<ColumnLayout, String> {
         return Err("Cannot find x/y/z, xs/ys/zs, or xu/yu/zu columns in ATOMS header".to_string());
     };
 
+    // Detect optional vector column groups.
+    let mut vector_groups = Vec::new();
+    if let (Some(vx), Some(vy), Some(vz)) = (find("vx"), find("vy"), find("vz")) {
+        vector_groups.push(VectorColumnGroup { name: "velocity", x_col: vx, y_col: vy, z_col: vz });
+    }
+    if let (Some(fx), Some(fy), Some(fz)) = (find("fx"), find("fy"), find("fz")) {
+        vector_groups.push(VectorColumnGroup { name: "force", x_col: fx, y_col: fy, z_col: fz });
+    }
+
     Ok(ColumnLayout {
         id_col,
         x_col,
         y_col,
         z_col,
         coord_type,
+        vector_groups,
     })
 }
 
@@ -79,6 +101,10 @@ pub fn parse_lammpstrj(text: &str) -> Result<LammpstrjData, String> {
     let mut n_atoms: usize = 0;
     let mut box_matrix: Option<[f32; 9]> = None;
     let mut i = 0;
+    // Per-group accumulated vector frames: indexed by group position in the layout.
+    // Outer Vec = one entry per group; inner Vec<f32> = all frames concatenated.
+    let mut vec_group_names: Vec<&'static str> = Vec::new();
+    let mut vec_group_frames: Vec<Vec<VectorFrame>> = Vec::new();
 
     while i < n_lines {
         let line = lines[i].trim();
@@ -214,8 +240,18 @@ pub fn parse_lammpstrj(text: &str) -> Result<LammpstrjData, String> {
         }
         let layout = parse_column_layout(lines[i])?;
 
-        // Read atom lines
+        // On the first frame, initialise vector group tracking from the layout.
+        if frame_positions.is_empty() {
+            vec_group_names = layout.vector_groups.iter().map(|g| g.name).collect();
+            vec_group_frames = layout.vector_groups.iter().map(|_| Vec::new()).collect();
+        }
+
+        // Read atom lines — accumulate both positions and per-group vector data.
         let mut atoms: Vec<(usize, f32, f32, f32)> = Vec::with_capacity(n_atoms);
+        // Per-group unsorted vector buffer for this frame.
+        let mut frame_vec_atoms: Vec<Vec<(usize, f32, f32, f32)>> =
+            layout.vector_groups.iter().map(|_| Vec::with_capacity(n_atoms)).collect();
+
         for _ in 0..n_atoms {
             i += 1;
             if i >= n_lines {
@@ -257,6 +293,17 @@ pub fn parse_lammpstrj(text: &str) -> Result<LammpstrjData, String> {
             }
 
             atoms.push((id, x, y, z));
+
+            // Collect per-group vector values for this atom (ignore parse errors).
+            for (g_idx, group) in layout.vector_groups.iter().enumerate() {
+                let max_vcol = group.x_col.max(group.y_col).max(group.z_col);
+                if parts.len() > max_vcol {
+                    let vx = parts[group.x_col].parse().unwrap_or(0.0);
+                    let vy = parts[group.y_col].parse().unwrap_or(0.0);
+                    let vz = parts[group.z_col].parse().unwrap_or(0.0);
+                    frame_vec_atoms[g_idx].push((id, vx, vy, vz));
+                }
+            }
         }
 
         // Sort by atom id for consistent ordering
@@ -270,6 +317,21 @@ pub fn parse_lammpstrj(text: &str) -> Result<LammpstrjData, String> {
             positions.push(*z);
         }
         frame_positions.push(positions);
+
+        // Build a sorted, flat vector array for each group and append as a VectorFrame.
+        let frame_idx = frame_positions.len() - 1;
+        for (g_idx, mut vatoms) in frame_vec_atoms.into_iter().enumerate() {
+            if vatoms.len() == n_atoms && g_idx < vec_group_frames.len() {
+                vatoms.sort_by_key(|a| a.0);
+                let mut flat = Vec::with_capacity(n_atoms * 3);
+                for (_, vx, vy, vz) in &vatoms {
+                    flat.push(*vx);
+                    flat.push(*vy);
+                    flat.push(*vz);
+                }
+                vec_group_frames[g_idx].push(VectorFrame { frame: frame_idx, vectors: flat });
+            }
+        }
 
         i += 1;
     }
@@ -290,12 +352,21 @@ pub fn parse_lammpstrj(text: &str) -> Result<LammpstrjData, String> {
 
     let n_frames = frame_positions.len();
 
+    // Assemble VectorChannel entries for groups that have data in every frame.
+    let vector_channels: Vec<VectorChannel> = vec_group_names
+        .into_iter()
+        .zip(vec_group_frames.into_iter())
+        .filter(|(_, frames)| frames.len() == n_frames)
+        .map(|(name, frames)| VectorChannel { name: name.to_string(), frames })
+        .collect();
+
     Ok(LammpstrjData {
         n_atoms,
         n_frames,
         timestep_ps,
         box_matrix,
         frame_positions,
+        vector_channels,
     })
 }
 
@@ -428,5 +499,50 @@ mod tests {
         let data = parse_lammpstrj(text).unwrap();
         assert_eq!(data.n_frames, 1);
         assert_eq!(data.timestep_ps, 0.0); // single frame → no dt
+        assert!(data.vector_channels.is_empty());
+    }
+
+    #[test]
+    fn test_vector_columns_velocity() {
+        let text = "ITEM: TIMESTEP\n\
+                    0\n\
+                    ITEM: NUMBER OF ATOMS\n\
+                    2\n\
+                    ITEM: BOX BOUNDS pp pp pp\n\
+                    0.0 10.0\n\
+                    0.0 10.0\n\
+                    0.0 10.0\n\
+                    ITEM: ATOMS id type x y z vx vy vz\n\
+                    1 1 1.0 2.0 3.0 0.1 0.2 0.3\n\
+                    2 2 4.0 5.0 6.0 0.4 0.5 0.6\n\
+                    ITEM: TIMESTEP\n\
+                    100\n\
+                    ITEM: NUMBER OF ATOMS\n\
+                    2\n\
+                    ITEM: BOX BOUNDS pp pp pp\n\
+                    0.0 10.0\n\
+                    0.0 10.0\n\
+                    0.0 10.0\n\
+                    ITEM: ATOMS id type x y z vx vy vz\n\
+                    1 1 1.1 2.1 3.1 0.11 0.21 0.31\n\
+                    2 2 4.1 5.1 6.1 0.41 0.51 0.61\n";
+        let data = parse_lammpstrj(text).unwrap();
+        assert_eq!(data.n_frames, 2);
+        assert_eq!(data.vector_channels.len(), 1);
+        let ch = &data.vector_channels[0];
+        assert_eq!(ch.name, "velocity");
+        assert_eq!(ch.frames.len(), 2);
+        // Frame 0, atom 1 (id=1 → index 0 after sort)
+        assert!((ch.frames[0].vectors[0] - 0.1).abs() < 1e-4);
+        assert!((ch.frames[0].vectors[1] - 0.2).abs() < 1e-4);
+        assert!((ch.frames[0].vectors[2] - 0.3).abs() < 1e-4);
+        // Frame 1, atom 1
+        assert!((ch.frames[1].vectors[0] - 0.11).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_no_vector_columns() {
+        let data = parse_lammpstrj(sample_dump()).unwrap();
+        assert!(data.vector_channels.is_empty());
     }
 }

--- a/crates/megane-core/src/lammpstrj.rs
+++ b/crates/megane-core/src/lammpstrj.rs
@@ -111,8 +111,8 @@ pub fn parse_lammpstrj(text: &str) -> Result<LammpstrjData, String> {
     let mut n_atoms: usize = 0;
     let mut box_matrix: Option<[f32; 9]> = None;
     let mut i = 0;
-    // Per-group accumulated vector frames: indexed by group position in the layout.
-    // Outer Vec = one entry per group; inner Vec<f32> = all frames concatenated.
+    // Accumulated vector frames keyed by channel name from the first frame's layout.
+    // Outer Vec = one entry per named group; inner Vec<VectorFrame> = one entry per frame.
     let mut vec_group_names: Vec<&'static str> = Vec::new();
     let mut vec_group_frames: Vec<Vec<VectorFrame>> = Vec::new();
 
@@ -307,14 +307,29 @@ pub fn parse_lammpstrj(text: &str) -> Result<LammpstrjData, String> {
 
             atoms.push((id, x, y, z));
 
-            // Collect per-group vector values for this atom (ignore parse errors).
-            for (g_idx, group) in layout.vector_groups.iter().enumerate() {
-                let max_vcol = group.x_col.max(group.y_col).max(group.z_col);
-                if parts.len() > max_vcol {
-                    let vx = parts[group.x_col].parse().unwrap_or(0.0);
-                    let vy = parts[group.y_col].parse().unwrap_or(0.0);
-                    let vz = parts[group.z_col].parse().unwrap_or(0.0);
-                    frame_vec_atoms[g_idx].push((id, vx, vy, vz));
+            // Collect per-group vector values for this atom.
+            // Groups are indexed by their slot in frame_vec_atoms, which mirrors
+            // vec_group_names (initialised from the first frame). Lookup by name
+            // guards against column reordering in later frames.
+            for group in layout.vector_groups.iter() {
+                let slot = vec_group_names.iter().position(|&n| n == group.name);
+                if let Some(slot) = slot {
+                    let max_vcol = group.x_col.max(group.y_col).max(group.z_col);
+                    if parts.len() > max_vcol {
+                        let vx: f32 = match parts[group.x_col].parse() {
+                            Ok(v) => v,
+                            Err(_) => continue,
+                        };
+                        let vy: f32 = match parts[group.y_col].parse() {
+                            Ok(v) => v,
+                            Err(_) => continue,
+                        };
+                        let vz: f32 = match parts[group.z_col].parse() {
+                            Ok(v) => v,
+                            Err(_) => continue,
+                        };
+                        frame_vec_atoms[slot].push((id, vx, vy, vz));
+                    }
                 }
             }
         }
@@ -332,9 +347,10 @@ pub fn parse_lammpstrj(text: &str) -> Result<LammpstrjData, String> {
         frame_positions.push(positions);
 
         // Build a sorted, flat vector array for each group and append as a VectorFrame.
+        // Only emit a frame entry when all n_atoms parsed successfully.
         let frame_idx = frame_positions.len() - 1;
-        for (g_idx, mut vatoms) in frame_vec_atoms.into_iter().enumerate() {
-            if vatoms.len() == n_atoms && g_idx < vec_group_frames.len() {
+        for (slot, mut vatoms) in frame_vec_atoms.into_iter().enumerate() {
+            if vatoms.len() == n_atoms {
                 vatoms.sort_by_key(|a| a.0);
                 let mut flat = Vec::with_capacity(n_atoms * 3);
                 for (_, vx, vy, vz) in &vatoms {
@@ -342,7 +358,7 @@ pub fn parse_lammpstrj(text: &str) -> Result<LammpstrjData, String> {
                     flat.push(*vy);
                     flat.push(*vz);
                 }
-                vec_group_frames[g_idx].push(VectorFrame {
+                vec_group_frames[slot].push(VectorFrame {
                     frame: frame_idx,
                     vectors: flat,
                 });

--- a/crates/megane-core/src/lammpstrj.rs
+++ b/crates/megane-core/src/lammpstrj.rs
@@ -72,10 +72,20 @@ fn parse_column_layout(header: &str) -> Result<ColumnLayout, String> {
     // Detect optional vector column groups.
     let mut vector_groups = Vec::new();
     if let (Some(vx), Some(vy), Some(vz)) = (find("vx"), find("vy"), find("vz")) {
-        vector_groups.push(VectorColumnGroup { name: "velocity", x_col: vx, y_col: vy, z_col: vz });
+        vector_groups.push(VectorColumnGroup {
+            name: "velocity",
+            x_col: vx,
+            y_col: vy,
+            z_col: vz,
+        });
     }
     if let (Some(fx), Some(fy), Some(fz)) = (find("fx"), find("fy"), find("fz")) {
-        vector_groups.push(VectorColumnGroup { name: "force", x_col: fx, y_col: fy, z_col: fz });
+        vector_groups.push(VectorColumnGroup {
+            name: "force",
+            x_col: fx,
+            y_col: fy,
+            z_col: fz,
+        });
     }
 
     Ok(ColumnLayout {
@@ -249,8 +259,11 @@ pub fn parse_lammpstrj(text: &str) -> Result<LammpstrjData, String> {
         // Read atom lines — accumulate both positions and per-group vector data.
         let mut atoms: Vec<(usize, f32, f32, f32)> = Vec::with_capacity(n_atoms);
         // Per-group unsorted vector buffer for this frame.
-        let mut frame_vec_atoms: Vec<Vec<(usize, f32, f32, f32)>> =
-            layout.vector_groups.iter().map(|_| Vec::with_capacity(n_atoms)).collect();
+        let mut frame_vec_atoms: Vec<Vec<(usize, f32, f32, f32)>> = layout
+            .vector_groups
+            .iter()
+            .map(|_| Vec::with_capacity(n_atoms))
+            .collect();
 
         for _ in 0..n_atoms {
             i += 1;
@@ -329,7 +342,10 @@ pub fn parse_lammpstrj(text: &str) -> Result<LammpstrjData, String> {
                     flat.push(*vy);
                     flat.push(*vz);
                 }
-                vec_group_frames[g_idx].push(VectorFrame { frame: frame_idx, vectors: flat });
+                vec_group_frames[g_idx].push(VectorFrame {
+                    frame: frame_idx,
+                    vectors: flat,
+                });
             }
         }
 
@@ -357,7 +373,10 @@ pub fn parse_lammpstrj(text: &str) -> Result<LammpstrjData, String> {
         .into_iter()
         .zip(vec_group_frames.into_iter())
         .filter(|(_, frames)| frames.len() == n_frames)
-        .map(|(name, frames)| VectorChannel { name: name.to_string(), frames })
+        .map(|(name, frames)| VectorChannel {
+            name: name.to_string(),
+            frames,
+        })
         .collect();
 
     Ok(LammpstrjData {

--- a/crates/megane-core/src/mol.rs
+++ b/crates/megane-core/src/mol.rs
@@ -124,6 +124,7 @@ pub fn parse(text: &str) -> Result<crate::parser::ParsedStructure, String> {
         box_matrix: None,
         frame_positions: Vec::new(),
         atom_labels: None,
+        vector_channels: vec![],
     })
 }
 

--- a/crates/megane-core/src/parser.rs
+++ b/crates/megane-core/src/parser.rs
@@ -26,6 +26,9 @@ pub struct ParsedStructure {
     pub box_matrix: Option<[f32; 9]>,
     pub frame_positions: Vec<Vec<f32>>,
     pub atom_labels: Option<Vec<String>>,
+    /// Embedded vector channels (e.g. GRO velocities).
+    /// Empty for formats that carry no per-atom vector quantities.
+    pub vector_channels: Vec<crate::trajectory::VectorChannel>,
 }
 
 /// Parse the element from a PDB ATOM/HETATM line.
@@ -320,6 +323,7 @@ pub fn parse(text: &str) -> Result<ParsedStructure, String> {
         box_matrix,
         frame_positions,
         atom_labels,
+        vector_channels: vec![],
     })
 }
 

--- a/crates/megane-core/src/traj.rs
+++ b/crates/megane-core/src/traj.rs
@@ -410,6 +410,7 @@ pub fn parse_traj(data: &[u8]) -> Result<ParsedStructure, String> {
         box_matrix,
         frame_positions,
         atom_labels: None,
+        vector_channels: vec![],
     })
 }
 

--- a/crates/megane-core/src/trajectory.rs
+++ b/crates/megane-core/src/trajectory.rs
@@ -1,8 +1,3 @@
-/// Common trajectory data returned by XTC and LAMMPS dump parsers.
-///
-/// Both formats provide multi-frame position data without topology;
-/// element and bond information comes from a separate structure file.
-
 /// A single frame of per-atom vector data (e.g. velocity or force).
 pub struct VectorFrame {
     /// Index of the trajectory frame this data corresponds to.

--- a/crates/megane-core/src/trajectory.rs
+++ b/crates/megane-core/src/trajectory.rs
@@ -2,10 +2,34 @@
 ///
 /// Both formats provide multi-frame position data without topology;
 /// element and bond information comes from a separate structure file.
+
+/// A single frame of per-atom vector data (e.g. velocity or force).
+pub struct VectorFrame {
+    /// Index of the trajectory frame this data corresponds to.
+    pub frame: usize,
+    /// Flat array of per-atom vectors: [vx0,vy0,vz0, vx1,vy1,vz1, ...]
+    pub vectors: Vec<f32>,
+}
+
+/// A named channel of per-atom vector data across one or more frames.
+///
+/// A channel with a single frame is treated as "static" — the same vectors
+/// are shown for all playback frames. A channel with N frames advances in sync
+/// with the trajectory.
+pub struct VectorChannel {
+    /// Human-readable name, e.g. "velocity" or "force".
+    pub name: String,
+    /// Per-frame vector data. Length 1 = static; length N = frame-synced.
+    pub frames: Vec<VectorFrame>,
+}
+
 pub struct TrajectoryData {
     pub n_atoms: usize,
     pub n_frames: usize,
     pub timestep_ps: f32,
     pub box_matrix: Option<[f32; 9]>,
     pub frame_positions: Vec<Vec<f32>>,
+    /// Embedded vector channels parsed from the trajectory file.
+    /// Empty when the format carries no per-atom vector quantities.
+    pub vector_channels: Vec<VectorChannel>,
 }

--- a/crates/megane-core/src/xtc.rs
+++ b/crates/megane-core/src/xtc.rs
@@ -458,6 +458,7 @@ pub fn parse_xtc(data: &[u8]) -> Result<XtcData, String> {
         timestep_ps,
         box_matrix: last_box,
         frame_positions,
+        vector_channels: vec![],
     })
 }
 

--- a/crates/megane-core/src/xyz.rs
+++ b/crates/megane-core/src/xyz.rs
@@ -145,6 +145,7 @@ pub fn parse(text: &str) -> Result<crate::parser::ParsedStructure, String> {
         box_matrix,
         frame_positions,
         atom_labels,
+        vector_channels: vec![],
     })
 }
 

--- a/crates/megane-wasm/src/lib.rs
+++ b/crates/megane-wasm/src/lib.rs
@@ -3,6 +3,34 @@ use wasm_bindgen::prelude::*;
 
 use megane_core::{bonds, cif, gro, lammps_data, lammpstrj, mol, parser, top, traj, xtc, xyz};
 
+/// Serialize a slice of `VectorChannel`s into two parallel outputs:
+/// - A JSON string describing channel metadata (name, n_frames per channel).
+/// - A flat `Vec<f32>` with all channel/frame vectors concatenated in order.
+///
+/// Layout in the flat buffer: for each channel, for each frame in order,
+/// `n_atoms * 3` f32 values.
+fn serialize_vector_channels(
+    channels: &[megane_core::trajectory::VectorChannel],
+) -> (String, Vec<f32>) {
+    use std::fmt::Write as FmtWrite;
+
+    let mut meta = String::from("[");
+    let mut data: Vec<f32> = Vec::new();
+
+    for (idx, ch) in channels.iter().enumerate() {
+        if idx > 0 {
+            meta.push(',');
+        }
+        let _ = write!(meta, r#"{{"name":"{}", "n_frames":{}}}"#, ch.name, ch.frames.len());
+        for frame in &ch.frames {
+            data.extend_from_slice(&frame.vectors);
+        }
+    }
+    meta.push(']');
+
+    (meta, data)
+}
+
 /// Result of parsing a PDB file, exposed to JavaScript via wasm-bindgen.
 #[wasm_bindgen]
 pub struct ParseResult {
@@ -19,6 +47,9 @@ pub struct ParseResult {
     box_matrix: Vec<f32>,
     frame_data: Vec<f32>,
     atom_labels: String,
+    vector_channel_count: u32,
+    vector_channel_meta: String,
+    vector_channel_data: Vec<f32>,
 }
 
 #[wasm_bindgen]
@@ -59,6 +90,18 @@ impl ParseResult {
         self.atom_labels.clone()
     }
 
+    /// Number of embedded vector channels (0 when none).
+    #[wasm_bindgen(getter)]
+    pub fn vector_channel_count(&self) -> u32 {
+        self.vector_channel_count
+    }
+
+    /// JSON array describing each channel: `[{"name":"velocity","n_frames":1}, ...]`
+    #[wasm_bindgen(getter)]
+    pub fn vector_channel_meta(&self) -> String {
+        self.vector_channel_meta.clone()
+    }
+
     /// Atom positions as Float32Array [x0,y0,z0, x1,y1,z1, ...]
     pub fn positions(&self) -> Float32Array {
         Float32Array::from(&self.positions[..])
@@ -89,6 +132,13 @@ impl ParseResult {
     pub fn frame_data(&self) -> Float32Array {
         Float32Array::from(&self.frame_data[..])
     }
+
+    /// All vector channel data concatenated as Float32Array.
+    /// Layout: channel0_frame0, channel0_frame1, …, channel1_frame0, …
+    /// Each frame is n_atoms * 3 floats.
+    pub fn vector_channel_data(&self) -> Float32Array {
+        Float32Array::from(&self.vector_channel_data[..])
+    }
 }
 
 impl ParseResult {
@@ -113,6 +163,10 @@ impl ParseResult {
         let has_atom_labels = data.atom_labels.is_some();
         let atom_labels = data.atom_labels.map(|l| l.join("\n")).unwrap_or_default();
 
+        let vector_channel_count = data.vector_channels.len() as u32;
+        let (vector_channel_meta, vector_channel_data) =
+            serialize_vector_channels(&data.vector_channels);
+
         Self {
             n_atoms: data.n_atoms as u32,
             n_bonds,
@@ -127,6 +181,9 @@ impl ParseResult {
             box_matrix,
             frame_data,
             atom_labels,
+            vector_channel_count,
+            vector_channel_meta,
+            vector_channel_data,
         }
     }
 }
@@ -140,6 +197,9 @@ pub struct XtcParseResult {
     has_box: bool,
     box_matrix: Vec<f32>,
     frame_data: Vec<f32>,
+    vector_channel_count: u32,
+    vector_channel_meta: String,
+    vector_channel_data: Vec<f32>,
 }
 
 #[wasm_bindgen]
@@ -172,6 +232,23 @@ impl XtcParseResult {
     pub fn frame_data(&self) -> Float32Array {
         Float32Array::from(&self.frame_data[..])
     }
+
+    /// Number of embedded vector channels (0 when none).
+    #[wasm_bindgen(getter)]
+    pub fn vector_channel_count(&self) -> u32 {
+        self.vector_channel_count
+    }
+
+    /// JSON array describing each channel: `[{"name":"velocity","n_frames":N}, ...]`
+    #[wasm_bindgen(getter)]
+    pub fn vector_channel_meta(&self) -> String {
+        self.vector_channel_meta.clone()
+    }
+
+    /// All vector channel data concatenated as Float32Array.
+    pub fn vector_channel_data(&self) -> Float32Array {
+        Float32Array::from(&self.vector_channel_data[..])
+    }
 }
 
 /// Parse an XTC trajectory binary and return frame data.
@@ -190,6 +267,10 @@ pub fn parse_xtc_file(data: &[u8]) -> Result<XtcParseResult, JsError> {
         frame_data.extend_from_slice(frame);
     }
 
+    let vector_channel_count = xtc_data.vector_channels.len() as u32;
+    let (vector_channel_meta, vector_channel_data) =
+        serialize_vector_channels(&xtc_data.vector_channels);
+
     Ok(XtcParseResult {
         n_atoms: xtc_data.n_atoms as u32,
         n_frames: xtc_data.n_frames as u32,
@@ -197,6 +278,9 @@ pub fn parse_xtc_file(data: &[u8]) -> Result<XtcParseResult, JsError> {
         has_box,
         box_matrix,
         frame_data,
+        vector_channel_count,
+        vector_channel_meta,
+        vector_channel_data,
     })
 }
 
@@ -300,6 +384,10 @@ pub fn parse_lammpstrj_file(text: &str) -> Result<XtcParseResult, JsError> {
         frame_data.extend_from_slice(frame);
     }
 
+    let vector_channel_count = data.vector_channels.len() as u32;
+    let (vector_channel_meta, vector_channel_data) =
+        serialize_vector_channels(&data.vector_channels);
+
     Ok(XtcParseResult {
         n_atoms: data.n_atoms as u32,
         n_frames: data.n_frames as u32,
@@ -307,6 +395,9 @@ pub fn parse_lammpstrj_file(text: &str) -> Result<XtcParseResult, JsError> {
         has_box,
         box_matrix,
         frame_data,
+        vector_channel_count,
+        vector_channel_meta,
+        vector_channel_data,
     })
 }
 

--- a/crates/megane-wasm/src/lib.rs
+++ b/crates/megane-wasm/src/lib.rs
@@ -21,7 +21,12 @@ fn serialize_vector_channels(
         if idx > 0 {
             meta.push(',');
         }
-        let _ = write!(meta, r#"{{"name":"{}", "n_frames":{}}}"#, ch.name, ch.frames.len());
+        let _ = write!(
+            meta,
+            r#"{{"name":"{}", "n_frames":{}}}"#,
+            ch.name,
+            ch.frames.len()
+        );
         for frame in &ch.frames {
             data.extend_from_slice(&frame.vectors);
         }

--- a/src/hooks/useMeganeLocal.ts
+++ b/src/hooks/useMeganeLocal.ts
@@ -195,7 +195,15 @@ export function useMeganeLocal(): MeganeLocalState {
 
       // Auto-load first embedded vector channel (e.g. LAMMPS dump vx/vy/vz) into pipeline.
       if (vectorChannels.length > 0) {
-        usePipelineStore.getState().setFileVectors(vectorChannels[0].frames);
+        const ch = vectorChannels[0];
+        const store = usePipelineStore.getState();
+        store.setFileVectors(ch.frames);
+        // Update all load_vector nodes so the UI shows the channel name.
+        for (const n of store.nodes) {
+          if (n.type === "load_vector") {
+            store.updateNodeParams(n.id, { fileName: `[embedded] ${ch.name}` });
+          }
+        }
       }
     },
     [resetPlayback],

--- a/src/hooks/useMeganeLocal.ts
+++ b/src/hooks/useMeganeLocal.ts
@@ -177,10 +177,11 @@ export function useMeganeLocal(): MeganeLocalState {
       const ext = xtc.name.toLowerCase();
       const isLammpstrj = ext.endsWith(".lammpstrj") || ext.endsWith(".dump");
       const parseFn = isLammpstrj ? parseLammpstrjFile : parseXTCFile;
-      const { frames, meta: xtcMeta, vectorChannels } = await parseFn(
-        xtc,
-        baseSnapshotRef.current.nAtoms,
-      );
+      const {
+        frames,
+        meta: xtcMeta,
+        vectorChannels,
+      } = await parseFn(xtc, baseSnapshotRef.current.nAtoms);
       fileFramesRef.current = frames;
       fileTrajMetaRef.current = xtcMeta;
       xtcFileNameRef.current = xtc.name;

--- a/src/hooks/useMeganeLocal.ts
+++ b/src/hooks/useMeganeLocal.ts
@@ -11,6 +11,7 @@ import { parseXTCFile, parseLammpstrjFile } from "../parsers/xtc";
 import { useBondSource } from "./useBondSource";
 import { useLabelSource } from "./useLabelSource";
 import { useVectorSource } from "./useVectorSource";
+import { usePipelineStore } from "../pipeline/store";
 import type {
   Snapshot,
   Frame,
@@ -176,7 +177,10 @@ export function useMeganeLocal(): MeganeLocalState {
       const ext = xtc.name.toLowerCase();
       const isLammpstrj = ext.endsWith(".lammpstrj") || ext.endsWith(".dump");
       const parseFn = isLammpstrj ? parseLammpstrjFile : parseXTCFile;
-      const { frames, meta: xtcMeta } = await parseFn(xtc, baseSnapshotRef.current.nAtoms);
+      const { frames, meta: xtcMeta, vectorChannels } = await parseFn(
+        xtc,
+        baseSnapshotRef.current.nAtoms,
+      );
       fileFramesRef.current = frames;
       fileTrajMetaRef.current = xtcMeta;
       xtcFileNameRef.current = xtc.name;
@@ -187,6 +191,11 @@ export function useMeganeLocal(): MeganeLocalState {
       setMeta(xtcMeta);
       resetPlayback();
       setXtcFileName(xtc.name);
+
+      // Auto-load first embedded vector channel (e.g. LAMMPS dump vx/vy/vz) into pipeline.
+      if (vectorChannels.length > 0) {
+        usePipelineStore.getState().setFileVectors(vectorChannels[0].frames);
+      }
     },
     [resetPlayback],
   );

--- a/src/hooks/useNodeLoadHandlers.ts
+++ b/src/hooks/useNodeLoadHandlers.ts
@@ -61,6 +61,10 @@ export function useNodeLoadHandlers({
             hasTrajectory: result.frames.length > 0,
             hasCell: !!result.snapshot.box,
           });
+          // Auto-load first embedded vector channel (e.g. GRO velocities) into pipeline.
+          if (result.vectorChannels.length > 0) {
+            setFileVectors(result.vectorChannels[0].frames);
+          }
         })
         .catch((err: unknown) => {
           const message = err instanceof Error ? err.message : String(err);
@@ -80,6 +84,7 @@ export function useNodeLoadHandlers({
     updateNodeParams,
     setNodeParseError,
     clearNodeParseError,
+    setFileVectors,
   ]);
 
   // Wire up trajectory load handler

--- a/src/hooks/useNodeLoadHandlers.ts
+++ b/src/hooks/useNodeLoadHandlers.ts
@@ -63,7 +63,15 @@ export function useNodeLoadHandlers({
           });
           // Auto-load first embedded vector channel (e.g. GRO velocities) into pipeline.
           if (result.vectorChannels.length > 0) {
-            setFileVectors(result.vectorChannels[0].frames);
+            const ch = result.vectorChannels[0];
+            setFileVectors(ch.frames);
+            // Update all load_vector nodes so executeLoadVector shows the channel name.
+            const nodes = usePipelineStore.getState().nodes;
+            for (const n of nodes) {
+              if (n.type === "load_vector") {
+                updateNodeParams(n.id, { fileName: `[embedded] ${ch.name}` });
+              }
+            }
           }
         })
         .catch((err: unknown) => {

--- a/src/parsers/structure.ts
+++ b/src/parsers/structure.ts
@@ -194,10 +194,8 @@ function parseWithFn(parseFn: ParseFn, text: string): StructureParseResult {
 
   const labels: string[] | null = result.has_atom_labels ? result.atom_labels.split("\n") : null;
 
-  const vectorChannels = deserializeVectorChannels(
-    result.n_atoms,
-    result.vector_channel_meta,
-    () => result.vector_channel_data(),
+  const vectorChannels = deserializeVectorChannels(result.n_atoms, result.vector_channel_meta, () =>
+    result.vector_channel_data(),
   );
 
   result.free();

--- a/src/parsers/structure.ts
+++ b/src/parsers/structure.ts
@@ -4,13 +4,15 @@
  * Supports PDB, GRO, XYZ, MOL/SDF, CIF, and LAMMPS data formats.
  */
 
-import type { Snapshot, Frame, TrajectoryMeta } from "../types";
+import type { Snapshot, Frame, TrajectoryMeta, VectorChannel, VectorFrame } from "../types";
 
 export interface StructureParseResult {
   snapshot: Snapshot;
   frames: Frame[];
   meta: TrajectoryMeta | null;
   labels: string[] | null;
+  /** Per-atom vector channels embedded in the file (e.g. GRO velocities). */
+  vectorChannels: VectorChannel[];
 }
 
 let initPromise: Promise<void> | null = null;
@@ -24,12 +26,15 @@ interface WasmParseResult {
   has_box: boolean;
   has_atom_labels: boolean;
   atom_labels: string;
+  vector_channel_count: number;
+  vector_channel_meta: string;
   positions(): Float32Array;
   elements(): Uint8Array;
   bonds(): Uint32Array;
   bond_orders(): Uint8Array;
   box_matrix(): Float32Array;
   frame_data(): Float32Array;
+  vector_channel_data(): Float32Array;
   free(): void;
 }
 
@@ -134,6 +139,32 @@ export async function parseStructureFile(file: File): Promise<StructureParseResu
   return parseWithFn(parseFn, text);
 }
 
+/** Deserialize embedded vector channels from a WASM parse result. */
+function deserializeVectorChannels(
+  nAtoms: number,
+  metaStr: string,
+  dataFn: () => Float32Array,
+): VectorChannel[] {
+  if (!metaStr || metaStr === "[]") return [];
+  const meta = JSON.parse(metaStr) as Array<{ name: string; n_frames: number }>;
+  if (meta.length === 0) return [];
+
+  const data = dataFn();
+  const stride = nAtoms * 3;
+  const channels: VectorChannel[] = [];
+  let offset = 0;
+
+  for (const ch of meta) {
+    const frames: VectorFrame[] = [];
+    for (let f = 0; f < ch.n_frames; f++) {
+      frames.push({ frame: f, vectors: data.slice(offset, offset + stride) });
+      offset += stride;
+    }
+    channels.push({ name: ch.name, frames });
+  }
+  return channels;
+}
+
 function parseWithFn(parseFn: ParseFn, text: string): StructureParseResult {
   const result = parseFn(text) as WasmParseResult;
 
@@ -163,6 +194,12 @@ function parseWithFn(parseFn: ParseFn, text: string): StructureParseResult {
 
   const labels: string[] | null = result.has_atom_labels ? result.atom_labels.split("\n") : null;
 
+  const vectorChannels = deserializeVectorChannels(
+    result.n_atoms,
+    result.vector_channel_meta,
+    () => result.vector_channel_data(),
+  );
+
   result.free();
 
   const meta: TrajectoryMeta | null =
@@ -170,7 +207,7 @@ function parseWithFn(parseFn: ParseFn, text: string): StructureParseResult {
       ? { nFrames: frames.length + 1, timestepPs: 1.0, nAtoms: snapshot.nAtoms }
       : null;
 
-  return { snapshot, frames, meta, labels };
+  return { snapshot, frames, meta, labels, vectorChannels };
 }
 
 /** Infer bonds using VDW radii (threshold = vdw_sum * 0.6). */

--- a/src/parsers/structure.ts
+++ b/src/parsers/structure.ts
@@ -4,7 +4,8 @@
  * Supports PDB, GRO, XYZ, MOL/SDF, CIF, and LAMMPS data formats.
  */
 
-import type { Snapshot, Frame, TrajectoryMeta, VectorChannel, VectorFrame } from "../types";
+import type { Snapshot, Frame, TrajectoryMeta, VectorChannel } from "../types";
+import { deserializeVectorChannels } from "./vectorChannels";
 
 export interface StructureParseResult {
   snapshot: Snapshot;
@@ -137,32 +138,6 @@ export async function parseStructureFile(file: File): Promise<StructureParseResu
   const text = await file.text();
   const parseFn = getParserForExtension(ext);
   return parseWithFn(parseFn, text);
-}
-
-/** Deserialize embedded vector channels from a WASM parse result. */
-function deserializeVectorChannels(
-  nAtoms: number,
-  metaStr: string,
-  dataFn: () => Float32Array,
-): VectorChannel[] {
-  if (!metaStr || metaStr === "[]") return [];
-  const meta = JSON.parse(metaStr) as Array<{ name: string; n_frames: number }>;
-  if (meta.length === 0) return [];
-
-  const data = dataFn();
-  const stride = nAtoms * 3;
-  const channels: VectorChannel[] = [];
-  let offset = 0;
-
-  for (const ch of meta) {
-    const frames: VectorFrame[] = [];
-    for (let f = 0; f < ch.n_frames; f++) {
-      frames.push({ frame: f, vectors: data.slice(offset, offset + stride) });
-      offset += stride;
-    }
-    channels.push({ name: ch.name, frames });
-  }
-  return channels;
 }
 
 function parseWithFn(parseFn: ParseFn, text: string): StructureParseResult {

--- a/src/parsers/vectorChannels.ts
+++ b/src/parsers/vectorChannels.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared helper for deserializing embedded vector channels from WASM parse results.
+ * Used by both structure.ts and xtc.ts.
+ */
+
+import type { VectorChannel, VectorFrame } from "../types";
+
+/**
+ * Deserialize embedded vector channels from a WASM parse result.
+ *
+ * @param nAtoms   Number of atoms (determines stride = nAtoms * 3).
+ * @param metaStr  JSON string: `[{"name":"velocity","n_frames":1}, ...]`
+ * @param dataFn   Lazy accessor for the flat Float32Array of all channel data.
+ *                 Called only when metaStr indicates channels are present.
+ *
+ * Data layout in the flat buffer: for each channel, for each frame in order,
+ * `nAtoms * 3` f32 values.  `subarray` is used to avoid per-frame copies.
+ */
+export function deserializeVectorChannels(
+  nAtoms: number,
+  metaStr: string,
+  dataFn: () => Float32Array,
+): VectorChannel[] {
+  if (!metaStr || metaStr === "[]") return [];
+  const meta = JSON.parse(metaStr) as Array<{ name: string; n_frames: number }>;
+  if (meta.length === 0) return [];
+
+  const data = dataFn();
+  const stride = nAtoms * 3;
+  const channels: VectorChannel[] = [];
+  let offset = 0;
+
+  for (const ch of meta) {
+    const frames: VectorFrame[] = [];
+    for (let f = 0; f < ch.n_frames; f++) {
+      // subarray avoids a copy — the view shares the underlying WASM buffer.
+      frames.push({ frame: f, vectors: data.subarray(offset, offset + stride) });
+      offset += stride;
+    }
+    channels.push({ name: ch.name, frames });
+  }
+  return channels;
+}

--- a/src/parsers/xtc.ts
+++ b/src/parsers/xtc.ts
@@ -4,7 +4,8 @@
  * and returns Frame[] + meta.
  */
 
-import type { Frame, TrajectoryMeta, VectorChannel, VectorFrame } from "../types";
+import type { Frame, TrajectoryMeta, VectorChannel } from "../types";
+import { deserializeVectorChannels } from "./vectorChannels";
 
 export interface XTCParseResult {
   frames: Frame[];
@@ -44,32 +45,6 @@ async function ensureInit(): Promise<void> {
     })();
   }
   await initPromise;
-}
-
-/** Deserialize embedded vector channels from a WASM trajectory result. */
-function deserializeVectorChannels(
-  nAtoms: number,
-  metaStr: string,
-  dataFn: () => Float32Array,
-): VectorChannel[] {
-  if (!metaStr || metaStr === "[]") return [];
-  const meta = JSON.parse(metaStr) as Array<{ name: string; n_frames: number }>;
-  if (meta.length === 0) return [];
-
-  const data = dataFn();
-  const stride = nAtoms * 3;
-  const channels: VectorChannel[] = [];
-  let offset = 0;
-
-  for (const ch of meta) {
-    const frames: VectorFrame[] = [];
-    for (let f = 0; f < ch.n_frames; f++) {
-      frames.push({ frame: f, vectors: data.slice(offset, offset + stride) });
-      offset += stride;
-    }
-    channels.push({ name: ch.name, frames });
-  }
-  return channels;
 }
 
 /** Convert a WasmXtcResult into Frame[] + TrajectoryMeta + VectorChannels. */

--- a/src/parsers/xtc.ts
+++ b/src/parsers/xtc.ts
@@ -4,11 +4,13 @@
  * and returns Frame[] + meta.
  */
 
-import type { Frame, TrajectoryMeta } from "../types";
+import type { Frame, TrajectoryMeta, VectorChannel, VectorFrame } from "../types";
 
 export interface XTCParseResult {
   frames: Frame[];
   meta: TrajectoryMeta;
+  /** Per-atom vector channels embedded in the file (e.g. LAMMPS dump vx/vy/vz). */
+  vectorChannels: VectorChannel[];
 }
 
 let initPromise: Promise<void> | null = null;
@@ -20,8 +22,11 @@ interface WasmXtcResult {
   n_frames: number;
   timestep_ps: number;
   has_box: boolean;
+  vector_channel_count: number;
+  vector_channel_meta: string;
   box_matrix(): Float32Array;
   frame_data(): Float32Array;
+  vector_channel_data(): Float32Array;
   free(): void;
 }
 
@@ -41,7 +46,33 @@ async function ensureInit(): Promise<void> {
   await initPromise;
 }
 
-/** Convert a WasmXtcResult into Frame[] + TrajectoryMeta. */
+/** Deserialize embedded vector channels from a WASM trajectory result. */
+function deserializeVectorChannels(
+  nAtoms: number,
+  metaStr: string,
+  dataFn: () => Float32Array,
+): VectorChannel[] {
+  if (!metaStr || metaStr === "[]") return [];
+  const meta = JSON.parse(metaStr) as Array<{ name: string; n_frames: number }>;
+  if (meta.length === 0) return [];
+
+  const data = dataFn();
+  const stride = nAtoms * 3;
+  const channels: VectorChannel[] = [];
+  let offset = 0;
+
+  for (const ch of meta) {
+    const frames: VectorFrame[] = [];
+    for (let f = 0; f < ch.n_frames; f++) {
+      frames.push({ frame: f, vectors: data.slice(offset, offset + stride) });
+      offset += stride;
+    }
+    channels.push({ name: ch.name, frames });
+  }
+  return channels;
+}
+
+/** Convert a WasmXtcResult into Frame[] + TrajectoryMeta + VectorChannels. */
 function extractFrames(
   result: WasmXtcResult,
   expectedNAtoms: number,
@@ -71,8 +102,14 @@ function extractFrames(
     nAtoms: result.n_atoms,
   };
 
+  const vectorChannels = deserializeVectorChannels(
+    result.n_atoms,
+    result.vector_channel_meta,
+    () => result.vector_channel_data(),
+  );
+
   result.free();
-  return { frames, meta };
+  return { frames, meta, vectorChannels };
 }
 
 /**

--- a/src/parsers/xtc.ts
+++ b/src/parsers/xtc.ts
@@ -102,10 +102,8 @@ function extractFrames(
     nAtoms: result.n_atoms,
   };
 
-  const vectorChannels = deserializeVectorChannels(
-    result.n_atoms,
-    result.vector_channel_meta,
-    () => result.vector_channel_data(),
+  const vectorChannels = deserializeVectorChannels(result.n_atoms, result.vector_channel_meta, () =>
+    result.vector_channel_data(),
   );
 
   result.free();

--- a/src/pipeline/executors/loadVector.ts
+++ b/src/pipeline/executors/loadVector.ts
@@ -12,7 +12,7 @@ export function executeLoadVector(
 ): Map<string, PipelineData> {
   const outputs = new Map<string, PipelineData>();
 
-  if (!params.fileName || !fileVectors || fileVectors.length === 0) {
+  if (!fileVectors || fileVectors.length === 0) {
     return outputs;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,16 @@ export interface VectorFrame {
   vectors: Float32Array; // length = nAtoms * 3
 }
 
+/**
+ * A named channel of per-atom vector data embedded in a structure/trajectory file.
+ * A channel with one frame is "static" (same vectors for all playback frames).
+ * A channel with N frames advances in sync with the trajectory.
+ */
+export interface VectorChannel {
+  name: string; // e.g. "velocity", "force"
+  frames: VectorFrame[];
+}
+
 /** Decoded trajectory frame. */
 export interface Frame {
   frameId: number;


### PR DESCRIPTION
## Summary

- **Rust**: Add `VectorChannel`/`VectorFrame` types to `megane-core`; parse GRO velocity columns as a static 1-frame channel and LAMMPS dump `vx/vy/vz`/`fx/fy/fz` columns as N-frame channels; all other parsers return empty `vector_channels`
- **WASM**: Expose vector channels on `ParseResult` and `XtcParseResult` via `vector_channel_count`, `vector_channel_meta` (JSON), and `vector_channel_data` (flat Float32Array)
- **TypeScript**: Add `VectorChannel` type; deserialize embedded channels in `structure.ts` and `xtc.ts`; auto-load first embedded channel into the pipeline store on structure/trajectory load

## Motivation

Previously, per-atom vector quantities (velocities in GRO, forces/velocities in LAMMPS dump) were silently discarded. Users had to provide a separate `.vec` JSON Lines file. Now these values are extracted automatically and fed into the existing `LoadVectorNode` / `VectorOverlayNode` pipeline — a GRO file with velocities will display velocity arrows without any extra steps.

## Frame semantics

| Source | Frames | Behaviour |
|---|---|---|
| GRO velocity | 1 (static) | Same vectors shown for all playback frames |
| LAMMPS dump vx/vy/vz | N (dynamic) | Vectors advance in sync with trajectory |
| `.vec` file | 1 or N | Unchanged |

The existing `getVectorsForFrame()` length-1 heuristic handles both cases transparently — no TypeScript rendering changes needed.

## Test plan

- [x] `cargo test -p megane-core` — 75 tests pass (5 new: GRO with/without velocities, partial velocities ignored; LAMMPS dump with/without velocity columns)
- [x] `npm test` — 266 tests pass
- [x] `npm run build:wasm` — WASM builds cleanly

https://claude.ai/code/session_01ET5q8oujWEHCK7UaR2ntPv