### PR TITLE
docs: document bond_query, pivotMarkerVisible, and enabled in pipeline/web docs

### DIFF
--- a/docs/guide/pipeline.md
+++ b/docs/guide/pipeline.md
@@ -112,9 +112,12 @@ Requires a connection from a LoadStructure node. Frames are loaded lazily when `
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| Query | string | `""` (all) | Selection query expression (see [Filter DSL](#filter-dsl)) |
+| Query | string | `""` (all) | Atom selection query expression (see [Filter DSL](#filter-dsl)) |
+| Bond query | string | `""` (all) | Bond selection query expression (see [Bond Selection DSL](#bond-selection-dsl)) |
 
-The input field validates your query in real time — invalid syntax is highlighted in red.
+Both input fields validate your query in real time — invalid syntax is highlighted in red.
+
+The **Query** field filters which atoms pass through (particle output). The **Bond query** field filters which bonds are selected for the downstream Modify node to apply per-bond opacity overrides — it does not remove bonds from the scene.
 
 ### Modify
 
@@ -155,6 +158,7 @@ The input field validates your query in real time — invalid syntax is highligh
 |-----------|---------|-------------|
 | Perspective | off | Toggle perspective / orthographic projection |
 | Cell axes visible | on | Show simulation cell axes with labels |
+| Pivot marker visible | on | Show the rotation pivot marker at the camera target |
 
 A **Render Export** button is available in the pipeline editor toolbar. Click it to export the current viewport as a PNG image (or other formats such as EPS, GIF, and MP4 via the render modal).
 
@@ -209,6 +213,44 @@ element == "O" or element == "N"       # Oxygen or nitrogen
 (x > 0 and x < 10) and element == "C" # Carbons in x range
 mass > 32                              # Atoms heavier than sulfur
 ```
+
+## Bond Selection DSL
+
+The **Bond query** field in the Filter node accepts expressions to select bonds.
+
+### Available Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `bond_index` | number | 0-based sequential bond index |
+| `atom_index` | number | Atom endpoint index |
+| `element` | string | Element symbol of an atom endpoint (e.g., `"C"`, `"O"`) |
+
+### Operators
+
+`==`, `!=`, `>`, `<`, `>=`, `<=`
+
+### Logical Operators
+
+`and`, `or`, `not`, parentheses `()`
+
+### Special Keywords
+
+- `all` — select all bonds (default when query is empty)
+- `none` — select no bonds
+- `both` — prefix on a comparison to require **both** atoms satisfy it (default: either atom, OR semantics)
+
+### Examples
+
+```
+element == "C"                         # Bonds where either atom is carbon
+both element != "H"                    # Bonds where neither atom is hydrogen
+atom_index >= 24                       # Bonds involving atom 24 or higher
+bond_index < 10                        # First 10 bonds only
+both atom_index >= 0 and bond_index < 50  # First 50 bonds (all-atom filter)
+```
+
+The bond query selects which bonds a downstream **Modify** node applies opacity overrides to. This lets you selectively fade specific bonds without removing them from the scene.
 
 ## Example: TiO₆ Octahedra in SrTiO₃
 
@@ -271,7 +313,9 @@ Each layer is processed independently through its own chain of Filter, Modify, a
 
 ## Serialization
 
-Pipelines serialize to JSON (v3 format) and can be saved, loaded, and version-controlled. The serialization format includes node types, parameters, positions, and edge connections.
+Pipelines serialize to JSON (v3 format) and can be saved, loaded, and version-controlled. The serialization format includes node types, parameters, positions, edge connections, and an optional `enabled` flag per node.
+
+Each node entry can include `"enabled": false` to bypass that node (equivalent to deleting it from the execution graph while keeping it in the editor). Omitting `enabled` or setting it to `true` is the default active state.
 
 ## Python Pipeline API
 

