### PR TITLE
Fix load trajectory node animation not playing

### DIFF
--- a/src/hooks/useMeganeLocal.ts
+++ b/src/hooks/useMeganeLocal.ts
@@ -193,10 +193,13 @@ export function useMeganeLocal(): MeganeLocalState {
       resetPlayback();
       setXtcFileName(xtc.name);
 
+      // Feed parsed frames into the pipeline store so executeLoadTrajectory produces output.
+      const store = usePipelineStore.getState();
+      store.setFileFrames(frames, xtcMeta ?? null);
+
       // Auto-load first embedded vector channel (e.g. LAMMPS dump vx/vy/vz) into pipeline.
       if (vectorChannels.length > 0) {
         const ch = vectorChannels[0];
-        const store = usePipelineStore.getState();
         store.setFileVectors(ch.frames);
         // Update all load_vector nodes so the UI shows the channel name.
         for (const n of store.nodes) {


### PR DESCRIPTION
## Summary

- `useMeganeLocal.loadXtc` parsed XTC frames but never called `usePipelineStore.setFileFrames()`, so the pipeline executor received `ctx.fileFrames = null`
- `executeLoadTrajectory` therefore returned no output → `viewportState.trajectories` was empty → `setPlaybackProvider(null)` → `totalFrames = 0` in the playback store → pressing play did nothing
- Fix: call `store.setFileFrames(frames, xtcMeta)` after parsing so the pipeline re-executes, creates a `MemoryFrameProvider`, and wires it to the playback store correctly

## Test plan

- [ ] Load a structure file, then drop an XTC onto the Load Trajectory node — verify the timeline appears and play works (frames animate)
- [ ] Verify streaming node trajectory playback still works (no regression)
- [ ] All 266 TypeScript unit tests pass (`npm test`)

https://claude.ai/code/session_01RbcyGfRQyhuqjXcWo7pEcp