### PR TITLE
feat: add JSON import/export for browser and Python pipeline

### DIFF
--- a/examples/pipeline.ipynb
+++ b/examples/pipeline.ipynb
@@ -126,6 +126,32 @@
    "metadata": {},
    "outputs": [],
    "source": "pipe = megane.Pipeline()\ns = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/caffeine_water.pdb\"))\nbonds = pipe.add_node(megane.AddBonds(source=\"distance\"))\nlabels = pipe.add_node(megane.AddLabels(source=\"element\"))\nv = pipe.add_node(megane.Viewport())\n\npipe.add_edge(s.out.particle, bonds.inp.particle)\npipe.add_edge(s.out.particle, labels.inp.particle)\npipe.add_edge(s.out.particle, v.inp.particle)\npipe.add_edge(bonds.out.bond, v.inp.bond)\npipe.add_edge(labels.out.label, v.inp.label)\n\nviewer = megane.MolecularViewer()\nviewer.set_pipeline(pipe)\nviewer"
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## 7. Import / Export\n\nPipelines can be saved to and loaded from JSON files for reproducible workflows.\n\n### Browser\nIn the Pipeline Editor panel, click **Export** to download the current pipeline as `pipeline.json`,\nor **Import** to upload a saved JSON file and restore it in the editor.\n\n### Python API\n- `pipeline.to_json()` — serialize to a JSON string\n- `pipeline.save(path)` — write JSON to a file\n- `Pipeline.from_dict(d)` — reconstruct from a plain dict\n- `Pipeline.from_json(s)` — reconstruct from a JSON string\n- `Pipeline.load(path)` — load from a JSON file",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "import tempfile, pathlib\n\n# Build a pipeline to export\npipe = megane.Pipeline()\ns = pipe.add_node(megane.LoadStructure(\"../tests/fixtures/1crn.pdb\"))\nbonds = pipe.add_node(megane.AddBonds(source=\"structure\"))\nv = pipe.add_node(megane.Viewport())\n\npipe.add_edge(s.out.particle, bonds.inp.particle)\npipe.add_edge(s.out.particle, v.inp.particle)\npipe.add_edge(bonds.out.bond, v.inp.bond)\n\n# Serialize to JSON string\njson_str = pipe.to_json()\nprint(json_str[:300], \"...\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# Save to a file and load it back\ntmp = pathlib.Path(tempfile.mkdtemp()) / \"my_pipeline.json\"\npipe.save(tmp)\nprint(f\"Saved to {tmp}\")\n\n# Load from file — file paths must still be accessible\npipe2 = megane.Pipeline.load(tmp)\n\nviewer2 = megane.MolecularViewer()\nviewer2.set_pipeline(pipe2)\nviewer2",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# Round-trip via dict (from_dict / from_json also work)\npipe3 = megane.Pipeline.from_dict(pipe.to_dict())\n\nviewer3 = megane.MolecularViewer()\nviewer3.set_pipeline(pipe3)\nviewer3",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -501,6 +501,162 @@ class Pipeline:
         edges = list(self._edges)
         return {"version": 3, "nodes": nodes, "edges": edges}
 
