### PR TITLE
fix: snap pivot animation to end before zoom or rotation

### DIFF
--- a/src/renderer/MoleculeRenderer.ts
+++ b/src/renderer/MoleculeRenderer.ts
@@ -672,10 +672,26 @@ export class MoleculeRenderer {
     };
   }
 
-  /** Cancel any in-progress pivot animation when the user begins interacting. */
+  /** Immediately snap any in-progress pivot animation to its final state.
+   * Called before zoom or rotation so the interaction always starts from the
+   * atom position rather than an intermediate mid-animation position.
+   */
+  private snapPivotAnimToEnd(): void {
+    if (!this.pivotAnim) return;
+    this.controls.target.copy(this.pivotAnim.endTarget);
+    this.camera.position.copy(this.pivotAnim.endCameraPos);
+    if (this.camera instanceof THREE.OrthographicCamera && this.pivotAnim.startHalfW > 0) {
+      const hw = this.pivotAnim.startHalfW;
+      this.camera.left = -hw - this.pivotAnim.endShift;
+      this.camera.right = hw - this.pivotAnim.endShift;
+      this.camera.updateProjectionMatrix();
+    }
+    this.pivotAnim = null;
+  }
+
   private attachPivotCancelListener(): void {
     this.controls.addEventListener("start", () => {
-      this.pivotAnim = null;
+      this.snapPivotAnimToEnd();
     });
   }
 
@@ -695,7 +711,10 @@ export class MoleculeRenderer {
       if (!(this.camera instanceof THREE.OrthographicCamera)) return;
       e.preventDefault();
       e.stopPropagation(); // prevent OrbitControls from also processing this
-      this.pivotAnim = null;
+
+      // Snap pivot animation to its end state so zoom is always centered on
+      // the clicked atom, not on an intermediate position mid-animation.
+      this.snapPivotAnimToEnd();
 
       // Normalize deltaY across deltaMode (pixel / line / page)
       let delta = e.deltaY;

--- a/src/renderer/MoleculeRenderer.ts
+++ b/src/renderer/MoleculeRenderer.ts
@@ -687,6 +687,14 @@ export class MoleculeRenderer {
       this.camera.updateProjectionMatrix();
     }
     this.pivotAnim = null;
+    // Sync camera world matrices and OrbitControls internal state so that
+    // subsequent project()/unproject() calls and interaction math use the
+    // snapped end pose rather than the mid-animation matrices.
+    this.camera.updateMatrixWorld(true);
+    const wasDamping = this.controls.enableDamping;
+    this.controls.enableDamping = false;
+    this.controls.update();
+    this.controls.enableDamping = wasDamping;
   }
 
   private attachPivotCancelListener(): void {


### PR DESCRIPTION
## Summary

- When the user scrolled the wheel (or started rotating) immediately after double-clicking an atom, the 400 ms pivot animation was canceled mid-flight, leaving `controls.target` at an intermediate world position instead of the clicked atom.
- Subsequent zoom was then centered on that intermediate point rather than the atom, causing the reported bug where zoom did not appear to be centered on the double-clicked atom.
- Introduced `snapPivotAnimToEnd()` which immediately jumps `camera.position`, `controls.target`, and the orthographic frustum shift to their final values before any zoom or rotation interaction starts.
- This guarantees that both zoom and orbit always operate from the atom's exact world position.

## Test plan

- [ ] Double-click an atom, immediately scroll to zoom — verify zoom is centered on the clicked atom
- [ ] Double-click an atom, immediately drag to rotate — verify rotation is around the clicked atom
- [ ] Double-click an atom, wait for animation to finish, then scroll — verify zoom still centered on atom
- [ ] `npm test` passes (274 tests)

https://claude.ai/code/session_01XMS6EpAZHUhD6XcXh3K5VK