### PR TITLE
feat: add bond selection and per-bond opacity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,6 @@ docs/api/python/
 docs/api/typescript/
 docs/notebooks/
 docs/public/notebooks/
-dev-preview/videos/tmp-*/
+dev-preview/
 coverage/
 .coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+
+- **Bond selection** — Filter node now accepts a `bond_query` for selecting bonds by index or connected atoms. Supports `bond_index`, `atom_index`, and `element` fields with a `both` modifier for requiring both endpoints to match. Example: `both atom_index >= 24` selects bonds where both atoms are solvent.
+- **Per-bond opacity** — Modify node applies per-bond opacity when bonds are filtered, enabling selective transparency (e.g., semi-transparent solvent bonds)
+- Default caffeine-water pipeline now renders solvent bonds semi-transparent to match solvent atom opacity
+
 ## [0.4.0] - 2026-03-14
 
 ### Added

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -203,9 +203,10 @@ class Filter(PipelineNode):
     _out_ports = {"particle": "out"}
     _inp_ports = {"particle": "in"}
 
-    def __init__(self, *, query: str) -> None:
+    def __init__(self, *, query: str = "all", bond_query: str = "") -> None:
         super().__init__()
         self.query = query
+        self.bond_query = bond_query
 
 
 class Modify(PipelineNode):
@@ -528,6 +529,7 @@ class Pipeline:
             base["connected"] = False
         elif isinstance(node, Filter):
             base["query"] = node.query
+            base["bond_query"] = node.bond_query
         elif isinstance(node, Modify):
             base["scale"] = node.scale
             base["opacity"] = node.opacity

--- a/src/components/nodes/FilterNode.tsx
+++ b/src/components/nodes/FilterNode.tsx
@@ -10,7 +10,7 @@ import type { NodeProps, Node } from "@xyflow/react";
 import type { PipelineNodeData } from "../../pipeline/execute";
 import type { FilterParams } from "../../pipeline/types";
 import { usePipelineStore } from "../../pipeline/store";
-import { validateQuery } from "../../pipeline/selection";
+import { validateQuery, validateBondQuery } from "../../pipeline/selection";
 import { NodeShell } from "./NodeShell";
 
 const inputStyle: React.CSSProperties = {
@@ -50,11 +50,17 @@ export function FilterNode({ id, data }: NodeProps<Node<PipelineNodeData>>) {
   const updateNodeParams = usePipelineStore((s) => s.updateNodeParams);
   const params = data.params as FilterParams;
   const [localQuery, setLocalQuery] = useState(params.query);
+  const [localBondQuery, setLocalBondQuery] = useState(params.bond_query ?? "");
   const [error, setError] = useState<string | null>(null);
+  const [bondError, setBondError] = useState<string | null>(null);
 
   useEffect(() => {
     setLocalQuery(params.query);
   }, [params.query]);
+
+  useEffect(() => {
+    setLocalBondQuery(params.bond_query ?? "");
+  }, [params.bond_query]);
 
   const handleCommit = useCallback(() => {
     const result = validateQuery(localQuery);
@@ -62,13 +68,24 @@ export function FilterNode({ id, data }: NodeProps<Node<PipelineNodeData>>) {
     updateNodeParams(id, { query: localQuery });
   }, [id, localQuery, updateNodeParams]);
 
+  const handleBondCommit = useCallback(() => {
+    const result = validateBondQuery(localBondQuery);
+    setBondError(result.valid ? null : (result.error ?? "Invalid bond query"));
+    updateNodeParams(id, { bond_query: localBondQuery });
+  }, [id, localBondQuery, updateNodeParams]);
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === "Enter") {
-        handleCommit();
-      }
+      if (e.key === "Enter") handleCommit();
     },
     [handleCommit],
+  );
+
+  const handleBondKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") handleBondCommit();
+    },
+    [handleBondCommit],
   );
 
   return (
@@ -83,6 +100,18 @@ export function FilterNode({ id, data }: NodeProps<Node<PipelineNodeData>>) {
       />
       {error && <div style={errorStyle}>{error}</div>}
       {!error && !localQuery && <div style={hintStyle}>element, index, x, y, z, resname, mass</div>}
+      <input
+        value={localBondQuery}
+        onChange={(e) => setLocalBondQuery(e.target.value)}
+        onBlur={handleBondCommit}
+        onKeyDown={handleBondKeyDown}
+        placeholder='both atom_index >= 24'
+        style={{ ...(bondError ? inputErrorStyle : inputStyle), marginTop: 6 }}
+      />
+      {bondError && <div style={errorStyle}>{bondError}</div>}
+      {!bondError && !localBondQuery && (
+        <div style={hintStyle}>bond_index, atom_index, element · "both" for AND</div>
+      )}
     </NodeShell>
   );
 }

