### PR TITLE
feat: add PipelineViewer component for MDX/docs embedding

### DIFF
--- a/docs/guide/web.md
+++ b/docs/guide/web.md
@@ -101,6 +101,222 @@ See the [TypeScript API Reference](/api/typescript/) for the complete interface.
 
 ---
 
+## PipelineViewer (Docs / MDX Embed)
+
+`PipelineViewer` is a self-contained React component designed for embedding molecular visualizations in documentation, blog posts, and MDX pages. Unlike `MeganeViewer`, it has **no dependency on global stores** — multiple instances on the same page are fully independent and each manages its own playback state.
+
+### Key differences from `MeganeViewer`
+
+| Feature | `MeganeViewer` | `PipelineViewer` |
+|---------|---------------|-----------------|
+| UI panels (sidebar, appearance) | Yes | No |
+| Pipeline-driven rendering | No | Yes |
+| Multiple instances per page | Conflicts | Fully independent |
+| File loading | Upload / drag-drop | URL fetch via `fileUrl` |
+| Trajectory playback | Yes | Yes (Timeline shown automatically) |
+
+### Installation
+
+```bash
+npm install megane-viewer
+```
+
+### Usage
+
+```tsx
+import { PipelineViewer } from "megane-viewer";
+
+<PipelineViewer
+  width="100%"
+  height={500}
+  pipeline={{
+    version: 3,
+    nodes: [
+      {
+        id: "s1",
+        type: "load_structure",
+        fileName: "caffeine_water.pdb",
+        fileUrl: "/structures/caffeine_water.pdb",
+        hasTrajectory: false,
+        hasCell: false,
+        position: { x: 0, y: 0 },
+      },
+      {
+        id: "b1",
+        type: "add_bond",
+        bondSource: "distance",
+        position: { x: 200, y: 0 },
+      },
+      {
+        id: "v1",
+        type: "viewport",
+        perspective: false,
+        cellAxesVisible: true,
+        pivotMarkerVisible: true,
+        position: { x: 400, y: 0 },
+      },
+    ],
+    edges: [
+      { source: "s1", target: "b1", sourceHandle: "particle", targetHandle: "particle" },
+      { source: "s1", target: "v1", sourceHandle: "particle", targetHandle: "particle" },
+      { source: "b1", target: "v1", sourceHandle: "bond",     targetHandle: "bond" },
+    ],
+  }}
+/>
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `pipeline` | `SerializedPipeline` | *(required)* | Pipeline JSON describing the node graph |
+| `width` | `string \| number` | `"100%"` | Component width |
+| `height` | `string \| number` | `500` | Component height in pixels |
+
+### `SerializedPipeline` format
+
+```ts
+interface SerializedPipeline {
+  version: 3;
+  nodes: Array<NodeParams & { id: string; position: { x: number; y: number } }>;
+  edges: Array<{
+    source: string;
+    target: string;
+    sourceHandle: string;
+    targetHandle: string;
+  }>;
+}
+```
+
+Each node's `type` field determines which parameters are required. See [Node Reference](/guide/pipeline#node-reference) for the full list.
+
+#### `load_structure` node — the `fileUrl` field
+
+`PipelineViewer` cannot use a local file picker, so `load_structure` nodes need a `fileUrl` field pointing to a URL where the structure file can be fetched:
+
+```ts
+{
+  id: "s1",
+  type: "load_structure",
+  fileName: "protein.pdb",        // displayed name (optional, inferred from URL)
+  fileUrl: "/structures/protein.pdb",  // fetched at render time
+  hasTrajectory: false,
+  hasCell: false,
+  position: { x: 0, y: 0 },
+}
+```
+
+The component fetches all `fileUrl` values in parallel at mount time using the browser's `fetch()` API, then parses them with the WASM parser.
+
+### Trajectory playback
+
+When the pipeline produces a trajectory (from an XTC or `.traj` file embedded in the structure), `PipelineViewer` automatically shows the Timeline bar at the bottom. Files with built-in frames (e.g. XYZ files with multiple frames) are also supported.
+
+```tsx
+<PipelineViewer
+  height={500}
+  pipeline={{
+    version: 3,
+    nodes: [
+      {
+        id: "s1",
+        type: "load_structure",
+        fileName: "caffeine_water.pdb",
+        fileUrl: "/structures/caffeine_water.pdb",
+        hasTrajectory: false,
+        hasCell: false,
+        position: { x: 0, y: 0 },
+      },
+      {
+        id: "t1",
+        type: "load_trajectory",
+        fileName: "caffeine_water_vibration.xtc",
+        fileUrl: "/structures/caffeine_water_vibration.xtc",
+        position: { x: 0, y: 150 },
+      },
+      {
+        id: "v1",
+        type: "viewport",
+        perspective: false,
+        cellAxesVisible: false,
+        pivotMarkerVisible: true,
+        position: { x: 300, y: 0 },
+      },
+    ],
+    edges: [
+      { source: "s1", target: "t1", sourceHandle: "particle",   targetHandle: "particle" },
+      { source: "s1", target: "v1", sourceHandle: "particle",   targetHandle: "particle" },
+      { source: "t1", target: "v1", sourceHandle: "trajectory", targetHandle: "trajectory" },
+    ],
+  }}
+/>
+```
+
+### Usage in MDX (Next.js / VitePress)
+
+`PipelineViewer` works in any MDX-based framework. Import it directly in your `.mdx` file:
+
+```mdx
+import { PipelineViewer } from "megane-viewer";
+
+# Caffeine in Water
+
+<PipelineViewer
+  height={480}
+  pipeline={{
+    version: 3,
+    nodes: [
+      { id: "s1", type: "load_structure", fileName: "caffeine_water.pdb",
+        fileUrl: "/structures/caffeine_water.pdb",
+        hasTrajectory: false, hasCell: false, position: { x: 0, y: 0 } },
+      { id: "b1", type: "add_bond", bondSource: "distance", position: { x: 200, y: 0 } },
+      { id: "v1", type: "viewport", perspective: false, cellAxesVisible: false,
+        pivotMarkerVisible: true, position: { x: 400, y: 0 } },
+    ],
+    edges: [
+      { source: "s1", target: "b1", sourceHandle: "particle", targetHandle: "particle" },
+      { source: "s1", target: "v1", sourceHandle: "particle", targetHandle: "particle" },
+      { source: "b1", target: "v1", sourceHandle: "bond",     targetHandle: "bond" },
+    ],
+  }}
+/>
+```
+
+For Next.js you also need WASM support in `next.config.mjs`:
+
+```js
+const nextConfig = {
+  webpack: (config) => {
+    config.experiments = { ...config.experiments, asyncWebAssembly: true };
+    return config;
+  },
+};
+export default nextConfig;
+```
+
+### Using a saved pipeline JSON
+
+You can serialize a pipeline from the megane UI (Pipeline editor → Export) and load it directly:
+
+```tsx
+import pipelineJson from "./my-pipeline.json";
+import { PipelineViewer } from "megane-viewer";
+
+// Add fileUrl to each load_structure node before rendering
+const pipeline = {
+  ...pipelineJson,
+  nodes: pipelineJson.nodes.map((n) =>
+    n.type === "load_structure"
+      ? { ...n, fileUrl: `/structures/${n.fileName}` }
+      : n,
+  ),
+};
+
+<PipelineViewer pipeline={pipeline} height={500} />
+```
+
+---
+
 ## Individual Components
 
 For custom layouts, megane exports each panel as a separate component. This gives you full control over placement and behavior.

--- a/docs/guide/web.md
+++ b/docs/guide/web.md
@@ -210,7 +210,7 @@ The component fetches all `fileUrl` values in parallel at mount time using the b
 
 ### Trajectory playback
 
-When the pipeline produces a trajectory (from an XTC or `.traj` file embedded in the structure), `PipelineViewer` automatically shows the Timeline bar at the bottom. Files with built-in frames (e.g. XYZ files with multiple frames) are also supported.
+When the pipeline includes time-dependent data — by loading a multi-frame structure file (such as a multi-frame XYZ or ASE `.traj`) — `PipelineViewer` automatically shows the Timeline bar at the bottom.
 
 ```tsx
 <PipelineViewer
