### PR TITLE
fix: enable mouse events and measurement UI in Jupyter widget mode

### DIFF
--- a/src/components/WidgetViewer.tsx
+++ b/src/components/WidgetViewer.tsx
@@ -188,13 +188,16 @@ function WidgetViewerPipeline({
     }
   }, [pipelineJson]);
 
-  const handleRendererReady = useCallback((renderer: MoleculeRenderer) => {
-    rendererRef.current = renderer;
-    applyViewportState(renderer, usePipelineStore.getState().viewportState, null);
-    prevViewportStateRef.current = usePipelineStore.getState().viewportState;
-    // Apply initial selectedAtoms that may have arrived before the renderer was ready
-    setExternalSelection(selectedAtomsRef.current ?? []);
-  }, [setExternalSelection]);
+  const handleRendererReady = useCallback(
+    (renderer: MoleculeRenderer) => {
+      rendererRef.current = renderer;
+      applyViewportState(renderer, usePipelineStore.getState().viewportState, null);
+      prevViewportStateRef.current = usePipelineStore.getState().viewportState;
+      // Apply initial selectedAtoms that may have arrived before the renderer was ready
+      setExternalSelection(selectedAtomsRef.current ?? []);
+    },
+    [setExternalSelection],
+  );
 
   const handlePlayPause = useCallback(() => {
     setPlaying((prev) => {
@@ -314,11 +317,14 @@ function WidgetViewerSimple({
     setExternalSelection(selectedAtoms ?? []);
   }, [selectedAtoms, setExternalSelection]);
 
-  const handleRendererReady = useCallback((renderer: MoleculeRenderer) => {
-    rendererRef.current = renderer;
-    // Apply initial selectedAtoms that may have arrived before the renderer was ready
-    setExternalSelection(selectedAtomsRef.current ?? []);
-  }, [setExternalSelection]);
+  const handleRendererReady = useCallback(
+    (renderer: MoleculeRenderer) => {
+      rendererRef.current = renderer;
+      // Apply initial selectedAtoms that may have arrived before the renderer was ready
+      setExternalSelection(selectedAtomsRef.current ?? []);
+    },
+    [setExternalSelection],
+  );
 
   const handlePlayPause = useCallback(() => {
     setPlaying((prev) => {

--- a/src/components/WidgetViewer.tsx
+++ b/src/components/WidgetViewer.tsx
@@ -85,12 +85,14 @@ function WidgetViewerPipeline({
     setExternalSelection,
   } = useAtomSelection(rendererRef, onMeasurementChange);
 
+  // Keep a ref so handleRendererReady can apply the initial selection
+  const selectedAtomsRef = useRef(selectedAtoms);
+  selectedAtomsRef.current = selectedAtoms;
+
   // Sync external atom selection from Python
   useEffect(() => {
     setExternalSelection(selectedAtoms ?? []);
   }, [selectedAtoms, setExternalSelection]);
-
-  // Subscribe to pipeline store
   const viewportState = usePipelineStore((s) => s.viewportState);
   const storeSnapshot = usePipelineStore((s) => s.snapshot);
   const setSnapshot = usePipelineStore((s) => s.setSnapshot);
@@ -190,7 +192,9 @@ function WidgetViewerPipeline({
     rendererRef.current = renderer;
     applyViewportState(renderer, usePipelineStore.getState().viewportState, null);
     prevViewportStateRef.current = usePipelineStore.getState().viewportState;
-  }, []);
+    // Apply initial selectedAtoms that may have arrived before the renderer was ready
+    setExternalSelection(selectedAtomsRef.current ?? []);
+  }, [setExternalSelection]);
 
   const handlePlayPause = useCallback(() => {
     setPlaying((prev) => {
@@ -302,13 +306,19 @@ function WidgetViewerSimple({
     setExternalSelection,
   } = useAtomSelection(rendererRef, onMeasurementChange);
 
+  // Keep a ref so handleRendererReady can apply the initial selection
+  const selectedAtomsRef = useRef(selectedAtoms);
+  selectedAtomsRef.current = selectedAtoms;
+
   useEffect(() => {
     setExternalSelection(selectedAtoms ?? []);
   }, [selectedAtoms, setExternalSelection]);
 
   const handleRendererReady = useCallback((renderer: MoleculeRenderer) => {
     rendererRef.current = renderer;
-  }, []);
+    // Apply initial selectedAtoms that may have arrived before the renderer was ready
+    setExternalSelection(selectedAtomsRef.current ?? []);
+  }, [setExternalSelection]);
 
   const handlePlayPause = useCallback(() => {
     setPlaying((prev) => {

--- a/src/components/WidgetViewer.tsx
+++ b/src/components/WidgetViewer.tsx
@@ -10,7 +10,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Viewport } from "./Viewport";
 import { Timeline } from "./Timeline";
+import { Tooltip } from "./Tooltip";
+import { MeasurementPanel } from "./MeasurementPanel";
 import { MoleculeRenderer } from "../renderer/MoleculeRenderer";
+import { useAtomSelection } from "../hooks/useAtomSelection";
 import { inferBondsVdwJS } from "../parsers/inferBondsJS";
 import { processPbcBonds } from "../pipeline/executors/addBond";
 import { usePipelineStore } from "../pipeline/store";
@@ -18,7 +21,7 @@ import { applyViewportState } from "../pipeline/apply";
 import { decodeSnapshot, decodeHeader, MSG_SNAPSHOT } from "../protocol/protocol";
 import type { ViewportState, AddBondParams } from "../pipeline/types";
 import type { NodeSnapshotData } from "../pipeline/execute";
-import type { Snapshot, Frame, Measurement } from "../types";
+import type { Snapshot, Frame, Measurement, HoverInfo } from "../types";
 
 interface WidgetViewerProps {
   snapshot: Snapshot | null;
@@ -61,6 +64,8 @@ function WidgetViewerPipeline({
   currentFrame,
   totalFrames,
   onSeek,
+  selectedAtoms,
+  onMeasurementChange,
   pipelineJson,
   nodeSnapshotsData,
 }: WidgetViewerProps) {
@@ -68,7 +73,22 @@ function WidgetViewerPipeline({
   const playIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const [playing, setPlaying] = useState(false);
   const [fps, setFps] = useState(30);
+  const [hoverInfo, setHoverInfo] = useState<HoverInfo | null>(null);
   const prevViewportStateRef = useRef<ViewportState | null>(null);
+
+  const {
+    selection,
+    measurement,
+    handleAtomRightClick,
+    handleClearSelection,
+    handleFrameUpdated,
+    setExternalSelection,
+  } = useAtomSelection(rendererRef, onMeasurementChange);
+
+  // Sync external atom selection from Python
+  useEffect(() => {
+    setExternalSelection(selectedAtoms ?? []);
+  }, [selectedAtoms, setExternalSelection]);
 
   // Subscribe to pipeline store
   const viewportState = usePipelineStore((s) => s.viewportState);
@@ -229,9 +249,9 @@ function WidgetViewerPipeline({
         snapshot={storeSnapshot ?? snapshot}
         frame={frame}
         onRendererReady={handleRendererReady}
-        onHover={() => {}}
-        onAtomRightClick={() => {}}
-        onFrameUpdated={() => {}}
+        onHover={setHoverInfo}
+        onAtomRightClick={handleAtomRightClick}
+        onFrameUpdated={handleFrameUpdated}
       />
 
       {totalFrames > 1 && (
@@ -245,6 +265,13 @@ function WidgetViewerPipeline({
           onFpsChange={handleFpsChange}
         />
       )}
+      <Tooltip info={hoverInfo} />
+      <MeasurementPanel
+        selection={selection}
+        measurement={measurement}
+        elements={storeSnapshot?.elements ?? snapshot?.elements ?? null}
+        onClear={handleClearSelection}
+      />
     </div>
   );
 }
@@ -257,11 +284,27 @@ function WidgetViewerSimple({
   currentFrame,
   totalFrames,
   onSeek,
+  selectedAtoms,
+  onMeasurementChange,
 }: WidgetViewerProps) {
   const rendererRef = useRef<MoleculeRenderer | null>(null);
   const playIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const [playing, setPlaying] = useState(false);
   const [fps, setFps] = useState(30);
+  const [hoverInfo, setHoverInfo] = useState<HoverInfo | null>(null);
+
+  const {
+    selection,
+    measurement,
+    handleAtomRightClick,
+    handleClearSelection,
+    handleFrameUpdated,
+    setExternalSelection,
+  } = useAtomSelection(rendererRef, onMeasurementChange);
+
+  useEffect(() => {
+    setExternalSelection(selectedAtoms ?? []);
+  }, [selectedAtoms, setExternalSelection]);
 
   const handleRendererReady = useCallback((renderer: MoleculeRenderer) => {
     rendererRef.current = renderer;
@@ -324,9 +367,9 @@ function WidgetViewerSimple({
         snapshot={snapshot}
         frame={frame}
         onRendererReady={handleRendererReady}
-        onHover={() => {}}
-        onAtomRightClick={() => {}}
-        onFrameUpdated={() => {}}
+        onHover={setHoverInfo}
+        onAtomRightClick={handleAtomRightClick}
+        onFrameUpdated={handleFrameUpdated}
       />
 
       {totalFrames > 1 && (
@@ -340,6 +383,13 @@ function WidgetViewerSimple({
           onFpsChange={handleFpsChange}
         />
       )}
+      <Tooltip info={hoverInfo} />
+      <MeasurementPanel
+        selection={selection}
+        measurement={measurement}
+        elements={snapshot?.elements ?? null}
+        onClear={handleClearSelection}
+      />
     </div>
   );
 }

--- a/tests/ts/components/WidgetViewer.test.tsx
+++ b/tests/ts/components/WidgetViewer.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, act, cleanup } from "@testing-library/react";
+import type { HoverInfo } from "@/types";
+
+// Mock heavy components to avoid WebGL/canvas in jsdom
+vi.mock("@/components/Viewport", () => ({
+  Viewport: vi.fn(() => null),
+}));
+vi.mock("@/components/Tooltip", () => ({
+  Tooltip: vi.fn(() => null),
+}));
+vi.mock("@/components/MeasurementPanel", () => ({
+  MeasurementPanel: vi.fn(() => null),
+}));
+
+import { WidgetViewer } from "@/components/WidgetViewer";
+import { Viewport } from "@/components/Viewport";
+import { Tooltip } from "@/components/Tooltip";
+import { MeasurementPanel } from "@/components/MeasurementPanel";
+
+const mockViewport = vi.mocked(Viewport);
+const mockTooltip = vi.mocked(Tooltip);
+const mockMeasurementPanel = vi.mocked(MeasurementPanel);
+
+const defaultProps = {
+  snapshot: null,
+  frame: null,
+  currentFrame: 0,
+  totalFrames: 1,
+  onSeek: vi.fn(),
+};
+
+describe("WidgetViewer (simple mode)", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("passes non-noop handlers to Viewport", () => {
+    render(<WidgetViewer {...defaultProps} />);
+    const props = mockViewport.mock.calls[0][0];
+    expect(props.onHover).toBeTypeOf("function");
+    expect(props.onAtomRightClick).toBeTypeOf("function");
+    expect(props.onFrameUpdated).toBeTypeOf("function");
+  });
+
+  it("renders Tooltip overlay", () => {
+    render(<WidgetViewer {...defaultProps} />);
+    expect(mockTooltip).toHaveBeenCalled();
+  });
+
+  it("renders MeasurementPanel overlay", () => {
+    render(<WidgetViewer {...defaultProps} />);
+    expect(mockMeasurementPanel).toHaveBeenCalled();
+  });
+
+  it("calling Viewport onHover updates Tooltip info", () => {
+    render(<WidgetViewer {...defaultProps} />);
+    const viewportProps = mockViewport.mock.calls[0][0];
+
+    const atomInfo: HoverInfo = {
+      kind: "atom",
+      atomIndex: 3,
+      elementSymbol: "N",
+      atomicNumber: 7,
+      position: [0, 0, 0],
+      screenX: 100,
+      screenY: 200,
+    };
+
+    act(() => {
+      viewportProps.onHover(atomInfo);
+    });
+
+    const lastTooltipProps = mockTooltip.mock.lastCall?.[0];
+    expect(lastTooltipProps?.info).toEqual(atomInfo);
+  });
+
+  it("Tooltip starts with null info before any hover", () => {
+    render(<WidgetViewer {...defaultProps} />);
+    const tooltipProps = mockTooltip.mock.calls[0][0];
+    expect(tooltipProps.info).toBeNull();
+  });
+});
+
+describe("WidgetViewer (pipeline mode)", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("passes non-noop handlers to Viewport", () => {
+    render(<WidgetViewer {...defaultProps} pipeline />);
+    const props = mockViewport.mock.calls[0][0];
+    expect(props.onHover).toBeTypeOf("function");
+    expect(props.onAtomRightClick).toBeTypeOf("function");
+    expect(props.onFrameUpdated).toBeTypeOf("function");
+  });
+
+  it("renders Tooltip and MeasurementPanel in pipeline mode", () => {
+    render(<WidgetViewer {...defaultProps} pipeline />);
+    expect(mockTooltip).toHaveBeenCalled();
+    expect(mockMeasurementPanel).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Both `WidgetViewerSimple` and `WidgetViewerPipeline` were passing no-op callbacks (`() => {}`) to `<Viewport>`, disabling all mouse interactivity in Jupyter widget mode
- `<Tooltip>` and `<MeasurementPanel>` were not rendered in widget mode, making distance/angle/dihedral measurement inaccessible
- `selectedAtoms` and `onMeasurementChange` props from `widget.ts` were passed but never consumed

**Changes in `src/components/WidgetViewer.tsx`:**
- Wire `useAtomSelection` hook into both `WidgetViewerSimple` and `WidgetViewerPipeline`
- Replace no-op `onHover`, `onAtomRightClick`, `onFrameUpdated` with real handlers
- Add `<Tooltip>` and `<MeasurementPanel>` to the widget layout
- Sync Python-side `selectedAtoms` prop via `setExternalSelection`

## Test plan

- [ ] Open a Jupyter notebook with megane widget
- [ ] Right-click an atom → atom should highlight (blue selection sphere)
- [ ] Right-click a second atom → distance measurement panel should appear at bottom
- [ ] Hover over atoms → tooltip should appear showing atom symbol/index
- [ ] Step through trajectory frames → measurement values update correctly
- [ ] Verify `widget._measurement_json` is populated on the Python side
- [ ] TypeScript tests: `npm test` — all 267 tests pass

https://claude.ai/code/session_015MofBfdMA7wduesNuE42Z3