### PR TITLE
Fix wrong atoms rendered when switching solid to streaming template

### DIFF
--- a/src/hooks/useMeganeLocal.ts
+++ b/src/hooks/useMeganeLocal.ts
@@ -32,7 +32,15 @@ export interface MeganeLocalState {
   pdbFileName: string | null;
   xtcFileName: string | null;
   loadFile: (pdb: File) => Promise<void>;
-  loadText: (text: string, fileName?: string) => Promise<{ snapshot: Snapshot; frames: Frame[]; meta: TrajectoryMeta | null; labels: string[] | null }>;
+  loadText: (
+    text: string,
+    fileName?: string,
+  ) => Promise<{
+    snapshot: Snapshot;
+    frames: Frame[];
+    meta: TrajectoryMeta | null;
+    labels: string[] | null;
+  }>;
   loadXtc: (xtc: File) => Promise<void>;
   seekFrame: (frameIdx: number) => void;
   bondSource: BondSource;

--- a/src/hooks/useMeganeLocal.ts
+++ b/src/hooks/useMeganeLocal.ts
@@ -7,6 +7,7 @@
 
 import { useState, useRef, useCallback } from "react";
 import { parseStructureFile, parseStructureText } from "../parsers/structure";
+import type { StructureParseResult } from "../parsers/structure";
 import { parseXTCFile, parseLammpstrjFile } from "../parsers/xtc";
 import { useBondSource } from "./useBondSource";
 import { useLabelSource } from "./useLabelSource";
@@ -32,15 +33,7 @@ export interface MeganeLocalState {
   pdbFileName: string | null;
   xtcFileName: string | null;
   loadFile: (pdb: File) => Promise<void>;
-  loadText: (
-    text: string,
-    fileName?: string,
-  ) => Promise<{
-    snapshot: Snapshot;
-    frames: Frame[];
-    meta: TrajectoryMeta | null;
-    labels: string[] | null;
-  }>;
+  loadText: (text: string, fileName?: string) => Promise<StructureParseResult>;
   loadXtc: (xtc: File) => Promise<void>;
   seekFrame: (frameIdx: number) => void;
   bondSource: BondSource;

--- a/src/hooks/useMeganeLocal.ts
+++ b/src/hooks/useMeganeLocal.ts
@@ -32,7 +32,7 @@ export interface MeganeLocalState {
   pdbFileName: string | null;
   xtcFileName: string | null;
   loadFile: (pdb: File) => Promise<void>;
-  loadText: (text: string, fileName?: string) => Promise<void>;
+  loadText: (text: string, fileName?: string) => Promise<{ snapshot: Snapshot; frames: Frame[]; meta: TrajectoryMeta | null; labels: string[] | null }>;
   loadXtc: (xtc: File) => Promise<void>;
   seekFrame: (frameIdx: number) => void;
   bondSource: BondSource;
@@ -165,6 +165,7 @@ export function useMeganeLocal(): MeganeLocalState {
       applyResult(result);
       setPdbFileName(fileName ?? "caffeine_water.pdb");
       setXtcFileName(result.meta ? "PDB models" : null);
+      return result;
     },
     [applyResult],
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,6 @@ import { MeganeViewer } from "./components/MeganeViewer";
 import { useDataSource } from "./hooks/useDataSource";
 import { usePipelineStore } from "./pipeline/store";
 import { usePlaybackStore } from "./stores/usePlaybackStore";
-import { parseStructureText } from "./parsers/structure";
 import { parseXTCFile } from "./parsers/xtc";
 import { MemoryFrameProvider } from "./pipeline/types";
 import defaultPDB from "../tests/fixtures/caffeine_water.pdb?raw";
@@ -66,8 +65,8 @@ function App() {
       } else if (pendingTemplateId === "solid") {
         await ds.local.loadText(perovskiteXYZ, "perovskite_srtio3_3x3x3.xyz");
       } else if (pendingTemplateId === "streaming") {
-        // Simulate streaming by parsing local data and populating nodeStreamingData
-        const result = await parseStructureText(defaultPDB, "caffeine_water.pdb");
+        // Load via ds.local so ds.snapshot updates → Viewport.loadSnapshot uses caffeine atoms
+        const result = await ds.local.loadText(defaultPDB, "caffeine_water.pdb");
         const resp = await fetch(defaultXtcUrl);
         const blob = await resp.blob();
         const xtcFile = new File([blob], "caffeine_water_vibration.xtc");


### PR DESCRIPTION
## Summary

- The previous fix (#221) cleared the Zustand pipeline store on template switch, but the rendering bug persisted
- Root cause: `renderer.loadSnapshot(ds.snapshot)` is the **only** way atoms are loaded into the primary renderer — `applyViewportState` only applies per-atom overrides (scale/opacity), it does not reload atoms
- When switching solid → streaming, `ds.snapshot` remained as the perovskite snapshot because the streaming template path called `parseStructureText` directly (bypassing `useMeganeLocal`)
- The renderer kept perovskite atoms loaded, so `setAtomsVisible(true)` from the streaming node revealed the wrong structure

## Fix

- In the streaming template path (`index.tsx`), replace `parseStructureText(defaultPDB, ...)` with `ds.local.loadText(defaultPDB, "caffeine_water.pdb")`
- This updates `ds.snapshot → caffeineSnapshot`, triggering `Viewport.loadSnapshot(caffeineSnapshot)` so the renderer loads the correct atoms
- Modified `useMeganeLocal.loadText` to return the parsed result, so the same parse output is reused for `setNodeStreamingData` (no double-parsing)

## Test plan

- [ ] Apply solid template (perovskite) → Apply streaming template → verify caffeine+water is displayed correctly with trajectory
- [ ] Cycle through all templates (molecule → solid → streaming → molecule) and verify each shows the correct structure
- [ ] `npm test` — all 267 tests pass

https://claude.ai/code/session_01DVPCjREC3XqG3wb89K78u4