@@ -221,18 +221,11 @@ When the pipeline produces a trajectory (from an XTC or `.traj` file embedded in
       {
         id: "s1",
         type: "load_structure",
-        fileName: "caffeine_water.pdb",
-        fileUrl: "/structures/caffeine_water.pdb",
-        hasTrajectory: false,
+        fileName: "simulation.traj",
+        fileUrl: "/structures/simulation.traj",
+        hasTrajectory: true,
         hasCell: false,
         position: { x: 0, y: 0 },
-      },
-      {
-        id: "t1",
-        type: "load_trajectory",
-        fileName: "caffeine_water_vibration.xtc",
-        fileUrl: "/structures/caffeine_water_vibration.xtc",
-        position: { x: 0, y: 150 },
       },
       {
         id: "v1",
@@ -244,13 +237,14 @@ When the pipeline produces a trajectory (from an XTC or `.traj` file embedded in
       },
     ],
     edges: [
-      { source: "s1", target: "t1", sourceHandle: "particle",   targetHandle: "particle" },
       { source: "s1", target: "v1", sourceHandle: "particle",   targetHandle: "particle" },
-      { source: "t1", target: "v1", sourceHandle: "trajectory", targetHandle: "trajectory" },
+      { source: "s1", target: "v1", sourceHandle: "trajectory", targetHandle: "trajectory" },
     ],
   }}
 />
 ```
+
+> **Note:** `PipelineViewer` does not currently support `load_trajectory` nodes. Trajectories must be embedded in the structure file (e.g. ASE `.traj`, multi-frame XYZ). External XTC trajectories require a `MeganeViewer` with a server-side pipeline.
 
 ### Usage in MDX (Next.js / VitePress)
 

--- a/src/components/PipelineViewer.tsx
+++ b/src/components/PipelineViewer.tsx
@@ -233,8 +233,7 @@ export function PipelineViewer({ pipeline, width = "100%", height = 500 }: Pipel
     const renderer = rendererRef.current;
     if (!renderer) return;
     const hasDistanceBond = nodes.some(
-      (n) =>
-        n.type === "add_bond" && (n.data.params as AddBondParams).bondSource === "distance",
+      (n) => n.type === "add_bond" && (n.data.params as AddBondParams).bondSource === "distance",
     );
     if (!hasDistanceBond) return;
 

--- a/src/components/PipelineViewer.tsx
+++ b/src/components/PipelineViewer.tsx
@@ -36,14 +36,17 @@ import { MoleculeRenderer } from "../renderer/MoleculeRenderer";
 import { useAtomSelection } from "../hooks/useAtomSelection";
 import { deserializePipeline } from "../pipeline/serialize";
 import { executePipeline } from "../pipeline/execute";
-import { applyViewportState } from "../pipeline/apply";
+import { applyViewportState, applyVectorsForFrame } from "../pipeline/apply";
 import { parseStructureFile } from "../parsers/structure";
+import { inferBondsVdwJS } from "../parsers/inferBondsJS";
+import { processPbcBonds } from "../pipeline/executors/addBond";
 import type { PipelineNodeData, NodeSnapshotData } from "../pipeline/execute";
 import type {
   SerializedPipeline,
   ViewportState,
   LoadStructureParams,
   FrameProvider,
+  AddBondParams,
 } from "../pipeline/types";
 import { DEFAULT_VIEWPORT_STATE } from "../pipeline/types";
 import type { Snapshot, Frame, HoverInfo } from "../types";
@@ -103,16 +106,27 @@ export function PipelineViewer({ pipeline, width = "100%", height = 500 }: Pipel
 
   // ─── Initialization: fetch files + parse + execute pipeline ──────
 
-  const pipelineRef = useRef(pipeline);
-
   useEffect(() => {
-    let cancelled = false;
+    const abortController = new AbortController();
+    const { signal } = abortController;
+
+    // Reset state for each pipeline prop change
+    setStatus("loading");
+    setErrorMessage(null);
+    setNodes([]);
+    setEdges([]);
+    setViewportState(DEFAULT_VIEWPORT_STATE);
+    setPrimarySnapshot(null);
+    setProvider(null);
+    setTotalFrames(0);
+    currentFrameRef.current = 0;
+    setCurrentFrame(0);
+    setCurrentFrameData(null);
 
     async function init() {
       try {
-        const { nodes: deserializedNodes, edges: deserializedEdges } = deserializePipeline(
-          pipelineRef.current,
-        );
+        const { nodes: deserializedNodes, edges: deserializedEdges } =
+          deserializePipeline(pipeline);
 
         // Find load_structure nodes with fileUrl
         const loadNodes = deserializedNodes.filter(
@@ -127,7 +141,7 @@ export function PipelineViewer({ pipeline, width = "100%", height = 500 }: Pipel
             const url = params.fileUrl!;
             const fileName = params.fileName ?? basenameFromUrl(url);
 
-            const response = await fetch(url);
+            const response = await fetch(url, { signal });
             if (!response.ok) {
               throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
             }
@@ -144,7 +158,7 @@ export function PipelineViewer({ pipeline, width = "100%", height = 500 }: Pipel
           }),
         );
 
-        if (cancelled) return;
+        if (signal.aborted) return;
 
         // Execute pipeline with parsed snapshots
         const { viewportState: vs } = executePipeline(deserializedNodes, deserializedEdges, {
@@ -171,7 +185,7 @@ export function PipelineViewer({ pipeline, width = "100%", height = 500 }: Pipel
         setCurrentFrameData(frame0);
         setStatus("ready");
       } catch (err) {
-        if (cancelled) return;
+        if (signal.aborted) return;
         setErrorMessage(err instanceof Error ? err.message : String(err));
         setStatus("error");
       }
@@ -180,10 +194,9 @@ export function PipelineViewer({ pipeline, width = "100%", height = 500 }: Pipel
     init();
 
     return () => {
-      cancelled = true;
+      abortController.abort();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [pipeline]);
 
   // ─── Apply viewportState to renderer when ready ──────────────────
 
@@ -202,6 +215,52 @@ export function PipelineViewer({ pipeline, width = "100%", height = 500 }: Pipel
     applyViewportState(renderer, viewportState, prevViewportStateRef.current);
     prevViewportStateRef.current = viewportState;
   }, [viewportState]);
+
+  // ─── Per-frame vector update ─────────────────────────────────────
+
+  useEffect(() => {
+    const renderer = rendererRef.current;
+    if (!renderer) return;
+    if (viewportState.vectors.length > 0) {
+      applyVectorsForFrame(renderer, viewportState.vectors, currentFrame);
+    }
+  }, [currentFrame, viewportState.vectors]);
+
+  // ─── Per-frame bond recalculation (distance mode) ────────────────
+
+  useEffect(() => {
+    if (!currentFrameData || !primarySnapshot) return;
+    const renderer = rendererRef.current;
+    if (!renderer) return;
+    const hasDistanceBond = nodes.some(
+      (n) =>
+        n.type === "add_bond" && (n.data.params as AddBondParams).bondSource === "distance",
+    );
+    if (!hasDistanceBond) return;
+
+    const newBonds = inferBondsVdwJS(
+      currentFrameData.positions,
+      primarySnapshot.elements,
+      primarySnapshot.nAtoms,
+      0.6,
+      primarySnapshot.box,
+    );
+    const result = processPbcBonds(
+      newBonds,
+      null,
+      currentFrameData.positions,
+      primarySnapshot.elements,
+      primarySnapshot.nAtoms,
+      primarySnapshot.box,
+    );
+    renderer.updateBondsExt(
+      result.bondIndices,
+      result.bondOrders,
+      result.positions,
+      result.elements,
+      result.nAtoms,
+    );
+  }, [currentFrameData, primarySnapshot, nodes]);
 
   // ─── Playback ────────────────────────────────────────────────────
 

--- a/src/components/PipelineViewer.tsx
+++ b/src/components/PipelineViewer.tsx
@@ -1,0 +1,345 @@
+/**
+ * Self-contained pipeline viewer for embedding in MDX, docs, and other contexts.
+ * Accepts a SerializedPipeline JSON as a prop, fetches structure files via fileUrl,
+ * and renders Viewport + Timeline with full trajectory playback support.
+ *
+ * Unlike MeganeViewer and WidgetViewer, this component uses NO global stores
+ * (no usePipelineStore, no usePlaybackStore), so multiple instances on the same
+ * page are fully independent.
+ *
+ * Usage:
+ *   <PipelineViewer
+ *     width="100%"
+ *     height={500}
+ *     pipeline={{
+ *       version: 3,
+ *       nodes: [
+ *         { id: "s1", type: "load_structure", fileName: "protein.pdb",
+ *           fileUrl: "/structures/protein.pdb",
+ *           hasTrajectory: false, hasCell: false, position: { x: 0, y: 0 } },
+ *         { id: "v1", type: "viewport", perspective: false,
+ *           cellAxesVisible: true, pivotMarkerVisible: true, position: { x: 0, y: 200 } }
+ *       ],
+ *       edges: [
+ *         { source: "s1", target: "v1", sourceHandle: "particle", targetHandle: "particle" }
+ *       ]
+ *     }}
+ *   />
+ */
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import type { Node, Edge } from "@xyflow/react";
+import { Viewport } from "./Viewport";
+import { Timeline } from "./Timeline";
+import { Tooltip } from "./Tooltip";
+import { MoleculeRenderer } from "../renderer/MoleculeRenderer";
+import { useAtomSelection } from "../hooks/useAtomSelection";
+import { deserializePipeline } from "../pipeline/serialize";
+import { executePipeline } from "../pipeline/execute";
+import { applyViewportState } from "../pipeline/apply";
+import { parseStructureFile } from "../parsers/structure";
+import type { PipelineNodeData, NodeSnapshotData } from "../pipeline/execute";
+import type {
+  SerializedPipeline,
+  ViewportState,
+  LoadStructureParams,
+  FrameProvider,
+} from "../pipeline/types";
+import { DEFAULT_VIEWPORT_STATE } from "../pipeline/types";
+import type { Snapshot, Frame, HoverInfo } from "../types";
+
+interface PipelineViewerProps {
+  pipeline: SerializedPipeline;
+  width?: string | number;
+  height?: string | number;
+}
+
+type LoadStatus = "loading" | "ready" | "error";
+
+/** Extract the file name from a URL path (last path segment). */
+function basenameFromUrl(url: string): string {
+  try {
+    const pathname = new URL(url, globalThis.location?.href ?? "http://localhost").pathname;
+    return pathname.split("/").pop() ?? "file.bin";
+  } catch {
+    return url.split("/").pop() ?? "file.bin";
+  }
+}
+
+export function PipelineViewer({ pipeline, width = "100%", height = 500 }: PipelineViewerProps) {
+  const [status, setStatus] = useState<LoadStatus>("loading");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // Pipeline execution results
+  const [nodes, setNodes] = useState<Node<PipelineNodeData>[]>([]);
+  const [edges, setEdges] = useState<Edge[]>([]);
+  const [viewportState, setViewportState] = useState<ViewportState>(DEFAULT_VIEWPORT_STATE);
+  const [primarySnapshot, setPrimarySnapshot] = useState<Snapshot | null>(null);
+
+  // Trajectory playback (local state — no global store)
+  const [provider, setProvider] = useState<FrameProvider | null>(null);
+  const [totalFrames, setTotalFrames] = useState(0);
+  const [currentFrame, setCurrentFrame] = useState(0);
+  const [currentFrameData, setCurrentFrameData] = useState<Frame | null>(null);
+  const [playing, setPlaying] = useState(false);
+  const [fps, setFpsState] = useState(30);
+
+  // Refs for setInterval (avoids stale closure)
+  const rendererRef = useRef<MoleculeRenderer | null>(null);
+  const prevViewportStateRef = useRef<ViewportState | null>(null);
+  const playIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const currentFrameRef = useRef(0);
+  const providerRef = useRef<FrameProvider | null>(null);
+  const totalFramesRef = useRef(0);
+  const fpsRef = useRef(30);
+  const [hoverInfo, setHoverInfo] = useState<HoverInfo | null>(null);
+
+  // Keep refs in sync
+  providerRef.current = provider;
+  totalFramesRef.current = totalFrames;
+  fpsRef.current = fps;
+
+  const { handleAtomRightClick, handleFrameUpdated } = useAtomSelection(rendererRef);
+
+  // ─── Initialization: fetch files + parse + execute pipeline ──────
+
+  const pipelineRef = useRef(pipeline);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function init() {
+      try {
+        const { nodes: deserializedNodes, edges: deserializedEdges } = deserializePipeline(
+          pipelineRef.current,
+        );
+
+        // Find load_structure nodes with fileUrl
+        const loadNodes = deserializedNodes.filter(
+          (n) => n.type === "load_structure" && (n.data.params as LoadStructureParams).fileUrl,
+        );
+
+        // Fetch and parse all structure files in parallel
+        const nodeSnapshots: Record<string, NodeSnapshotData> = {};
+        await Promise.all(
+          loadNodes.map(async (node) => {
+            const params = node.data.params as LoadStructureParams;
+            const url = params.fileUrl!;
+            const fileName = params.fileName ?? basenameFromUrl(url);
+
+            const response = await fetch(url);
+            if (!response.ok) {
+              throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+            }
+            const blob = await response.blob();
+            const file = new File([blob], fileName);
+            const result = await parseStructureFile(file);
+
+            nodeSnapshots[node.id] = {
+              snapshot: result.snapshot,
+              frames: result.frames.length > 0 ? result.frames : null,
+              meta: result.meta,
+              labels: result.labels,
+            };
+          }),
+        );
+
+        if (cancelled) return;
+
+        // Execute pipeline with parsed snapshots
+        const { viewportState: vs } = executePipeline(deserializedNodes, deserializedEdges, {
+          nodeSnapshots,
+        });
+
+        // Extract primary snapshot for Viewport
+        const snap = vs.particles[0]?.source ?? null;
+
+        // Extract trajectory provider
+        const traj = vs.trajectories[0] ?? null;
+        const prov = traj?.provider ?? null;
+        const frames = prov ? prov.meta.nFrames : 0;
+        const frame0 = prov ? prov.getFrame(0) : null;
+
+        setNodes(deserializedNodes);
+        setEdges(deserializedEdges);
+        setViewportState(vs);
+        setPrimarySnapshot(snap);
+        setProvider(prov);
+        setTotalFrames(frames);
+        currentFrameRef.current = 0;
+        setCurrentFrame(0);
+        setCurrentFrameData(frame0);
+        setStatus("ready");
+      } catch (err) {
+        if (cancelled) return;
+        setErrorMessage(err instanceof Error ? err.message : String(err));
+        setStatus("error");
+      }
+    }
+
+    init();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ─── Apply viewportState to renderer when ready ──────────────────
+
+  const handleRendererReady = useCallback(
+    (renderer: MoleculeRenderer) => {
+      rendererRef.current = renderer;
+      applyViewportState(renderer, viewportState, null);
+      prevViewportStateRef.current = viewportState;
+    },
+    [viewportState],
+  );
+
+  useEffect(() => {
+    const renderer = rendererRef.current;
+    if (!renderer) return;
+    applyViewportState(renderer, viewportState, prevViewportStateRef.current);
+    prevViewportStateRef.current = viewportState;
+  }, [viewportState]);
+
+  // ─── Playback ────────────────────────────────────────────────────
+
+  const startInterval = useCallback(() => {
+    if (playIntervalRef.current !== null) return;
+    playIntervalRef.current = setInterval(() => {
+      const prov = providerRef.current;
+      const total = totalFramesRef.current;
+      if (!prov || total <= 1) return;
+      const next = (currentFrameRef.current + 1) % total;
+      const frame = prov.getFrame(next);
+      currentFrameRef.current = next;
+      setCurrentFrame(next);
+      setCurrentFrameData(frame);
+    }, 1000 / fpsRef.current);
+  }, []);
+
+  const stopInterval = useCallback(() => {
+    if (playIntervalRef.current !== null) {
+      clearInterval(playIntervalRef.current);
+      playIntervalRef.current = null;
+    }
+  }, []);
+
+  const handleSeek = useCallback(
+    (index: number) => {
+      const prov = providerRef.current;
+      if (!prov) return;
+      if (playing) {
+        stopInterval();
+        setPlaying(false);
+      }
+      const frame = prov.getFrame(index);
+      currentFrameRef.current = index;
+      setCurrentFrame(index);
+      setCurrentFrameData(frame);
+    },
+    [playing, stopInterval],
+  );
+
+  const handlePlayPause = useCallback(() => {
+    if (playing) {
+      stopInterval();
+      setPlaying(false);
+    } else {
+      setPlaying(true);
+      startInterval();
+    }
+  }, [playing, startInterval, stopInterval]);
+
+  const handleFpsChange = useCallback(
+    (newFps: number) => {
+      setFpsState(newFps);
+      fpsRef.current = newFps;
+      if (playing) {
+        stopInterval();
+        startInterval();
+      }
+    },
+    [playing, startInterval, stopInterval],
+  );
+
+  // Cleanup interval on unmount
+  useEffect(() => {
+    return () => {
+      stopInterval();
+    };
+  }, [stopInterval]);
+
+  // ─── Render ──────────────────────────────────────────────────────
+
+  const containerStyle: React.CSSProperties = {
+    width,
+    height,
+    position: "relative",
+    overflow: "hidden",
+    background: "#ffffff",
+    borderRadius: 8,
+  };
+
+  if (status === "loading") {
+    return (
+      <div
+        style={{
+          ...containerStyle,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "#94a3b8",
+          fontSize: 16,
+        }}
+      >
+        Loading…
+      </div>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <div
+        style={{
+          ...containerStyle,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "#ef4444",
+          fontSize: 14,
+          padding: 16,
+          textAlign: "center",
+        }}
+      >
+        {errorMessage ?? "Failed to load pipeline"}
+      </div>
+    );
+  }
+
+  return (
+    <div style={containerStyle}>
+      <Viewport
+        snapshot={primarySnapshot}
+        frame={currentFrameData}
+        onRendererReady={handleRendererReady}
+        onHover={setHoverInfo}
+        onAtomRightClick={handleAtomRightClick}
+        onFrameUpdated={handleFrameUpdated}
+      />
+      {totalFrames > 1 && (
+        <Timeline
+          currentFrame={currentFrame}
+          totalFrames={totalFrames}
+          playing={playing}
+          fps={fps}
+          onSeek={handleSeek}
+          onPlayPause={handlePlayPause}
+          onFpsChange={handleFpsChange}
+        />
+      )}
+      <Tooltip info={hoverInfo} />
+    </div>
+  );
+}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -5,6 +5,7 @@
 
 // React components
 export { MeganeViewer } from "./components/MeganeViewer";
+export { PipelineViewer } from "./components/PipelineViewer";
 export { Viewport } from "./components/Viewport";
 export { Sidebar } from "./components/Sidebar";
 export { Timeline } from "./components/Timeline";

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -309,6 +309,8 @@ export const GENERIC_NODE_ACCEPTS: Record<string, PipelineDataType[]> = {
 export interface LoadStructureParams {
   type: "load_structure";
   fileName: string | null;
+  /** URL for PipelineViewer to fetch (relative or absolute). Not used by the execution engine. */
+  fileUrl?: string;
   /** Which output ports have data (determined by the loaded file). */
   hasTrajectory: boolean;
   hasCell: boolean;


### PR DESCRIPTION
## Summary

- Add `PipelineViewer` component that accepts a `SerializedPipeline` JSON prop and renders Viewport + Timeline, with no dependency on global stores
- Add optional `fileUrl` field to `LoadStructureParams` so `PipelineViewer` can fetch structure files from relative/absolute URLs at mount time
- Export `PipelineViewer` from `src/lib.ts`

## Motivation

Users want to embed pre-configured molecular visualizations in MDX/docs pages without writing complex code. The existing `MeganeViewer` uses a global Zustand singleton (`usePipelineStore`), which conflicts when multiple instances appear on the same page. `PipelineViewer` is fully self-contained — each instance manages its own state independently.

## Design

- On mount, `PipelineViewer` calls `deserializePipeline()` then fetches each `load_structure` node's `fileUrl` via `fetch()`, parses with the existing WASM `parseStructureFile()`, and runs `executePipeline()` directly
- Trajectory playback uses local `useState`/`useRef` (mirrors `usePlaybackStore` pattern but scoped per instance)
- Renders `<Viewport>` + `<Timeline>` (when `totalFrames > 1`) + `<Tooltip>`

## Usage

```tsx
<PipelineViewer
  width="100%"
  height={500}
  pipeline={{
    version: 3,
    nodes: [
      { id: "s1", type: "load_structure", fileName: "protein.pdb",
        fileUrl: "/structures/protein.pdb",
        hasTrajectory: false, hasCell: false, position: { x: 0, y: 0 } },
      { id: "v1", type: "viewport", perspective: false,
        cellAxesVisible: true, pivotMarkerVisible: true, position: { x: 0, y: 200 } }
    ],
    edges: [
      { source: "s1", target: "v1", sourceHandle: "particle", targetHandle: "particle" }
    ]
  }}
/>
```

## Test plan

- [x] `npm test` — 274 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run build:lib` — build succeeds
- [ ] Manual: embed `PipelineViewer` with a real structure URL and verify it renders
- [ ] Manual: embed two instances on the same page and verify they are independent
- [ ] Manual: embed with a trajectory file and verify Timeline appears and playback works

https://claude.ai/code/session_01D4gPAsSCgzBKZJAJ6ucT58