### PR TITLE
Fix state leak when switching between pipeline templates

### DIFF
--- a/src/pipeline/store.ts
+++ b/src/pipeline/store.ts
@@ -385,6 +385,16 @@ export const usePipelineStore = create<PipelineStore>((set, get) => ({
       edges,
       viewportState: { ...DEFAULT_VIEWPORT_STATE },
       pendingTemplateId: templateId,
+      snapshot: null,
+      atomLabels: null,
+      structureFrames: null,
+      structureMeta: null,
+      fileFrames: null,
+      fileMeta: null,
+      fileVectors: null,
+      nodeSnapshots: {},
+      nodeParseErrors: {},
+      nodeStreamingData: {},
     });
     get().execute();
   },

--- a/src/pipeline/store.ts
+++ b/src/pipeline/store.ts
@@ -105,6 +105,19 @@ function getInitialPipeline() {
 const rawDefault = getInitialPipeline();
 const defaultState = getLayoutedElements(rawDefault.nodes, rawDefault.edges);
 
+const CLEARED_EXECUTION_CONTEXT = {
+  snapshot: null,
+  atomLabels: null,
+  structureFrames: null,
+  structureMeta: null,
+  fileFrames: null,
+  fileMeta: null,
+  fileVectors: null,
+  nodeSnapshots: {} as Record<string, NodeSnapshotData>,
+  nodeParseErrors: {} as Record<string, string>,
+  nodeStreamingData: {} as Record<string, NodeStreamingData>,
+} as const;
+
 export const usePipelineStore = create<PipelineStore>((set, get) => ({
   nodes: defaultState.nodes,
   edges: defaultState.edges,
@@ -385,16 +398,7 @@ export const usePipelineStore = create<PipelineStore>((set, get) => ({
       edges,
       viewportState: { ...DEFAULT_VIEWPORT_STATE },
       pendingTemplateId: templateId,
-      snapshot: null,
-      atomLabels: null,
-      structureFrames: null,
-      structureMeta: null,
-      fileFrames: null,
-      fileMeta: null,
-      fileVectors: null,
-      nodeSnapshots: {},
-      nodeParseErrors: {},
-      nodeStreamingData: {},
+      ...CLEARED_EXECUTION_CONTEXT,
     });
     get().execute();
   },
@@ -415,6 +419,7 @@ export const usePipelineStore = create<PipelineStore>((set, get) => ({
       nodes: def.nodes,
       edges: def.edges,
       viewportState: { ...DEFAULT_VIEWPORT_STATE },
+      ...CLEARED_EXECUTION_CONTEXT,
     });
   },
 }));

--- a/tests/ts/pipeline/store.test.ts
+++ b/tests/ts/pipeline/store.test.ts
@@ -134,6 +134,28 @@ describe("usePipelineStore", () => {
       usePipelineStore.getState().applyTemplate("nonexistent");
       expect(usePipelineStore.getState().nodes).toEqual(nodesBefore);
     });
+
+    it("clears execution context state when switching templates", () => {
+      const store = usePipelineStore.getState();
+      // Pre-populate execution context fields
+      store.setSnapshot({ positions: new Float32Array(3), elements: new Int32Array(1), nAtoms: 1, bonds: [], cell: null, pbc: [false, false, false] });
+      store.setNodeSnapshot("loader-1", { snapshot: { positions: new Float32Array(3), elements: new Int32Array(1), nAtoms: 1, bonds: [], cell: null, pbc: [false, false, false] }, atomLabels: null });
+      store.setNodeParseError("loader-1", "some error");
+
+      usePipelineStore.getState().applyTemplate("molecule");
+
+      const state = usePipelineStore.getState();
+      expect(state.snapshot).toBeNull();
+      expect(state.atomLabels).toBeNull();
+      expect(state.structureFrames).toBeNull();
+      expect(state.structureMeta).toBeNull();
+      expect(state.fileFrames).toBeNull();
+      expect(state.fileMeta).toBeNull();
+      expect(state.fileVectors).toBeNull();
+      expect(state.nodeSnapshots).toEqual({});
+      expect(state.nodeParseErrors).toEqual({});
+      expect(state.nodeStreamingData).toEqual({});
+    });
   });
 
   describe("autoLayout", () => {


### PR DESCRIPTION
## Summary
- `applyTemplate` did not clear per-node state (`nodeSnapshots`, `nodeParseErrors`, `nodeStreamingData`) or global molecular data when switching templates
- This caused solid template's structure/cell data to persist when switching to the streaming template, resulting in incorrect display

## Test plan
- [ ] Apply solid template, then switch to streaming template — verify streaming displays correctly without solid structure data leaking in
- [ ] Apply streaming template, then switch to solid — verify solid displays correctly
- [ ] Run `npm test` — all 266 tests pass

https://claude.ai/code/session_01DVPCjREC3XqG3wb89K78u4