### PR TITLE
fix: rotation center tracks atom world coordinates

### DIFF
--- a/src/renderer/MoleculeRenderer.ts
+++ b/src/renderer/MoleculeRenderer.ts
@@ -98,6 +98,9 @@ export class MoleculeRenderer {
   private readonly _panRight = new THREE.Vector3();
   private readonly _panUp = new THREE.Vector3();
   private readonly _panDelta = new THREE.Vector3();
+  // Accumulated screen-space pan offset applied after controls.update() each
+  // frame so controls.target (the rotation center) stays fixed in world space.
+  private readonly _panOffset = new THREE.Vector3();
 
   private wheelZoomHandler: ((e: WheelEvent) => void) | null = null;
 
@@ -618,6 +621,9 @@ export class MoleculeRenderer {
    * The clicked atom is animated to the screen center.
    */
   setRotationCenter(x: number, y: number, z: number, animate = true): void {
+    // Clear any accumulated pan offset so the new rotation center is truly
+    // centered in the viewport after the animation completes.
+    this._panOffset.setScalar(0);
     const endTarget = new THREE.Vector3(x, y, z);
     if (!animate) {
       this.pivotAnim = null;
@@ -766,8 +772,10 @@ export class MoleculeRenderer {
     };
   }
 
-  /** Apply a screen-space pan delta by translating only the camera position,
-   * keeping controls.target (the rotation center) fixed in world space. */
+  /** Translate the camera in its local right/up directions based on a
+   * screen-space pointer delta, while keeping controls.target (the rotation
+   * center) fixed in world space. This approximates a pan near the target but
+   * is not a pure screen-space pan of the entire image. */
   private applyCustomPan(screenDx: number, screenDy: number): void {
     if (!this.container) return;
     const W = this.container.clientWidth;
@@ -783,8 +791,7 @@ export class MoleculeRenderer {
       const worldDx = -screenDx * (frustumW / W);
       const worldDy = screenDy * (frustumH / H);
       const delta = this._panDelta.copy(right).multiplyScalar(worldDx).addScaledVector(up, worldDy);
-      this.camera.position.add(delta);
-      this.camera.updateMatrixWorld(true);
+      this._panOffset.add(delta);
     } else if (this.camera instanceof THREE.PerspectiveCamera) {
       const distance = this.camera.position.distanceTo(this.controls.target);
       const vFov = (this.camera.fov * Math.PI) / 180;
@@ -794,8 +801,7 @@ export class MoleculeRenderer {
         .copy(right)
         .multiplyScalar(-screenDx * (worldW / W))
         .addScaledVector(up, screenDy * (worldH / H));
-      this.camera.position.add(delta);
-      this.camera.updateMatrixWorld(true);
+      this._panOffset.add(delta);
     }
   }
 
@@ -887,7 +893,10 @@ export class MoleculeRenderer {
    * Used for image/video capture outside the rAF loop.
    */
   renderSingleFrame(): void {
+    this.camera.position.sub(this._panOffset);
     this.controls.update();
+    this.camera.position.add(this._panOffset);
+    this.camera.updateMatrixWorld(true);
 
     if (this.polyhedronRenderer && this.container) {
       const sz = new THREE.Vector2();
@@ -1153,7 +1162,13 @@ export class MoleculeRenderer {
       this.controls.update();
       this.controls.enableDamping = wasDamping;
     } else {
+      // Remove panOffset before update so OrbitControls sees the canonical
+      // camera position; re-apply after so the view is offset without
+      // disturbing the internal spherical state or controls.target.
+      this.camera.position.sub(this._panOffset);
       this.controls.update();
+      this.camera.position.add(this._panOffset);
+      this.camera.updateMatrixWorld(true);
     }
 
     // Update pivot marker position and scale

--- a/src/renderer/MoleculeRenderer.ts
+++ b/src/renderer/MoleculeRenderer.ts
@@ -708,7 +708,6 @@ export class MoleculeRenderer {
       const desiredWorld = ndcBefore.clone().unproject(this.camera);
       const shift = desiredWorld.sub(targetWorld);
       this.camera.position.add(shift);
-      this.controls.target.add(shift);
       this.controls.update();
     };
     el.addEventListener("wheel", this.wheelZoomHandler, { capture: true, passive: false });
@@ -767,8 +766,8 @@ export class MoleculeRenderer {
     };
   }
 
-  /** Apply a screen-space pan delta, translating both camera and target together
-   * so the rotation center follows the screen center. */
+  /** Apply a screen-space pan delta by translating only the camera position,
+   * keeping controls.target (the rotation center) fixed in world space. */
   private applyCustomPan(screenDx: number, screenDy: number): void {
     if (!this.container) return;
     const W = this.container.clientWidth;
@@ -785,7 +784,6 @@ export class MoleculeRenderer {
       const worldDy = screenDy * (frustumH / H);
       const delta = this._panDelta.copy(right).multiplyScalar(worldDx).addScaledVector(up, worldDy);
       this.camera.position.add(delta);
-      this.controls.target.add(delta);
       this.camera.updateMatrixWorld(true);
     } else if (this.camera instanceof THREE.PerspectiveCamera) {
       const distance = this.camera.position.distanceTo(this.controls.target);
@@ -797,7 +795,6 @@ export class MoleculeRenderer {
         .multiplyScalar(-screenDx * (worldW / W))
         .addScaledVector(up, screenDy * (worldH / H));
       this.camera.position.add(delta);
-      this.controls.target.add(delta);
       this.camera.updateMatrixWorld(true);
     }
   }


### PR DESCRIPTION
## Summary

- **Rotation center follows atom world position**: Double-clicking an atom sets `controls.target` to the atom's 3D world coordinates. That position is now preserved as the permanent rotation/zoom pivot — panning and zooming no longer reset it.
- **Pan moves camera only**: `applyCustomPan` now translates only `camera.position`, leaving `controls.target` (the rotation center) fixed in world space.
- **Zoom centered on rotation center**: `attachWheelZoomListener` no longer shifts `controls.target` — camera position compensates to keep the rotation center at the same screen position during zoom.
- **Code cleanup**: Reuse temp `Vector3` fields (`_panRight`, `_panUp`, `_panDelta`) to avoid per-frame allocations; stale comments updated.

## Test plan

- [ ] Load a structure and double-click an atom — it smoothly centers on screen and becomes the rotation pivot
- [ ] Right-drag to pan — atom moves off-screen; rotating still orbits around the atom (not screen center)
- [ ] Zoom with mouse wheel — zooms toward the atom (not screen center)
- [ ] Double-click another atom — new pivot set, centers on screen
- [ ] Reset view — structure re-centers correctly
- [ ] TypeScript unit tests pass: `npm test`
- [ ] Full build succeeds: `npm run build`

https://claude.ai/code/session_01YCKuwWCLzp2QfLWeed3wVY