### PR TITLE
feat: remove atom double-click rotation center feature

### DIFF
--- a/src/components/Viewport.tsx
+++ b/src/components/Viewport.tsx
@@ -82,6 +82,21 @@ export function Viewport({
       onHoverRef.current?.(null);
     };
 
+    const handleDblClick = (e: MouseEvent) => {
+      const info = renderer.raycastAtPixel(e.clientX, e.clientY);
+      if (info && info.kind === "atom") {
+        const positions = renderer.getCurrentPositionsCopy();
+        if (positions) {
+          const idx = info.atomIndex;
+          renderer.setRotationCenter(
+            positions[idx * 3],
+            positions[idx * 3 + 1],
+            positions[idx * 3 + 2],
+          );
+        }
+      }
+    };
+
     // ── Axes-inset drag handlers (pointer events for mouse+touch) ──
 
     const containerEl = containerRef.current!;
@@ -114,6 +129,7 @@ export function Viewport({
     canvas.addEventListener("mousemove", handleMouseMove);
     canvas.addEventListener("contextmenu", handleContextMenu);
     canvas.addEventListener("mouseleave", handleMouseLeave);
+    canvas.addEventListener("dblclick", handleDblClick);
     canvas.addEventListener("pointerdown", handlePointerDown);
     canvas.addEventListener("pointermove", handlePointerMove);
     canvas.addEventListener("pointerup", handlePointerUp);
@@ -123,6 +139,7 @@ export function Viewport({
       canvas.removeEventListener("mousemove", handleMouseMove);
       canvas.removeEventListener("contextmenu", handleContextMenu);
       canvas.removeEventListener("mouseleave", handleMouseLeave);
+      canvas.removeEventListener("dblclick", handleDblClick);
       canvas.removeEventListener("pointerdown", handlePointerDown);
       canvas.removeEventListener("pointermove", handlePointerMove);
       canvas.removeEventListener("pointerup", handlePointerUp);

--- a/src/components/Viewport.tsx
+++ b/src/components/Viewport.tsx
@@ -82,21 +82,6 @@ export function Viewport({
       onHoverRef.current?.(null);
     };
 
-    const handleDblClick = (e: MouseEvent) => {
-      const info = renderer.raycastAtPixel(e.clientX, e.clientY);
-      if (info && info.kind === "atom") {
-        const positions = renderer.getCurrentPositionsCopy();
-        if (positions) {
-          const idx = info.atomIndex;
-          renderer.setRotationCenter(
-            positions[idx * 3],
-            positions[idx * 3 + 1],
-            positions[idx * 3 + 2],
-          );
-        }
-      }
-    };
-
     // ── Axes-inset drag handlers (pointer events for mouse+touch) ──
 
     const containerEl = containerRef.current!;
@@ -129,7 +114,7 @@ export function Viewport({
     canvas.addEventListener("mousemove", handleMouseMove);
     canvas.addEventListener("contextmenu", handleContextMenu);
     canvas.addEventListener("mouseleave", handleMouseLeave);
-    canvas.addEventListener("dblclick", handleDblClick);
+
     canvas.addEventListener("pointerdown", handlePointerDown);
     canvas.addEventListener("pointermove", handlePointerMove);
     canvas.addEventListener("pointerup", handlePointerUp);
@@ -139,7 +124,7 @@ export function Viewport({
       canvas.removeEventListener("mousemove", handleMouseMove);
       canvas.removeEventListener("contextmenu", handleContextMenu);
       canvas.removeEventListener("mouseleave", handleMouseLeave);
-      canvas.removeEventListener("dblclick", handleDblClick);
+
       canvas.removeEventListener("pointerdown", handlePointerDown);
       canvas.removeEventListener("pointermove", handlePointerMove);
       canvas.removeEventListener("pointerup", handlePointerUp);

--- a/src/components/Viewport.tsx
+++ b/src/components/Viewport.tsx
@@ -82,25 +82,6 @@ export function Viewport({
       onHoverRef.current?.(null);
     };
 
-    const handleDblClick = (e: MouseEvent) => {
-      const info = renderer.raycastAtPixel(e.clientX, e.clientY);
-      if (info && info.kind === "atom") {
-        const positions = renderer.getCurrentPositionsCopy();
-        if (positions) {
-          const idx = info.atomIndex;
-          const rect = containerRef.current!.getBoundingClientRect();
-          renderer.setRotationCenter(
-            positions[idx * 3],
-            positions[idx * 3 + 1],
-            positions[idx * 3 + 2],
-            true,
-            e.clientX - rect.left,
-            e.clientY - rect.top,
-          );
-        }
-      }
-    };
-
     // ── Axes-inset drag handlers (pointer events for mouse+touch) ──
 
     const containerEl = containerRef.current!;
@@ -133,7 +114,6 @@ export function Viewport({
     canvas.addEventListener("mousemove", handleMouseMove);
     canvas.addEventListener("contextmenu", handleContextMenu);
     canvas.addEventListener("mouseleave", handleMouseLeave);
-    canvas.addEventListener("dblclick", handleDblClick);
     canvas.addEventListener("pointerdown", handlePointerDown);
     canvas.addEventListener("pointermove", handlePointerMove);
     canvas.addEventListener("pointerup", handlePointerUp);
@@ -143,7 +123,6 @@ export function Viewport({
       canvas.removeEventListener("mousemove", handleMouseMove);
       canvas.removeEventListener("contextmenu", handleContextMenu);
       canvas.removeEventListener("mouseleave", handleMouseLeave);
-      canvas.removeEventListener("dblclick", handleDblClick);
       canvas.removeEventListener("pointerdown", handlePointerDown);
       canvas.removeEventListener("pointermove", handlePointerMove);
       canvas.removeEventListener("pointerup", handlePointerUp);

--- a/src/renderer/MoleculeRenderer.ts
+++ b/src/renderer/MoleculeRenderer.ts
@@ -764,12 +764,6 @@ export class MoleculeRenderer {
     };
   }
 
-  /** Set the rotation and zoom center (orbit target) to the given world coordinates. */
-  setRotationCenter(x: number, y: number, z: number): void {
-    this.controls.target.set(x, y, z);
-    this.controls.update();
-  }
-
   /** Get a copy of current atom positions (public, for external use). */
   getCurrentPositionsCopy(): Float32Array | null {
     if (!this.snapshot) return null;

--- a/src/renderer/MoleculeRenderer.ts
+++ b/src/renderer/MoleculeRenderer.ts
@@ -764,6 +764,12 @@ export class MoleculeRenderer {
     };
   }
 
+  /** Set the rotation and zoom center (orbit target) to the given world coordinates. */
+  setRotationCenter(x: number, y: number, z: number): void {
+    this.controls.target.set(x, y, z);
+    this.controls.update();
+  }
+
   /** Get a copy of current atom positions (public, for external use). */
   getCurrentPositionsCopy(): Float32Array | null {
     if (!this.snapshot) return null;

--- a/src/renderer/MoleculeRenderer.ts
+++ b/src/renderer/MoleculeRenderer.ts
@@ -74,32 +74,6 @@ export class MoleculeRenderer {
   private lastContainerW = 0;
   private lastContainerH = 0;
   private lastDpr = 1;
-  /** Duration of the smooth pivot animation in milliseconds. */
-  private static readonly PIVOT_ANIM_DURATION_MS = 400;
-  /** Smooth pivot animation state (set by setRotationCenter). */
-  private pivotAnim: {
-    startTarget: THREE.Vector3;
-    endTarget: THREE.Vector3;
-    startCameraPos: THREE.Vector3;
-    endCameraPos: THREE.Vector3;
-    /** Frustum shift at animation start (= -(camera.left + camera.right) / 2). */
-    startShift: number;
-    /** Frustum shift at animation end (places controls.target at the cursor pixel). */
-    endShift: number;
-    /** Half-width of the frustum, fixed for the duration of the animation. */
-    startHalfW: number;
-    startTime: number;
-    duration: number;
-  } | null = null;
-
-  /**
-   * Fractional X position [0, 1] where controls.target should appear on screen
-   * after the user sets a rotation center by double-clicking.
-   * null = use the inset-computed visual center (default).
-   * Reset to null on fit-to-view.
-   */
-  private pivotFracX: number | null = null;
-
   private wheelZoomHandler: ((e: WheelEvent) => void) | null = null;
 
   /** Structure layers for multi-structure overlay rendering. */
@@ -171,7 +145,6 @@ export class MoleculeRenderer {
     this.controls.dampingFactor = 0.1;
     this.controls.rotateSpeed = 0.8;
     this.controls.zoomSpeed = 1.2;
-    this.attachPivotCancelListener();
     this.attachWheelZoomListener();
 
     // Lighting - hemisphere + 3-point
@@ -586,7 +559,6 @@ export class MoleculeRenderer {
 
   /** Fit camera to show all atoms (or simulation cell if present). */
   private fitToView(snapshot: Snapshot): void {
-    this.pivotFracX = null; // Reset pivot so the inset-based visual center is used.
     this.lastExtent = fitCameraToView(this.camera, this.controls, snapshot);
     if (this.camera instanceof THREE.OrthographicCamera) {
       this.doApplyFrustumInsets();
@@ -598,85 +570,6 @@ export class MoleculeRenderer {
     if (this.snapshot) {
       this.fitToView(this.snapshot);
     }
-  }
-
-  /** Set the rotation center (orbit target) to the given world coordinates.
-   * @param animate  - When true (default), smoothly animates the transition over
-   *   PIVOT_ANIM_DURATION_MS.  Pass false to update synchronously (legacy behaviour).
-   * @param screenX  - Container-relative X pixel of the cursor that triggered the
-   *   pivot change (optional).  When provided the animation also shifts the frustum
-   *   so the clicked atom arrives under the cursor instead of at the inset-shifted
-   *   visual center.
-   * @param screenY  - Container-relative Y pixel of the cursor (optional, paired
-   *   with screenX).
-   */
-  setRotationCenter(
-    x: number,
-    y: number,
-    z: number,
-    animate = true,
-    screenX?: number,
-    screenY?: number,
-  ): void {
-    const endTarget = new THREE.Vector3(x, y, z);
-    if (!animate) {
-      this.pivotAnim = null;
-      this.controls.target.copy(endTarget);
-      this.controls.update();
-      return;
-    }
-    const startTarget = this.controls.target.clone();
-    const delta = endTarget.clone().sub(startTarget);
-    const startCameraPos = this.camera.position.clone();
-    const endCameraPos = startCameraPos.clone().add(delta);
-
-    // Compute frustum-shift animation so the atom arrives at the cursor
-    // position (screenX, screenY) instead of the inset-shifted visual center.
-    // For orthographic cameras only; ignored for perspective.
-    let startShift = 0;
-    let endShift = 0;
-    let startHalfW = 0;
-    if (
-      this.camera instanceof THREE.OrthographicCamera &&
-      this.container &&
-      screenX !== undefined &&
-      screenY !== undefined
-    ) {
-      const W = this.container.clientWidth;
-      startHalfW = (this.camera.right - this.camera.left) / 2;
-      startShift = -(this.camera.left + this.camera.right) / 2;
-      endShift = ((2 * screenX) / W - 1) * startHalfW;
-      // Store as fraction so doApplyFrustumInsets can maintain the position
-      // after resize / zoom.
-      this.pivotFracX = screenX / W;
-    } else if (this.camera instanceof THREE.OrthographicCamera) {
-      startHalfW = (this.camera.right - this.camera.left) / 2;
-      startShift = -(this.camera.left + this.camera.right) / 2;
-      endShift = startShift; // no frustum change
-    }
-
-    // Translate both controls.target and camera.position by the same delta
-    // so the scene pans smoothly.  Damping is disabled during animation frames
-    // (see render loop) to prevent residual sphericalDelta from adding
-    // unwanted rotation.
-    this.pivotAnim = {
-      startTarget,
-      endTarget,
-      startCameraPos,
-      endCameraPos,
-      startShift,
-      endShift,
-      startHalfW,
-      startTime: performance.now(),
-      duration: MoleculeRenderer.PIVOT_ANIM_DURATION_MS,
-    };
-  }
-
-  /** Cancel any in-progress pivot animation when the user begins interacting. */
-  private attachPivotCancelListener(): void {
-    this.controls.addEventListener("start", () => {
-      this.pivotAnim = null;
-    });
   }
 
   /** Zoom orthographic camera centered on controls.target using mouse wheel.
@@ -695,7 +588,6 @@ export class MoleculeRenderer {
       if (!(this.camera instanceof THREE.OrthographicCamera)) return;
       e.preventDefault();
       e.stopPropagation(); // prevent OrbitControls from also processing this
-      this.pivotAnim = null;
 
       // Normalize deltaY across deltaMode (pixel / line / page)
       let delta = e.deltaY;
@@ -740,15 +632,6 @@ export class MoleculeRenderer {
       this.viewInsetRight,
       this.lastExtent,
     );
-    // If the user set a rotation center by double-clicking, override the
-    // inset-based shift to keep controls.target at the cursor position.
-    if (this.pivotFracX !== null) {
-      const halfW = (this.camera.right - this.camera.left) / 2;
-      const pivotShift = (2 * this.pivotFracX - 1) * halfW;
-      this.camera.left = -halfW - pivotShift;
-      this.camera.right = halfW - pivotShift;
-      this.camera.updateProjectionMatrix();
-    }
   }
 
   /** Switch between orthographic and perspective projection. */
@@ -779,7 +662,6 @@ export class MoleculeRenderer {
     this.controls.zoomSpeed = oldZoomSpeed;
     this.controls.target.copy(target);
     this.controls.update();
-    this.attachPivotCancelListener();
     this.attachWheelZoomListener();
 
     if (this.snapshot) {
@@ -1058,47 +940,7 @@ export class MoleculeRenderer {
       }
     }
 
-    // Tick smooth pivot animation (set by setRotationCenter).
-    // Both controls.target and camera.position are translated by the same
-    // delta so the scene pans (not rotates).  The frustum shift is also
-    // interpolated so the clicked atom arrives at the cursor position rather
-    // than the inset-shifted visual center.  Damping is temporarily disabled
-    // so residual sphericalDelta from prior interaction does not add
-    // unwanted rotation.
-    if (this.pivotAnim) {
-      const t = Math.min(
-        (performance.now() - this.pivotAnim.startTime) / this.pivotAnim.duration,
-        1,
-      );
-      const ease = 1 - Math.pow(1 - t, 3); // ease-out cubic
-      this.controls.target.lerpVectors(this.pivotAnim.startTarget, this.pivotAnim.endTarget, ease);
-      this.camera.position.lerpVectors(
-        this.pivotAnim.startCameraPos,
-        this.pivotAnim.endCameraPos,
-        ease,
-      );
-      // Interpolate the frustum shift so the atom drifts to the cursor pixel.
-      if (this.camera instanceof THREE.OrthographicCamera && this.pivotAnim.startHalfW > 0) {
-        const shiftLerped = THREE.MathUtils.lerp(
-          this.pivotAnim.startShift,
-          this.pivotAnim.endShift,
-          ease,
-        );
-        const hw = this.pivotAnim.startHalfW;
-        this.camera.left = -hw - shiftLerped;
-        this.camera.right = hw - shiftLerped;
-        this.camera.updateProjectionMatrix();
-      }
-      if (t >= 1) this.pivotAnim = null;
-      // Update with damping off so sphericalDelta is zeroed and cannot
-      // override the manually-set camera position.
-      const wasDamping = this.controls.enableDamping;
-      this.controls.enableDamping = false;
-      this.controls.update();
-      this.controls.enableDamping = wasDamping;
-    } else {
-      this.controls.update();
-    }
+    this.controls.update();
 
     // Sync LineMaterial resolution for polyhedron fat edges
     if (this.polyhedronRenderer && this.container) {


### PR DESCRIPTION
## Summary

- Remove the `dblclick` event listener and `handleDblClick` handler from `Viewport.tsx` entirely
- Delete the `setRotationCenter` public method from `MoleculeRenderer.ts`
- Double-clicking an atom now has no effect at all

## Test Plan

- [ ] Double-click an atom — nothing should happen (no rotation center change, no camera shift)
- [ ] Normal orbit/zoom/pan controls still work correctly