--- a/docs/guide/pipeline.md
+++ b/docs/guide/pipeline.md
@@ -117,7 +117,7 @@ Requires a connection from a LoadStructure node. Frames are loaded lazily when `
 
 Both input fields validate your query in real time — invalid syntax is highlighted in red.
 
-The **Query** field filters which atoms pass through (particle output). The **Bond query** field filters which bonds are selected for the downstream Modify node to apply per-bond opacity overrides — it does not remove bonds from the scene.
+The **Query** field filters which atoms pass through when the Filter node is connected to a particle stream (particle input/output). The **Bond query** field filters which bonds are selected when the Filter node is connected to a bond stream; this selection is used by downstream nodes (for example, Modify) to apply per-bond opacity overrides — it does not remove bonds from the scene. Because a Filter node has a single generic `in → out` port and only one data type flows through it at a time, using both atom and bond queries in the same workflow typically means adding two Filter nodes: one on the particle edge and one on the bond edge.
 
 ### Modify
 
@@ -238,7 +238,7 @@ The **Bond query** field in the Filter node accepts expressions to select bonds.
 
 - `all` — select all bonds (default when query is empty)
 - `none` — select no bonds
-- `both` — prefix on a comparison to require **both** atoms satisfy it (default: either atom, OR semantics)
+- `both` — prefix on a comparison involving `atom_index` or `element` to require **both** atoms of the bond to satisfy the condition (default: either atom, OR semantics). Has no effect on `bond_index` comparisons.
 
 ### Examples
 

--- a/docs/guide/web.md
+++ b/docs/guide/web.md
@@ -178,7 +178,11 @@ import { PipelineViewer } from "megane-viewer";
 ```ts
 interface SerializedPipeline {
   version: 3;
-  nodes: Array<NodeParams & { id: string; position: { x: number; y: number } }>;
+  nodes: Array<NodeParams & {
+    id: string;
+    position: { x: number; y: number };
+    enabled?: boolean;   // false = node is bypassed (default: true)
+  }>;
   edges: Array<{
     source: string;
     target: string;

--- a/docs/guide/web.md
+++ b/docs/guide/web.md
@@ -176,9 +176,12 @@ import { PipelineViewer } from "megane-viewer";
 ### `SerializedPipeline` format
 
 ```ts
+import type { PipelineNodeParams, SerializedPipeline } from "megane-viewer";
+
+// SerializedPipeline (exported from megane-viewer):
 interface SerializedPipeline {
   version: 3;
-  nodes: Array<NodeParams & {
+  nodes: Array<PipelineNodeParams & {
     id: string;
     position: { x: number; y: number };
     enabled?: boolean;   // false = node is bypassed (default: true)
@@ -191,6 +194,8 @@ interface SerializedPipeline {
   }>;
 }
 ```
+
+`PipelineNodeParams` is a discriminated union exported by `megane-viewer`. The `type` field on each node determines which parameters are required — see [Node Reference](/guide/pipeline#node-reference) for the full list.
 
 Each node's `type` field determines which parameters are required. See [Node Reference](/guide/pipeline#node-reference) for the full list.
 


### PR DESCRIPTION
## Summary

- Add `bond_query` parameter to the Filter node table in `pipeline.md`, with an explanation of how it differs from the atom `query` field
- Add a new **Bond Selection DSL** section to `pipeline.md` documenting the bond query grammar (fields: `bond_index`, `atom_index`, `element`; the `both` keyword; examples)
- Add `pivotMarkerVisible` parameter to the Viewport node table in `pipeline.md`
- Add `enabled?: boolean` field to the `SerializedPipeline` format block in `web.md`
- Add an explanation of the `enabled` field to the Serialization section in `pipeline.md`

These features existed in the codebase but were not reflected in the documentation after the v0.5.0 update cycle.

## Test plan

- [ ] Read through updated `docs/guide/pipeline.md` and verify Filter, Viewport, Serialization, and Bond Selection DSL sections are accurate
- [ ] Read through updated `docs/guide/web.md` and verify `SerializedPipeline` format block is accurate
- [ ] Confirm docs site builds without errors (`cd docs && npm run build`)