+    def to_json(self, *, indent: int | None = 2) -> str:
+        """Serialize to a JSON string (SerializedPipeline v3).
+
+        Args:
+            indent: JSON indentation level (default 2). Pass ``None`` for compact output.
+
+        Returns:
+            JSON string representation of the pipeline.
+        """
+        import json
+
+        return json.dumps(self.to_dict(), indent=indent)
+
+    def save(self, path) -> None:
+        """Save the pipeline to a JSON file.
+
+        Args:
+            path: Destination file path (``str`` or :class:`pathlib.Path`).
+                  Creates or overwrites the file.
+        """
+        import pathlib
+
+        pathlib.Path(path).write_text(self.to_json(), encoding="utf-8")
+
+    @staticmethod
+    def _build_node_from_dict(nd: dict) -> "PipelineNode":
+        """Instantiate the correct PipelineNode subclass from a v3 node dict."""
+        ntype = nd.get("type")
+        if ntype == "load_structure":
+            return LoadStructure(nd.get("fileName") or "")
+        elif ntype == "load_trajectory":
+            import pathlib
+
+            fname = nd.get("fileName") or ""
+            ext = pathlib.Path(fname).suffix.lower()
+            return LoadTrajectory(
+                xtc=fname if ext == ".xtc" else None,
+                traj=fname if ext != ".xtc" and fname else None,
+            )
+        elif ntype == "filter":
+            return Filter(query=nd.get("query", "all"), bond_query=nd.get("bond_query", ""))
+        elif ntype == "modify":
+            return Modify(scale=nd.get("scale", 1.0), opacity=nd.get("opacity", 1.0))
+        elif ntype == "add_bond":
+            return AddBonds(source=nd.get("bondSource", "distance"))
+        elif ntype == "label_generator":
+            return AddLabels(source=nd.get("source", "element"))
+        elif ntype == "polyhedron_generator":
+            return AddPolyhedra(
+                center_elements=nd.get("centerElements", []),
+                ligand_elements=nd.get("ligandElements", [8]),
+                max_distance=nd.get("maxDistance", 2.5),
+                opacity=nd.get("opacity", 0.5),
+                show_edges=nd.get("showEdges", False),
+                edge_color=nd.get("edgeColor", "#dddddd"),
+                edge_width=nd.get("edgeWidth", 3.0),
+            )
+        elif ntype == "vector_overlay":
+            return VectorOverlay(scale=nd.get("scale", 1.0))
+        elif ntype == "viewport":
+            return Viewport(
+                perspective=nd.get("perspective", False),
+                cell_axes_visible=nd.get("cellAxesVisible", True),
+            )
+        elif ntype == "streaming":
+            return Streaming()
+        elif ntype == "load_vector":
+            return LoadVector(nd.get("fileName") or "")
+        else:
+            raise ValueError(f"Unknown node type {ntype!r}")
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Pipeline":
+        """Reconstruct a Pipeline from a SerializedPipeline v3 dict.
+
+        ``LoadStructure`` file paths in the JSON must still be accessible.
+        Relative paths are resolved from the current working directory at call
+        time.
+
+        Args:
+            d: A dict in ``SerializedPipeline`` v3 format (e.g. from
+               :meth:`to_dict`).
+
+        Returns:
+            A new :class:`Pipeline` instance ready to pass to
+            ``MolecularViewer.set_pipeline()``.
+
+        Raises:
+            ValueError: If the dict is not version 3 or contains an unknown
+                        node type.
+        """
+        if d.get("version") != 3:
+            raise ValueError(
+                f"Unsupported pipeline version: {d.get('version')!r}. Expected 3."
+            )
+
+        pipe = cls()
+        node_by_id: dict[str, PipelineNode] = {}
+
+        for nd in d.get("nodes", []):
+            node = cls._build_node_from_dict(nd)
+            node._id = nd["id"]
+            pipe._nodes[node._id] = (node, pipe._serialize_node(node))
+            node_by_id[node._id] = node
+
+            if isinstance(node, LoadStructure) and node.path:
+                pipe._load_structure_data(node)
+
+        pipe._edges = [dict(e) for e in d.get("edges", [])]
+
+        # Trigger trajectory loading for LoadStructure → LoadTrajectory edges.
+        for edge in pipe._edges:
+            target = node_by_id.get(edge["target"])
+            source = node_by_id.get(edge["source"])
+            if isinstance(target, LoadTrajectory) and isinstance(source, LoadStructure):
+                pipe._load_trajectory_data(target, source)
+
+        # Advance counter past any imported IDs to avoid future collisions.
+        max_counter = 0
+        for nid in pipe._nodes:
+            parts = nid.rsplit("-", 1)
+            if len(parts) == 2 and parts[1].isdigit():
+                max_counter = max(max_counter, int(parts[1]))
+        pipe._counter = max_counter
+
+        return pipe
+
+    @classmethod
+    def from_json(cls, s: str) -> "Pipeline":
+        """Reconstruct a Pipeline from a JSON string.
+
+        Args:
+            s: JSON string in ``SerializedPipeline`` v3 format.
+
+        Returns:
+            A new :class:`Pipeline` instance.
+        """
+        import json
+
+        return cls.from_dict(json.loads(s))
+
+    @classmethod
+    def load(cls, path) -> "Pipeline":
+        """Load a Pipeline from a JSON file saved with :meth:`save`.
+
+        Args:
+            path: Path to a JSON file in ``SerializedPipeline`` v3 format
+                  (``str`` or :class:`pathlib.Path`).
+
+        Returns:
+            A new :class:`Pipeline` instance.
+        """
+        import pathlib
+
+        return cls.from_json(pathlib.Path(path).read_text(encoding="utf-8"))
+
     # ── Internal ────────────────────────────────────────────
 
     def _serialize_node(self, node: PipelineNode) -> dict:

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -593,9 +593,7 @@ class Pipeline:
                         node type.
         """
         if d.get("version") != 3:
-            raise ValueError(
-                f"Unsupported pipeline version: {d.get('version')!r}. Expected 3."
-            )
+            raise ValueError(f"Unsupported pipeline version: {d.get('version')!r}. Expected 3.")
 
         pipe = cls()
         node_by_id: dict[str, PipelineNode] = {}

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -598,7 +598,9 @@ class Pipeline:
         pipe = cls()
         node_by_id: dict[str, PipelineNode] = {}
 
-        for nd in d.get("nodes", []):
+        for i, nd in enumerate(d.get("nodes", [])):
+            if "id" not in nd:
+                raise ValueError(f"Node at index {i} is missing required field 'id'.")
             node = cls._build_node_from_dict(nd)
             node._id = nd["id"]
             pipe._nodes[node._id] = (node, pipe._serialize_node(node))
@@ -607,6 +609,10 @@ class Pipeline:
             if isinstance(node, LoadStructure) and node.path:
                 pipe._load_structure_data(node)
 
+        for i, e in enumerate(d.get("edges", [])):
+            for field in ("source", "target", "sourceHandle", "targetHandle"):
+                if field not in e:
+                    raise ValueError(f"Edge at index {i} is missing required field {field!r}.")
         pipe._edges = [dict(e) for e in d.get("edges", [])]
 
         # Trigger trajectory loading for LoadStructure → LoadTrajectory edges.

--- a/src/components/PipelineEditor.tsx
+++ b/src/components/PipelineEditor.tsx
@@ -16,6 +16,7 @@ import {
 import type { Connection } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { usePipelineStore } from "../pipeline/store";
+import { downloadBlob } from "../renderer/RenderCapture";
 import type { PipelineNodeType } from "../pipeline/types";
 import {
   NODE_TYPE_LABELS,
@@ -353,14 +354,7 @@ function PipelineEditorInner({
   const handleExport = useCallback(() => {
     const serialized = usePipelineStore.getState().serialize();
     const blob = new Blob([JSON.stringify(serialized, null, 2)], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "pipeline.json";
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+    downloadBlob(blob, "pipeline.json");
   }, []);
 
   const handleImportClick = useCallback(() => {
@@ -385,6 +379,10 @@ function PipelineEditorInner({
         } catch (err) {
           window.alert("Failed to load pipeline: " + (err as Error).message);
         }
+        e.target.value = "";
+      };
+      reader.onerror = () => {
+        window.alert("Failed to read file: " + (reader.error?.message ?? "unknown error"));
         e.target.value = "";
       };
       reader.readAsText(file);

--- a/src/components/PipelineEditor.tsx
+++ b/src/components/PipelineEditor.tsx
@@ -137,6 +137,28 @@ const layoutBtnStyle: React.CSSProperties = {
   color: "#10b981",
 };
 
+const exportBtnStyle: React.CSSProperties = {
+  background: "rgba(6, 182, 212, 0.08)",
+  border: "1px solid rgba(6, 182, 212, 0.25)",
+  borderRadius: 6,
+  padding: "4px 12px",
+  cursor: "pointer",
+  fontSize: 11,
+  fontWeight: 600,
+  color: "#06b6d4",
+};
+
+const importBtnStyle: React.CSSProperties = {
+  background: "rgba(99, 102, 241, 0.08)",
+  border: "1px solid rgba(99, 102, 241, 0.25)",
+  borderRadius: 6,
+  padding: "4px 12px",
+  cursor: "pointer",
+  fontSize: 11,
+  fontWeight: 600,
+  color: "#6366f1",
+};
+
 const renderBtnStyle: React.CSSProperties = {
   background: "rgba(245, 158, 11, 0.08)",
   border: "1px solid rgba(245, 158, 11, 0.25)",
@@ -213,6 +235,7 @@ function PipelineEditorInner({
   const addNode = usePipelineStore((s) => s.addNode);
   const applyTemplate = usePipelineStore((s) => s.applyTemplate);
   const autoLayout = usePipelineStore((s) => s.autoLayout);
+  const deserialize = usePipelineStore((s) => s.deserialize);
   const { fitView } = useReactFlow();
 
   const { screenToFlowPosition } = useReactFlow();
@@ -222,6 +245,7 @@ function PipelineEditorInner({
   const [panelWidth, setPanelWidth] = useState(DEFAULT_WIDTH);
   const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
   const flowContainerRef = useRef<HTMLDivElement | null>(null);
+  const importInputRef = useRef<HTMLInputElement | null>(null);
 
   // Resize drag handling
   const handleResizeMouseDown = useCallback(
@@ -326,6 +350,48 @@ function PipelineEditorInner({
     });
   }, [autoLayout, fitView]);
 
+  const handleExport = useCallback(() => {
+    const serialized = usePipelineStore.getState().serialize();
+    const blob = new Blob([JSON.stringify(serialized, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "pipeline.json";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, []);
+
+  const handleImportClick = useCallback(() => {
+    importInputRef.current?.click();
+  }, []);
+
+  const handleImportFile = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        try {
+          const parsed = JSON.parse(reader.result as string);
+          if (parsed.version !== 3) {
+            throw new Error("Not a valid megane pipeline JSON (version 3 required)");
+          }
+          deserialize(parsed);
+          window.requestAnimationFrame(() => {
+            fitView({ padding: 0.1, maxZoom: 1.95, duration: 300 });
+          });
+        } catch (err) {
+          window.alert("Failed to load pipeline: " + (err as Error).message);
+        }
+        e.target.value = "";
+      };
+      reader.readAsText(file);
+    },
+    [deserialize, fitView],
+  );
+
   const memoizedNodeTypes = useMemo(() => nodeTypes, []);
 
   const headerExtra = (
@@ -335,6 +401,12 @@ function PipelineEditorInner({
       </button>
       <button onClick={handleAutoLayout} style={layoutBtnStyle}>
         Auto Layout
+      </button>
+      <button onClick={handleExport} style={exportBtnStyle}>
+        Export
+      </button>
+      <button onClick={handleImportClick} style={importBtnStyle}>
+        Import
       </button>
       <button
         onClick={() => {
@@ -483,6 +555,13 @@ function PipelineEditorInner({
             fitView({ padding: 0.1, maxZoom: 1.95, duration: 300 });
           });
         }}
+      />
+      <input
+        ref={importInputRef}
+        type="file"
+        accept=".json,application/json"
+        style={{ display: "none" }}
+        onChange={handleImportFile}
       />
       <RenderModal
         open={showRenderModal}

--- a/tests/python/test_pipeline.py
+++ b/tests/python/test_pipeline.py
@@ -258,9 +258,11 @@ class TestPipelineAddEdge:
     def test_trajectory_to_viewport_traj(self):
         pipe = Pipeline()
         s = pipe.add_node(LoadStructure(str(FIXTURES / "caffeine_water.pdb")))
-        t = pipe.add_node(LoadTrajectory(
-            xtc=str(FIXTURES / "caffeine_water_vibration.xtc"),
-        ))
+        t = pipe.add_node(
+            LoadTrajectory(
+                xtc=str(FIXTURES / "caffeine_water_vibration.xtc"),
+            )
+        )
         v = pipe.add_node(Viewport())
         pipe.add_edge(s.out.particle, t.inp.particle)
         pipe.add_edge(t.out.traj, v.inp.traj)
@@ -324,9 +326,7 @@ class TestPipelineSerialization:
 
         node_types = [n["type"] for n in result["nodes"]]
         assert "viewport" in node_types
-        viewport_edges = [
-            e for e in result["edges"] if e["target"] == v._id
-        ]
+        viewport_edges = [e for e in result["edges"] if e["target"] == v._id]
         assert len(viewport_edges) == 1
         assert viewport_edges[0]["sourceHandle"] == "particle"
         assert viewport_edges[0]["targetHandle"] == "particle"
@@ -334,7 +334,7 @@ class TestPipelineSerialization:
     def test_viewport_serialization_params(self):
         """Viewport parameters are serialized correctly."""
         pipe = Pipeline()
-        v = pipe.add_node(Viewport(perspective=True, cell_axes_visible=False))
+        pipe.add_node(Viewport(perspective=True, cell_axes_visible=False))
         result = pipe.to_dict()
 
         vp_node = next(n for n in result["nodes"] if n["type"] == "viewport")
@@ -356,9 +356,7 @@ class TestPipelineSerialization:
         pipe.add_edge(lbl.out.label, v.inp.label)
 
         result = pipe.to_dict()
-        viewport_edges = [
-            e for e in result["edges"] if e["target"] == v._id
-        ]
+        viewport_edges = [e for e in result["edges"] if e["target"] == v._id]
         handles = {(e["sourceHandle"], e["targetHandle"]) for e in viewport_edges}
         assert ("particle", "particle") in handles
         assert ("bond", "bond") in handles
@@ -392,18 +390,18 @@ class TestPipelineSerialization:
     def test_polyhedra_serialization(self):
         pipe = Pipeline()
         s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
-        p = pipe.add_node(AddPolyhedra(
-            center_elements=[26],
-            ligand_elements=[8],
-            max_distance=3.0,
-            opacity=0.7,
-        ))
+        p = pipe.add_node(
+            AddPolyhedra(
+                center_elements=[26],
+                ligand_elements=[8],
+                max_distance=3.0,
+                opacity=0.7,
+            )
+        )
         pipe.add_edge(s.out.particle, p.inp.particle)
         result = pipe.to_dict()
 
-        poly_node = next(
-            n for n in result["nodes"] if n["type"] == "polyhedron_generator"
-        )
+        poly_node = next(n for n in result["nodes"] if n["type"] == "polyhedron_generator")
         assert poly_node["centerElements"] == [26]
         assert poly_node["maxDistance"] == 3.0
         assert poly_node["opacity"] == 0.7
@@ -471,15 +469,242 @@ class TestPipelineDAG:
 
         result = pipe.to_dict()
         # f → m: out → in
-        fm_edge = next(
-            e for e in result["edges"]
-            if e["source"] == f._id and e["target"] == m._id
-        )
+        fm_edge = next(e for e in result["edges"] if e["source"] == f._id and e["target"] == m._id)
         assert fm_edge["sourceHandle"] == "out"
 
         # f → lbl: out → particle
-        fl_edge = next(
-            e for e in result["edges"]
-            if e["source"] == f._id and e["target"] == lbl._id
-        )
+        fl_edge = next(e for e in result["edges"] if e["source"] == f._id and e["target"] == lbl._id)
         assert fl_edge["sourceHandle"] == "out"
+
+
+class TestPipelineJsonExport:
+    """Pipeline.to_json() and Pipeline.save() produce correct output."""
+
+    def _make_simple_pipe(self):
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        bonds = pipe.add_node(AddBonds(source="structure"))
+        v = pipe.add_node(Viewport())
+        pipe.add_edge(s.out.particle, bonds.inp.particle)
+        pipe.add_edge(s.out.particle, v.inp.particle)
+        pipe.add_edge(bonds.out.bond, v.inp.bond)
+        return pipe
+
+    def test_to_json_returns_string(self):
+        pipe = self._make_simple_pipe()
+        result = pipe.to_json()
+        assert isinstance(result, str)
+
+    def test_to_json_is_valid_json(self):
+        import json
+
+        pipe = self._make_simple_pipe()
+        d = json.loads(pipe.to_json())
+        assert d["version"] == 3
+        assert isinstance(d["nodes"], list)
+        assert isinstance(d["edges"], list)
+
+    def test_to_json_default_indent(self):
+        pipe = self._make_simple_pipe()
+        json_str = pipe.to_json()
+        # Default indent=2 means the string is not on one line.
+        assert "\n" in json_str
+
+    def test_to_json_compact(self):
+        pipe = self._make_simple_pipe()
+        json_str = pipe.to_json(indent=None)
+        assert "\n" not in json_str
+
+    def test_save_creates_file(self, tmp_path):
+        pipe = self._make_simple_pipe()
+        path = tmp_path / "pipeline.json"
+        pipe.save(path)
+        assert path.exists()
+        assert path.stat().st_size > 0
+
+    def test_save_content_matches_to_json(self, tmp_path):
+        pipe = self._make_simple_pipe()
+        path = tmp_path / "pipeline.json"
+        pipe.save(path)
+        assert path.read_text(encoding="utf-8") == pipe.to_json()
+
+
+class TestPipelineJsonImport:
+    """Pipeline.from_dict(), from_json(), and load() reconstruct pipelines."""
+
+    def _make_simple_pipe(self):
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        bonds = pipe.add_node(AddBonds(source="structure"))
+        v = pipe.add_node(Viewport())
+        pipe.add_edge(s.out.particle, bonds.inp.particle)
+        pipe.add_edge(s.out.particle, v.inp.particle)
+        pipe.add_edge(bonds.out.bond, v.inp.bond)
+        return pipe
+
+    def test_from_dict_returns_pipeline(self):
+        pipe = self._make_simple_pipe()
+        pipe2 = Pipeline.from_dict(pipe.to_dict())
+        assert isinstance(pipe2, Pipeline)
+
+    def test_from_dict_preserves_node_types(self):
+        pipe = self._make_simple_pipe()
+        pipe2 = Pipeline.from_dict(pipe.to_dict())
+        types1 = [cfg["type"] for _, cfg in pipe._nodes.values()]
+        types2 = [cfg["type"] for _, cfg in pipe2._nodes.values()]
+        assert types1 == types2
+
+    def test_from_dict_preserves_edges(self):
+        pipe = self._make_simple_pipe()
+        pipe2 = Pipeline.from_dict(pipe.to_dict())
+        assert len(pipe2._edges) == len(pipe._edges)
+
+    def test_from_dict_preserves_node_ids(self):
+        pipe = self._make_simple_pipe()
+        pipe2 = Pipeline.from_dict(pipe.to_dict())
+        assert set(pipe2._nodes.keys()) == set(pipe._nodes.keys())
+
+    def test_from_dict_loads_structure_binary_data(self):
+        pipe = self._make_simple_pipe()
+        pipe2 = Pipeline.from_dict(pipe.to_dict())
+        # Each LoadStructure node ID should have binary data.
+        load_ids = [nid for nid, (_, cfg) in pipe2._nodes.items() if cfg["type"] == "load_structure"]
+        for nid in load_ids:
+            assert nid in pipe2._node_data
+            assert pipe2._node_data[nid][:4] == b"MEGN"
+
+    def test_from_dict_round_trip_to_dict(self):
+        pipe = self._make_simple_pipe()
+        d = pipe.to_dict()
+        pipe2 = Pipeline.from_dict(d)
+        d2 = pipe2.to_dict()
+        assert d["version"] == d2["version"]
+        assert len(d["nodes"]) == len(d2["nodes"])
+        assert len(d["edges"]) == len(d2["edges"])
+
+    def test_from_dict_counter_advanced(self):
+        """After from_dict, add_node should not collide with imported IDs."""
+        pipe = self._make_simple_pipe()
+        pipe2 = Pipeline.from_dict(pipe.to_dict())
+        new_node = pipe2.add_node(Filter(query="element == 'C'"))
+        assert new_node._id not in pipe._nodes
+
+    def test_from_json_returns_pipeline(self):
+        pipe = self._make_simple_pipe()
+        pipe2 = Pipeline.from_json(pipe.to_json())
+        assert isinstance(pipe2, Pipeline)
+        assert len(pipe2._nodes) == len(pipe._nodes)
+
+    def test_from_json_round_trip(self):
+        pipe = self._make_simple_pipe()
+        pipe2 = Pipeline.from_json(pipe.to_json())
+        assert len(pipe2._edges) == len(pipe._edges)
+
+    def test_load_round_trip(self, tmp_path):
+        pipe = self._make_simple_pipe()
+        path = tmp_path / "test.json"
+        pipe.save(path)
+        pipe2 = Pipeline.load(path)
+        assert isinstance(pipe2, Pipeline)
+        assert len(pipe2._nodes) == len(pipe._nodes)
+        assert len(pipe2._edges) == len(pipe._edges)
+
+    def test_load_structure_data_accessible_after_load(self, tmp_path):
+        pipe = self._make_simple_pipe()
+        path = tmp_path / "test.json"
+        pipe.save(path)
+        pipe2 = Pipeline.load(path)
+        load_ids = [nid for nid, (_, cfg) in pipe2._nodes.items() if cfg["type"] == "load_structure"]
+        assert len(load_ids) == 1
+        assert load_ids[0] in pipe2._node_data
+
+    def test_from_dict_with_filter_params(self):
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        f = pipe.add_node(Filter(query="element == 'C'", bond_query="order > 1"))
+        v = pipe.add_node(Viewport())
+        pipe.add_edge(s.out.particle, f.inp.particle)
+        pipe.add_edge(f.out.particle, v.inp.particle)
+
+        pipe2 = Pipeline.from_dict(pipe.to_dict())
+        filter_cfg = next(cfg for _, cfg in pipe2._nodes.values() if cfg["type"] == "filter")
+        assert filter_cfg["query"] == "element == 'C'"
+        assert filter_cfg["bond_query"] == "order > 1"
+
+    def test_from_dict_with_modify_params(self):
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        m = pipe.add_node(Modify(scale=1.5, opacity=0.7))
+        v = pipe.add_node(Viewport())
+        pipe.add_edge(s.out.particle, m.inp.particle)
+        pipe.add_edge(m.out.particle, v.inp.particle)
+
+        pipe2 = Pipeline.from_dict(pipe.to_dict())
+        modify_cfg = next(cfg for _, cfg in pipe2._nodes.values() if cfg["type"] == "modify")
+        assert modify_cfg["scale"] == 1.5
+        assert modify_cfg["opacity"] == 0.7
+
+    def test_from_dict_with_viewport_params(self):
+        pipe = Pipeline()
+        pipe.add_node(Viewport(perspective=True, cell_axes_visible=False))
+
+        pipe2 = Pipeline.from_dict(pipe.to_dict())
+        vp_cfg = next(cfg for _, cfg in pipe2._nodes.values() if cfg["type"] == "viewport")
+        assert vp_cfg["perspective"] is True
+        assert vp_cfg["cellAxesVisible"] is False
+
+
+class TestPipelineJsonImportErrors:
+    """from_dict raises clear errors on malformed input."""
+
+    def test_wrong_version_raises(self):
+        with pytest.raises(ValueError, match="Unsupported pipeline version"):
+            Pipeline.from_dict({"version": 2, "nodes": [], "edges": []})
+
+    def test_missing_version_raises(self):
+        with pytest.raises(ValueError, match="Unsupported pipeline version"):
+            Pipeline.from_dict({"nodes": [], "edges": []})
+
+    def test_unknown_node_type_raises(self):
+        d = {
+            "version": 3,
+            "nodes": [{"id": "n1", "type": "not_a_real_node"}],
+            "edges": [],
+        }
+        with pytest.raises(ValueError, match="Unknown node type"):
+            Pipeline.from_dict(d)
+
+    def test_missing_node_id_raises(self):
+        d = {
+            "version": 3,
+            "nodes": [{"type": "viewport"}],
+            "edges": [],
+        }
+        with pytest.raises(ValueError, match="missing required field 'id'"):
+            Pipeline.from_dict(d)
+
+    def test_missing_edge_source_raises(self):
+        d = {
+            "version": 3,
+            "nodes": [],
+            "edges": [{"target": "n2", "sourceHandle": "particle", "targetHandle": "particle"}],
+        }
+        with pytest.raises(ValueError, match="missing required field 'source'"):
+            Pipeline.from_dict(d)
+
+    def test_missing_edge_target_raises(self):
+        d = {
+            "version": 3,
+            "nodes": [],
+            "edges": [{"source": "n1", "sourceHandle": "particle", "targetHandle": "particle"}],
+        }
+        with pytest.raises(ValueError, match="missing required field 'target'"):
+            Pipeline.from_dict(d)
+
+    def test_from_json_invalid_json_raises(self):
+        with pytest.raises(Exception):
+            Pipeline.from_json("not valid json {{{")
+
+    def test_load_nonexistent_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            Pipeline.load(tmp_path / "does_not_exist.json")


### PR DESCRIPTION
## Summary

- **Browser Export**: Added an **Export** button to the pipeline editor toolbar that downloads the current pipeline as `pipeline.json` using the existing `serialize()` store action
- **Browser Import**: Added an **Import** button that opens a file picker, parses the uploaded JSON, and calls `deserialize()` to restore the pipeline (with `fitView` after loading and error reporting via `alert` for invalid files)
- **Python `Pipeline` methods**:
  - `to_json()` — serialize to a JSON string
  - `save(path)` — write JSON to a file
  - `from_dict(d)` — reconstruct from a `SerializedPipeline` v3 dict, reloading structure binary data from original file paths
  - `from_json(s)` — reconstruct from a JSON string
  - `Pipeline.load(path)` — load from a JSON file saved with `save()`
- **Example notebook**: Added section 7 to `examples/pipeline.ipynb` demonstrating the full Python save/load round-trip and `from_dict` usage

## Test plan

- [ ] TypeScript: `npm test` — all 267 tests pass
- [ ] Python: `python -m pytest` — all 143 tests pass
- [ ] Browser: Load a structure → click Export → verify `pipeline.json` downloads with correct content → click Import → select the downloaded file → verify pipeline restores and renders
- [ ] Python round-trip: `pipe.save(path)` → `Pipeline.load(path)` → `viewer.set_pipeline(pipe2)` displays the same structure

https://claude.ai/code/session_015Cu9F7DdK6NUGFgweGjZWf