### PR TITLE
Fix trajectory controls broken on streaming template

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,6 +32,7 @@ function App() {
   // Playback store state
   const playing = usePlaybackStore((s) => s.playing);
   const fps = usePlaybackStore((s) => s.fps);
+  const totalFrames = usePlaybackStore((s) => s.totalFrames);
   const togglePlayPause = usePlaybackStore((s) => s.togglePlayPause);
   const setFps = usePlaybackStore((s) => s.setFps);
   const seekFrame = usePlaybackStore((s) => s.seekFrame);
@@ -129,7 +130,7 @@ function App() {
       snapshot={ds.snapshot}
       frame={ds.frame}
       currentFrame={ds.currentFrame}
-      totalFrames={ds.meta?.nFrames ?? 0}
+      totalFrames={totalFrames}
       playing={playing}
       fps={fps}
       onSeek={handleSeek}


### PR DESCRIPTION
## Summary

- `totalFrames` was derived from `ds.meta?.nFrames ?? 0` in `index.tsx`, but `ds.meta` is `null` for the streaming template because `ds.local.loadXtc()` is never called (XTC frames go directly to `nodeStreamingData` via `parseXTCFile`)
- As a result, `totalFrames = 0` was passed to the Timeline and PipelineEditor, breaking the seekbar and frame counter while the playback store internally had the correct frame count
- Fix: subscribe to `usePlaybackStore.totalFrames` directly, which is always set correctly from the pipeline provider regardless of template type

## Test plan

- [ ] All TypeScript tests pass (`npm test`)
- [ ] Prettier formatting passes (`npm run format:check`)
- [ ] Streaming template: Timeline shows correct frame count and seekbar is functional
- [ ] Molecule template: Timeline still works correctly (regression check)

https://claude.ai/code/session_01DVPCjREC3XqG3wb89K78u4