--- a/src/components/nodes/FilterNode.tsx
+++ b/src/components/nodes/FilterNode.tsx
@@ -105,7 +105,7 @@ export function FilterNode({ id, data }: NodeProps<Node<PipelineNodeData>>) {
         onChange={(e) => setLocalBondQuery(e.target.value)}
         onBlur={handleBondCommit}
         onKeyDown={handleBondKeyDown}
-        placeholder='both atom_index >= 24'
+        placeholder="both atom_index >= 24"
         style={{ ...(bondError ? inputErrorStyle : inputStyle), marginTop: 6 }}
       />
       {bondError && <div style={errorStyle}>{bondError}</div>}

--- a/src/pipeline/apply.ts
+++ b/src/pipeline/apply.ts
@@ -117,7 +117,12 @@ export function applyViewportState(
         bond.nAtoms,
       );
       layer.setBondScale(bond.scale);
-      layer.setBondOpacity(bond.opacity);
+      if (bond.bondOpacityOverrides) {
+        layer.setBondOpacityOverrides(bond.bondOpacityOverrides);
+      } else {
+        layer.clearBondOpacityOverrides();
+        layer.setBondOpacity(bond.opacity);
+      }
       layer.setBondsVisible(true);
     } else {
       layer.setBondsVisible(false);
@@ -316,7 +321,16 @@ function applyBondSettings(
   if (!prevBond || bond.scale !== prevBond.scale) {
     renderer.setBondScale(bond.scale);
   }
-  if (!prevBond || bond.opacity !== prevBond.opacity) {
+  if (!prevBond || bond.bondOpacityOverrides !== prevBond?.bondOpacityOverrides) {
+    if (bond.bondOpacityOverrides) {
+      renderer.setBondOpacityOverrides(bond.bondOpacityOverrides);
+    } else {
+      renderer.clearBondOpacityOverrides();
+      if (!prevBond || bond.opacity !== prevBond.opacity) {
+        renderer.setBondOpacity(bond.opacity);
+      }
+    }
+  } else if (!prevBond || bond.opacity !== prevBond.opacity) {
     renderer.setBondOpacity(bond.opacity);
   }
 }

--- a/src/pipeline/defaults.ts
+++ b/src/pipeline/defaults.ts
@@ -122,6 +122,32 @@ export function createDefaultPipeline(): {
           enabled: true,
         },
       },
+      {
+        id: "filter-bond-sol",
+        type: "filter",
+        position: { x: 255, y: 615 },
+        data: {
+          params: {
+            type: "filter",
+            query: "",
+            bond_query: "both atom_index >= 24",
+          },
+          enabled: true,
+        },
+      },
+      {
+        id: "modify-bond-sol",
+        type: "modify",
+        position: { x: 255, y: 920 },
+        data: {
+          params: {
+            type: "modify",
+            scale: 1.0,
+            opacity: 0.15,
+          },
+          enabled: true,
+        },
+      },
       // Row 3: Sink
       {
         id: "viewport-1",
@@ -183,8 +209,22 @@ export function createDefaultPipeline(): {
       {
         id: "e7",
         source: "addbond-1",
-        target: "viewport-1",
+        target: "filter-bond-sol",
         sourceHandle: "bond",
+        targetHandle: "in",
+      },
+      {
+        id: "e7b",
+        source: "filter-bond-sol",
+        target: "modify-bond-sol",
+        sourceHandle: "out",
+        targetHandle: "in",
+      },
+      {
+        id: "e7c",
+        source: "modify-bond-sol",
+        target: "viewport-1",
+        sourceHandle: "out",
         targetHandle: "bond",
       },
       {

--- a/src/pipeline/executors/addBond.ts
+++ b/src/pipeline/executors/addBond.ts
@@ -229,6 +229,9 @@ export function executeAddBond(
           positions: extPositions,
           elements: extElements,
           nAtoms: extNAtoms,
+          atomElements: snapshot.elements,
+          selectedBondIndices: null,
+          bondOpacityOverrides: null,
         };
         outputs.set("bond", bond);
       }
@@ -274,6 +277,9 @@ export function executeAddBond(
           positions: extPositions,
           elements: extElements,
           nAtoms: extNAtoms,
+          atomElements: snapshot.elements,
+          selectedBondIndices: null,
+          bondOpacityOverrides: null,
         };
         outputs.set("bond", bond);
       }

--- a/src/pipeline/executors/filter.ts
+++ b/src/pipeline/executors/filter.ts
@@ -1,5 +1,5 @@
-import type { PipelineData, ParticleData, FilterParams } from "../types";
-import { evaluateSelection } from "../selection";
+import type { PipelineData, ParticleData, BondData, FilterParams } from "../types";
+import { evaluateSelection, evaluateBondSelection } from "../selection";
 
 export function executeFilter(
   params: FilterParams,
@@ -44,7 +44,28 @@ export function executeFilter(
       outputs.set("out", particle);
     }
   } else if (inData.type === "bond") {
-    outputs.set("out", inData);
+    const bond = inData as BondData;
+    const bondQuery = params.bond_query?.trim() ?? "";
+    if (bondQuery && bond.atomElements) {
+      try {
+        const selectedSet = evaluateBondSelection(
+          bondQuery,
+          bond.bondIndices,
+          bond.atomElements,
+          bond.nBonds,
+        );
+        if (selectedSet !== null) {
+          outputs.set("out", {
+            ...bond,
+            selectedBondIndices: new Uint32Array(selectedSet),
+          });
+          return outputs;
+        }
+      } catch {
+        // Invalid query: pass through unchanged
+      }
+    }
+    outputs.set("out", bond);
   }
 
   return outputs;

--- a/src/pipeline/executors/modify.ts
+++ b/src/pipeline/executors/modify.ts
@@ -52,12 +52,21 @@ export function executeModify(
     outputs.set("out", modified);
   } else if (inData.type === "bond") {
     const bond = inData as BondData;
-    const modified: BondData = {
-      ...bond,
-      scale: params.scale,
-      opacity: params.opacity,
-    };
-    outputs.set("out", modified);
+    if (bond.selectedBondIndices !== null) {
+      // Per-bond opacity: apply params.opacity only to selected bonds
+      const opacityArr = new Float32Array(bond.nBonds).fill(1.0);
+      for (const idx of bond.selectedBondIndices) {
+        opacityArr[idx] = params.opacity;
+      }
+      outputs.set("out", {
+        ...bond,
+        scale: params.scale,
+        bondOpacityOverrides: opacityArr,
+      });
+    } else {
+      // Global opacity (no bond selection active)
+      outputs.set("out", { ...bond, scale: params.scale, opacity: params.opacity });
+    }
   }
 
   return outputs;

--- a/src/pipeline/executors/streaming.ts
+++ b/src/pipeline/executors/streaming.ts
@@ -52,6 +52,9 @@ export function executeStreaming(
       positions: null,
       elements: null,
       nAtoms: snapshot.nAtoms,
+      atomElements: snapshot.elements,
+      selectedBondIndices: null,
+      bondOpacityOverrides: null,
     };
     outputs.set("bond", bond);
   }

--- a/src/pipeline/selection.ts
+++ b/src/pipeline/selection.ts
@@ -429,15 +429,50 @@ function tokenizeBond(query: string): BondToken[] {
   const tokens: BondToken[] = [];
   let i = 0;
   while (i < query.length) {
-    if (/\s/.test(query[i])) { i++; continue; }
-    if (query[i] === "(") { tokens.push({ type: "lparen", value: "(" }); i++; continue; }
-    if (query[i] === ")") { tokens.push({ type: "rparen", value: ")" }); i++; continue; }
-    if (query.startsWith("==", i)) { tokens.push({ type: "op", value: "==" }); i += 2; continue; }
-    if (query.startsWith("!=", i)) { tokens.push({ type: "op", value: "!=" }); i += 2; continue; }
-    if (query.startsWith(">=", i)) { tokens.push({ type: "op", value: ">=" }); i += 2; continue; }
-    if (query.startsWith("<=", i)) { tokens.push({ type: "op", value: "<=" }); i += 2; continue; }
-    if (query[i] === ">") { tokens.push({ type: "op", value: ">" }); i++; continue; }
-    if (query[i] === "<") { tokens.push({ type: "op", value: "<" }); i++; continue; }
+    if (/\s/.test(query[i])) {
+      i++;
+      continue;
+    }
+    if (query[i] === "(") {
+      tokens.push({ type: "lparen", value: "(" });
+      i++;
+      continue;
+    }
+    if (query[i] === ")") {
+      tokens.push({ type: "rparen", value: ")" });
+      i++;
+      continue;
+    }
+    if (query.startsWith("==", i)) {
+      tokens.push({ type: "op", value: "==" });
+      i += 2;
+      continue;
+    }
+    if (query.startsWith("!=", i)) {
+      tokens.push({ type: "op", value: "!=" });
+      i += 2;
+      continue;
+    }
+    if (query.startsWith(">=", i)) {
+      tokens.push({ type: "op", value: ">=" });
+      i += 2;
+      continue;
+    }
+    if (query.startsWith("<=", i)) {
+      tokens.push({ type: "op", value: "<=" });
+      i += 2;
+      continue;
+    }
+    if (query[i] === ">") {
+      tokens.push({ type: "op", value: ">" });
+      i++;
+      continue;
+    }
+    if (query[i] === "<") {
+      tokens.push({ type: "op", value: "<" });
+      i++;
+      continue;
+    }
     if (query[i] === '"' || query[i] === "'") {
       const quote = query[i];
       let j = i + 1;
@@ -447,7 +482,10 @@ function tokenizeBond(query: string): BondToken[] {
       i = j + 1;
       continue;
     }
-    if (/[\d.]/.test(query[i]) || (query[i] === "-" && i + 1 < query.length && /[\d.]/.test(query[i + 1]))) {
+    if (
+      /[\d.]/.test(query[i]) ||
+      (query[i] === "-" && i + 1 < query.length && /[\d.]/.test(query[i + 1]))
+    ) {
       let j = i;
       if (query[j] === "-") j++;
       while (j < query.length && /[\d.]/.test(query[j])) j++;
@@ -488,10 +526,16 @@ class BondParser {
   private tokens: BondToken[];
   private pos = 0;
 
-  constructor(tokens: BondToken[]) { this.tokens = tokens; }
+  constructor(tokens: BondToken[]) {
+    this.tokens = tokens;
+  }
 
-  private peek(): BondToken { return this.tokens[this.pos]; }
-  private advance(): BondToken { return this.tokens[this.pos++]; }
+  private peek(): BondToken {
+    return this.tokens[this.pos];
+  }
+  private advance(): BondToken {
+    return this.tokens[this.pos++];
+  }
 
   private expect(type: BondTokenType): BondToken {
     const t = this.peek();
@@ -533,8 +577,14 @@ class BondParser {
 
   private parseAtom(): BondASTNode {
     const t = this.peek();
-    if (t.type === "all") { this.advance(); return { kind: "all" }; }
-    if (t.type === "none") { this.advance(); return { kind: "none" }; }
+    if (t.type === "all") {
+      this.advance();
+      return { kind: "all" };
+    }
+    if (t.type === "none") {
+      this.advance();
+      return { kind: "none" };
+    }
     if (t.type === "lparen") {
       this.advance();
       const node = this.parseOr();
@@ -570,13 +620,20 @@ class BondParser {
 
 function applyOp(fieldValue: string | number, op: string, value: string | number): boolean {
   switch (op) {
-    case "==": return fieldValue === value;
-    case "!=": return fieldValue !== value;
-    case ">":  return fieldValue > value;
-    case "<":  return fieldValue < value;
-    case ">=": return fieldValue >= value;
-    case "<=": return fieldValue <= value;
-    default:   return false;
+    case "==":
+      return fieldValue === value;
+    case "!=":
+      return fieldValue !== value;
+    case ">":
+      return fieldValue > value;
+    case "<":
+      return fieldValue < value;
+    case ">=":
+      return fieldValue >= value;
+    case "<=":
+      return fieldValue <= value;
+    default:
+      return false;
   }
 }
 
@@ -586,8 +643,10 @@ function compileBondAST(
   elements: Uint8Array,
 ): (bondIdx: number) => boolean {
   switch (ast.kind) {
-    case "all":  return () => true;
-    case "none": return () => false;
+    case "all":
+      return () => true;
+    case "none":
+      return () => false;
     case "not": {
       const fn = compileBondAST(ast.operand, bondIndices, elements);
       return (i) => !fn(i);

--- a/src/pipeline/selection.ts
+++ b/src/pipeline/selection.ts
@@ -382,3 +382,292 @@ export function validateQuery(query: string): { valid: boolean; error?: string }
     return { valid: false, error: (e as Error).message };
   }
 }
+
+// ─── Bond Selection Query ──────────────────────────────────────────────────────
+//
+// Grammar:
+//   Query      := OrExpr
+//   OrExpr     := AndExpr ("or" AndExpr)*
+//   AndExpr    := NotExpr ("and" NotExpr)*
+//   NotExpr    := "not" NotExpr | Atom
+//   Atom       := "both" Comparison | Comparison | "(" OrExpr ")" | "all" | "none"
+//   Comparison := Field Op Value
+//   Field      := "bond_index" | "atom_index" | "element"
+//   Op         := "==" | "!=" | ">" | "<" | ">=" | "<="
+//   Value      := QuotedString | Number
+//
+// Semantics:
+//   "both" prefix: both atoms of the bond must satisfy the condition
+//   Without "both": either atom satisfies the condition (OR semantics)
+//   "bond_index": the 0-based sequential index of the bond
+//   "atom_index": index of an atom endpoint
+//   "element": element symbol of an atom endpoint
+
+const BOND_FIELDS = new Set(["bond_index", "atom_index", "element"]);
+
+type BondTokenType =
+  | "bond_field"
+  | "op"
+  | "number"
+  | "string"
+  | "and"
+  | "or"
+  | "not"
+  | "both"
+  | "lparen"
+  | "rparen"
+  | "all"
+  | "none"
+  | "eof";
+
+interface BondToken {
+  type: BondTokenType;
+  value: string;
+}
+
+function tokenizeBond(query: string): BondToken[] {
+  const tokens: BondToken[] = [];
+  let i = 0;
+  while (i < query.length) {
+    if (/\s/.test(query[i])) { i++; continue; }
+    if (query[i] === "(") { tokens.push({ type: "lparen", value: "(" }); i++; continue; }
+    if (query[i] === ")") { tokens.push({ type: "rparen", value: ")" }); i++; continue; }
+    if (query.startsWith("==", i)) { tokens.push({ type: "op", value: "==" }); i += 2; continue; }
+    if (query.startsWith("!=", i)) { tokens.push({ type: "op", value: "!=" }); i += 2; continue; }
+    if (query.startsWith(">=", i)) { tokens.push({ type: "op", value: ">=" }); i += 2; continue; }
+    if (query.startsWith("<=", i)) { tokens.push({ type: "op", value: "<=" }); i += 2; continue; }
+    if (query[i] === ">") { tokens.push({ type: "op", value: ">" }); i++; continue; }
+    if (query[i] === "<") { tokens.push({ type: "op", value: "<" }); i++; continue; }
+    if (query[i] === '"' || query[i] === "'") {
+      const quote = query[i];
+      let j = i + 1;
+      while (j < query.length && query[j] !== quote) j++;
+      if (j >= query.length) throw new Error(`Unterminated string at position ${i}`);
+      tokens.push({ type: "string", value: query.slice(i + 1, j) });
+      i = j + 1;
+      continue;
+    }
+    if (/[\d.]/.test(query[i]) || (query[i] === "-" && i + 1 < query.length && /[\d.]/.test(query[i + 1]))) {
+      let j = i;
+      if (query[j] === "-") j++;
+      while (j < query.length && /[\d.]/.test(query[j])) j++;
+      tokens.push({ type: "number", value: query.slice(i, j) });
+      i = j;
+      continue;
+    }
+    if (/[a-zA-Z_]/.test(query[i])) {
+      let j = i;
+      while (j < query.length && /[a-zA-Z_0-9]/.test(query[j])) j++;
+      const word = query.slice(i, j);
+      if (word === "and") tokens.push({ type: "and", value: word });
+      else if (word === "or") tokens.push({ type: "or", value: word });
+      else if (word === "not") tokens.push({ type: "not", value: word });
+      else if (word === "all") tokens.push({ type: "all", value: word });
+      else if (word === "none") tokens.push({ type: "none", value: word });
+      else if (word === "both") tokens.push({ type: "both", value: word });
+      else if (BOND_FIELDS.has(word)) tokens.push({ type: "bond_field", value: word });
+      else throw new Error(`Unknown identifier: "${word}"`);
+      i = j;
+      continue;
+    }
+    throw new Error(`Unexpected character: "${query[i]}" at position ${i}`);
+  }
+  tokens.push({ type: "eof", value: "" });
+  return tokens;
+}
+
+type BondASTNode =
+  | { kind: "comparison"; field: string; op: string; value: string | number; both: boolean }
+  | { kind: "and"; left: BondASTNode; right: BondASTNode }
+  | { kind: "or"; left: BondASTNode; right: BondASTNode }
+  | { kind: "not"; operand: BondASTNode }
+  | { kind: "all" }
+  | { kind: "none" };
+
+class BondParser {
+  private tokens: BondToken[];
+  private pos = 0;
+
+  constructor(tokens: BondToken[]) { this.tokens = tokens; }
+
+  private peek(): BondToken { return this.tokens[this.pos]; }
+  private advance(): BondToken { return this.tokens[this.pos++]; }
+
+  private expect(type: BondTokenType): BondToken {
+    const t = this.peek();
+    if (t.type !== type) throw new Error(`Expected ${type}, got ${t.type} ("${t.value}")`);
+    return this.advance();
+  }
+
+  parse(): BondASTNode {
+    const node = this.parseOr();
+    if (this.peek().type !== "eof") throw new Error(`Unexpected token: "${this.peek().value}"`);
+    return node;
+  }
+
+  private parseOr(): BondASTNode {
+    let left = this.parseAnd();
+    while (this.peek().type === "or") {
+      this.advance();
+      left = { kind: "or", left, right: this.parseAnd() };
+    }
+    return left;
+  }
+
+  private parseAnd(): BondASTNode {
+    let left = this.parseNot();
+    while (this.peek().type === "and") {
+      this.advance();
+      left = { kind: "and", left, right: this.parseNot() };
+    }
+    return left;
+  }
+
+  private parseNot(): BondASTNode {
+    if (this.peek().type === "not") {
+      this.advance();
+      return { kind: "not", operand: this.parseNot() };
+    }
+    return this.parseAtom();
+  }
+
+  private parseAtom(): BondASTNode {
+    const t = this.peek();
+    if (t.type === "all") { this.advance(); return { kind: "all" }; }
+    if (t.type === "none") { this.advance(); return { kind: "none" }; }
+    if (t.type === "lparen") {
+      this.advance();
+      const node = this.parseOr();
+      this.expect("rparen");
+      return node;
+    }
+    if (t.type === "both") {
+      this.advance();
+      return this.parseComparison(true);
+    }
+    if (t.type === "bond_field") {
+      return this.parseComparison(false);
+    }
+    throw new Error(`Unexpected token: "${t.value}" (${t.type})`);
+  }
+
+  private parseComparison(both: boolean): BondASTNode {
+    const field = this.expect("bond_field").value;
+    const op = this.expect("op").value;
+    const valToken = this.peek();
+    let value: string | number;
+    if (valToken.type === "string") {
+      value = this.advance().value;
+    } else if (valToken.type === "number") {
+      value = parseFloat(this.advance().value);
+      if (isNaN(value as number)) throw new Error("Invalid number");
+    } else {
+      throw new Error(`Expected value after operator, got ${valToken.type}`);
+    }
+    return { kind: "comparison", field, op, value, both };
+  }
+}
+
+function applyOp(fieldValue: string | number, op: string, value: string | number): boolean {
+  switch (op) {
+    case "==": return fieldValue === value;
+    case "!=": return fieldValue !== value;
+    case ">":  return fieldValue > value;
+    case "<":  return fieldValue < value;
+    case ">=": return fieldValue >= value;
+    case "<=": return fieldValue <= value;
+    default:   return false;
+  }
+}
+
+function compileBondAST(
+  ast: BondASTNode,
+  bondIndices: Uint32Array,
+  elements: Uint8Array,
+): (bondIdx: number) => boolean {
+  switch (ast.kind) {
+    case "all":  return () => true;
+    case "none": return () => false;
+    case "not": {
+      const fn = compileBondAST(ast.operand, bondIndices, elements);
+      return (i) => !fn(i);
+    }
+    case "and": {
+      const left = compileBondAST(ast.left, bondIndices, elements);
+      const right = compileBondAST(ast.right, bondIndices, elements);
+      return (i) => left(i) && right(i);
+    }
+    case "or": {
+      const left = compileBondAST(ast.left, bondIndices, elements);
+      const right = compileBondAST(ast.right, bondIndices, elements);
+      return (i) => left(i) || right(i);
+    }
+    case "comparison": {
+      const { field, op, value, both } = ast;
+      return (i) => {
+        const atomA = bondIndices[i * 2];
+        const atomB = bondIndices[i * 2 + 1];
+        switch (field) {
+          case "bond_index":
+            return applyOp(i, op, value);
+          case "atom_index":
+            if (both) return applyOp(atomA, op, value) && applyOp(atomB, op, value);
+            return applyOp(atomA, op, value) || applyOp(atomB, op, value);
+          case "element": {
+            const elemA = getElementSymbol(elements[atomA] ?? 0);
+            const elemB = getElementSymbol(elements[atomB] ?? 0);
+            if (both) return applyOp(elemA, op, value) && applyOp(elemB, op, value);
+            return applyOp(elemA, op, value) || applyOp(elemB, op, value);
+          }
+          default:
+            return false;
+        }
+      };
+    }
+  }
+}
+
+/**
+ * Evaluate a bond selection query.
+ * Returns null for empty/"all" (all bonds selected).
+ * Returns a Set of matching bond indices (0-based) otherwise.
+ */
+export function evaluateBondSelection(
+  query: string,
+  bondIndices: Uint32Array,
+  elements: Uint8Array,
+  nBonds: number,
+): Set<number> | null {
+  const trimmed = query.trim();
+  if (trimmed === "" || trimmed === "all") return null;
+
+  const tokens = tokenizeBond(trimmed);
+  const parser = new BondParser(tokens);
+  const ast = parser.parse();
+
+  if (ast.kind === "all") return null;
+  if (ast.kind === "none") return new Set();
+
+  const predicate = compileBondAST(ast, bondIndices, elements);
+  const result = new Set<number>();
+  for (let i = 0; i < nBonds; i++) {
+    if (predicate(i)) result.add(i);
+  }
+  return result;
+}
+
+/**
+ * Validate a bond query string without evaluating it.
+ */
+export function validateBondQuery(query: string): { valid: boolean; error?: string } {
+  const trimmed = query.trim();
+  if (trimmed === "" || trimmed === "all" || trimmed === "none") return { valid: true };
+  try {
+    const tokens = tokenizeBond(trimmed);
+    const parser = new BondParser(tokens);
+    parser.parse();
+    return { valid: true };
+  } catch (e) {
+    return { valid: false, error: (e as Error).message };
+  }
+}

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -338,7 +338,7 @@ export interface ViewportParams {
 export interface FilterParams {
   type: "filter";
   query: string;
-  bond_query: string; // bond selection query (empty = no filtering)
+  bond_query?: string; // bond selection query (empty/undefined = no filtering)
 }
 
 export interface ModifyParams {

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -52,6 +52,12 @@ export interface BondData {
   positions: Float32Array | null; // null = use particle positions
   elements: Uint8Array | null; // null = use particle elements
   nAtoms: number; // total atoms including ghosts (0 = use particle nAtoms)
+  // Base atom elements (non-ghost), used by bond filter for element/atom_index queries
+  atomElements: Uint8Array | null;
+  // Bond selection (set by filter node with bond_query)
+  selectedBondIndices: Uint32Array | null; // null = all bonds selected
+  // Per-bond opacity overrides (set by modify node when selectedBondIndices is non-null)
+  bondOpacityOverrides: Float32Array | null; // length = nBonds
 }
 
 /** Simulation cell data. */
@@ -332,6 +338,7 @@ export interface ViewportParams {
 export interface FilterParams {
   type: "filter";
   query: string;
+  bond_query: string; // bond selection query (empty = no filtering)
 }
 
 export interface ModifyParams {
@@ -396,7 +403,7 @@ export function defaultParams(type: PipelineNodeType): PipelineNodeParams {
     case "viewport":
       return { type, perspective: false, cellAxesVisible: true };
     case "filter":
-      return { type, query: "" };
+      return { type, query: "", bond_query: "" };
     case "modify":
       return { type, scale: 1.0, opacity: 1.0 };
     case "label_generator":

--- a/src/renderer/ImpostorBondMesh.ts
+++ b/src/renderer/ImpostorBondMesh.ts
@@ -44,6 +44,8 @@ export class ImpostorBondMesh {
   private colorBuf: Float32Array;
   private radiusBuf: Float32Array;
   private dashedBuf: Float32Array;
+  private opacityBuf: Float32Array; // per-visual-instance opacity override
+  private logicalBondIdx: Float32Array; // CPU-only: maps visual instance → logical bond index
 
   // Position DataTexture (updated per frame)
   private positionTex: THREE.DataTexture;
@@ -75,6 +77,8 @@ export class ImpostorBondMesh {
     this.colorBuf = new Float32Array(maxBonds * 3);
     this.radiusBuf = new Float32Array(maxBonds);
     this.dashedBuf = new Float32Array(maxBonds);
+    this.opacityBuf = new Float32Array(maxBonds).fill(1.0);
+    this.logicalBondIdx = new Float32Array(maxBonds);
 
     // Initial DataTexture (1x1 placeholder)
     this.positionTexData = new Float32Array(4);
@@ -102,6 +106,7 @@ export class ImpostorBondMesh {
         uBondScaleMultiplier: { value: 1.0 },
         uPositionTex: { value: this.positionTex },
         uPositionTexWidth: { value: 1 },
+        uUsePerBondOverrides: { value: 0 },
       },
       depthWrite: true,
       depthTest: true,
@@ -178,6 +183,8 @@ export class ImpostorBondMesh {
             cb,
             0,
           );
+          this.logicalBondIdx[idx] = i;
+          this.opacityBuf[idx] = 1.0;
           idx++;
         }
       } else if (order === BOND_TRIPLE) {
@@ -186,21 +193,32 @@ export class ImpostorBondMesh {
           const ox = Math.cos(angle) * TRIPLE_BOND_OFFSET;
           const oy = Math.sin(angle) * TRIPLE_BOND_OFFSET;
           this.setTopology(idx, ai, bi, ox, oy, TRIPLE_BOND_RADIUS, cr, cg, cb, 0);
+          this.logicalBondIdx[idx] = i;
+          this.opacityBuf[idx] = 1.0;
           idx++;
         }
       } else if (order === BOND_AROMATIC) {
         // Solid bond
         this.setTopology(idx, ai, bi, 0, 0, AROMATIC_BOND_RADIUS, cr, cg, cb, 0);
+        this.logicalBondIdx[idx] = i;
+        this.opacityBuf[idx] = 1.0;
         idx++;
         // Dashed offset bond
         this.setTopology(idx, ai, bi, DOUBLE_BOND_OFFSET, 0, AROMATIC_DASH_RADIUS, cr, cg, cb, 1);
+        this.logicalBondIdx[idx] = i;
+        this.opacityBuf[idx] = 1.0;
         idx++;
       } else {
         // Single bond
         this.setTopology(idx, ai, bi, 0, 0, BOND_RADIUS, cr, cg, cb, 0);
+        this.logicalBondIdx[idx] = i;
+        this.opacityBuf[idx] = 1.0;
         idx++;
       }
     }
+
+    // Reset per-bond override mode when loading a new snapshot
+    this.bondMaterial.uniforms.uUsePerBondOverrides.value = 0;
 
     // Recreate all InstancedBufferAttributes and re-register them.
     // This forces Three.js to create new GPU buffers, ensuring data
@@ -262,6 +280,7 @@ export class ImpostorBondMesh {
     const color = new THREE.InstancedBufferAttribute(this.colorBuf, 3);
     const radius = new THREE.InstancedBufferAttribute(this.radiusBuf, 1);
     const dashed = new THREE.InstancedBufferAttribute(this.dashedBuf, 1);
+    const opacity = new THREE.InstancedBufferAttribute(this.opacityBuf, 1);
 
     this.geo.setAttribute("instanceAtomA", atomA);
     this.geo.setAttribute("instanceAtomB", atomB);
@@ -270,6 +289,7 @@ export class ImpostorBondMesh {
     this.geo.setAttribute("instanceColor", color);
     this.geo.setAttribute("instanceRadius", radius);
     this.geo.setAttribute("instanceDashed", dashed);
+    this.geo.setAttribute("instanceBondOpacity", opacity);
   }
 
   private grow(needed: number): void {
@@ -282,6 +302,8 @@ export class ImpostorBondMesh {
     const newColor = new Float32Array(this.capacity * 3);
     const newRadius = new Float32Array(this.capacity);
     const newDashed = new Float32Array(this.capacity);
+    const newOpacity = new Float32Array(this.capacity).fill(1.0);
+    const newLogical = new Float32Array(this.capacity);
 
     newAtomA.set(this.atomABuf);
     newAtomB.set(this.atomBBuf);
@@ -290,6 +312,8 @@ export class ImpostorBondMesh {
     newColor.set(this.colorBuf);
     newRadius.set(this.radiusBuf);
     newDashed.set(this.dashedBuf);
+    newOpacity.set(this.opacityBuf);
+    newLogical.set(this.logicalBondIdx);
 
     this.atomABuf = newAtomA;
     this.atomBBuf = newAtomB;
@@ -298,6 +322,8 @@ export class ImpostorBondMesh {
     this.colorBuf = newColor;
     this.radiusBuf = newRadius;
     this.dashedBuf = newDashed;
+    this.opacityBuf = newOpacity;
+    this.logicalBondIdx = newLogical;
 
     this.registerAttributes();
   }
@@ -307,6 +333,33 @@ export class ImpostorBondMesh {
     this.bondMaterial.uniforms.uOpacity.value = opacity;
     this.bondMaterial.transparent = opacity < 1;
     this.bondMaterial.depthWrite = opacity >= 1;
+    this.bondMaterial.needsUpdate = true;
+  }
+
+  /**
+   * Apply per-bond opacity overrides (one value per logical bond).
+   * Maps logical bond opacities to visual instances and activates per-bond mode.
+   */
+  setBondOpacityOverrides(logicalOpacities: Float32Array): void {
+    const count = this.geo.instanceCount;
+    for (let v = 0; v < count; v++) {
+      const li = this.logicalBondIdx[v];
+      this.opacityBuf[v] = logicalOpacities[li] ?? 1.0;
+    }
+    const attr = this.geo.getAttribute("instanceBondOpacity") as THREE.InstancedBufferAttribute;
+    if (attr) attr.needsUpdate = true;
+    this.bondMaterial.uniforms.uUsePerBondOverrides.value = 1;
+    this.bondMaterial.transparent = true;
+    this.bondMaterial.depthWrite = false;
+    this.bondMaterial.needsUpdate = true;
+  }
+
+  /** Clear per-bond opacity overrides, reverting to global opacity mode. */
+  clearBondOpacityOverrides(): void {
+    this.opacityBuf.fill(1.0);
+    const attr = this.geo.getAttribute("instanceBondOpacity") as THREE.InstancedBufferAttribute;
+    if (attr) attr.needsUpdate = true;
+    this.bondMaterial.uniforms.uUsePerBondOverrides.value = 0;
     this.bondMaterial.needsUpdate = true;
   }
 

--- a/src/renderer/MoleculeRenderer.ts
+++ b/src/renderer/MoleculeRenderer.ts
@@ -436,6 +436,16 @@ export class MoleculeRenderer {
     this.bondRenderer?.setOpacity?.(opacity);
   }
 
+  /** Apply per-bond opacity overrides (one value per logical bond). */
+  setBondOpacityOverrides(overrides: Float32Array): void {
+    this.bondRenderer?.setBondOpacityOverrides?.(overrides);
+  }
+
+  /** Clear per-bond opacity overrides, reverting to global opacity. */
+  clearBondOpacityOverrides(): void {
+    this.bondRenderer?.clearBondOpacityOverrides?.();
+  }
+
   /** Toggle atom visibility. */
   setAtomsVisible(visible: boolean): void {
     if (this.atomRenderer) {

--- a/src/renderer/StructureLayer.ts
+++ b/src/renderer/StructureLayer.ts
@@ -138,6 +138,14 @@ export class StructureLayer {
     this.bondRenderer?.setOpacity?.(opacity);
   }
 
+  setBondOpacityOverrides(overrides: Float32Array): void {
+    this.bondRenderer?.setBondOpacityOverrides?.(overrides);
+  }
+
+  clearBondOpacityOverrides(): void {
+    this.bondRenderer?.clearBondOpacityOverrides?.();
+  }
+
   setAtomsVisible(visible: boolean): void {
     if (this.atomRenderer) {
       this.atomRenderer.mesh.visible = visible;

--- a/src/renderer/shaders.ts
+++ b/src/renderer/shaders.ts
@@ -136,10 +136,12 @@ export const bondVertexShader = /* glsl */ `precision highp float;
   in vec3 instanceColor;
   in float instanceRadius;
   in float instanceDashed;
+  in float instanceBondOpacity;
 
   out vec3 vColor;
   out vec2 vCylUv;
   out float vDashed;
+  out float vBondOpacity;
 
   vec3 getAtomPos(int idx) {
     int tx = idx % uPositionTexWidth;
@@ -151,6 +153,7 @@ export const bondVertexShader = /* glsl */ `precision highp float;
     vColor = instanceColor;
     vCylUv = uv;
     vDashed = instanceDashed;
+    vBondOpacity = instanceBondOpacity;
 
     int atomA = int(instanceAtomA + 0.5);
     int atomB = int(instanceAtomB + 0.5);
@@ -197,8 +200,10 @@ export const bondFragmentShader = /* glsl */ `precision highp float;
   in vec3 vColor;
   in vec2 vCylUv;
   in float vDashed;
+  in float vBondOpacity;
 
   uniform float uOpacity;
+  uniform int uUsePerBondOverrides;
 
   out vec4 fragColor;
 
@@ -236,6 +241,10 @@ export const bondFragmentShader = /* glsl */ `precision highp float;
     vec3 color = vColor * (ambient + diffuse)
                + vec3(1.0) * spec * 0.2
                + vec3(0.1) * fresnel;
-    fragColor = vec4(color, uOpacity);
+    float finalOpacity = uOpacity;
+    if (uUsePerBondOverrides == 1) {
+      finalOpacity *= vBondOpacity;
+    }
+    fragColor = vec4(color, finalOpacity);
   }
 `;

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,8 @@ export interface BondRenderer {
   updatePositions(positions: Float32Array, bonds: Uint32Array, nBonds: number): void;
   setOpacity?(opacity: number): void;
   setScale?(scale: number, snapshot: Snapshot): void;
+  setBondOpacityOverrides?(overrides: Float32Array): void;
+  clearBondOpacityOverrides?(): void;
   dispose(): void;
 }
 

--- a/tests/ts/pipeline/types.test.ts
+++ b/tests/ts/pipeline/types.test.ts
@@ -91,6 +91,7 @@ describe("defaultParams", () => {
     expect(params).toEqual({
       type: "filter",
       query: "",
+      bond_query: "",
     });
   });
 

--- a/tests/ts/pipeline/types.test.ts
+++ b/tests/ts/pipeline/types.test.ts
@@ -92,7 +92,7 @@ describe("defaultParams", () => {
       type: "filter",
       query: "",
       bond_query: "",
-    });
+    }); // bond_query is included in defaults
   });
 
   it("returns correct defaults for modify", () => {


### PR DESCRIPTION
## Summary

- Add `bond_query` field to the Filter node for selecting bonds by bond index, atom index, or element symbol
- `both` modifier requires both atom endpoints to satisfy the condition (AND); default is either-atom (OR)
- Modify node creates per-bond opacity arrays when bonds are filtered, enabling selective transparency
- ImpostorBondMesh gains per-instance GPU opacity attribute and `setBondOpacityOverrides` method
- Default caffeine-water pipeline updated so solvent bonds are semi-transparent (opacity 0.15) to match solvent atoms
- Python `Filter` class updated with `bond_query` parameter

### Bond query syntax examples
- `bond_index >= 10` — select by bond index
- `atom_index >= 24` — bonds where either atom has index ≥ 24
- `both atom_index >= 24` — bonds where both atoms have index ≥ 24 (water-water bonds)
- `element == "O"` — bonds where either atom is oxygen
- `both element == "O"` — bonds where both atoms are oxygen

## Test plan

- [x] All 266 TypeScript unit tests pass (`npm test`)
- [x] Rust tests pass (`cargo test -p megane-core`)
- [x] Visual screenshot confirms solvent bonds are semi-transparent in caffeine-water view
- [ ] CI passes on branch

https://claude.ai/code/session_01FTf5vGrKSzKx8zqxBYpLcs