### PR TITLE
docs: add visualization gallery section

### DIFF
--- a/docs/.vitepress/components/GalleryIndex.vue
+++ b/docs/.vitepress/components/GalleryIndex.vue
@@ -27,6 +27,7 @@ const filtered = computed(() =>
     <div v-if="allTags.length" class="tag-filter">
       <button
         :class="['filter-btn', { active: activeTag === null }]"
+        :aria-pressed="activeTag === null"
         @click="activeTag = null"
       >
         All
@@ -35,6 +36,7 @@ const filtered = computed(() =>
         v-for="tag in allTags"
         :key="tag"
         :class="['filter-btn', { active: activeTag === tag }]"
+        :aria-pressed="activeTag === tag"
         @click="activeTag = activeTag === tag ? null : tag"
       >
         {{ tag }}

--- a/docs/.vitepress/components/GalleryIndex.vue
+++ b/docs/.vitepress/components/GalleryIndex.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { ref, computed } from "vue";
+import { galleryExamples } from "../gallery/registry";
+import GalleryViewer from "./GalleryViewer.vue";
+
+// ── Tag filter ────────────────────────────────────────────────────────────────
+const allTags = computed(() => {
+  const set = new Set<string>();
+  for (const ex of galleryExamples) {
+    for (const t of ex.tags) set.add(t);
+  }
+  return Array.from(set).sort();
+});
+
+const activeTag = ref<string | null>(null);
+
+const filtered = computed(() =>
+  activeTag.value
+    ? galleryExamples.filter((ex) => ex.tags.includes(activeTag.value!))
+    : galleryExamples
+);
+</script>
+
+<template>
+  <div class="gallery-index">
+    <!-- Tag filter bar -->
+    <div v-if="allTags.length" class="tag-filter">
+      <button
+        :class="['filter-btn', { active: activeTag === null }]"
+        @click="activeTag = null"
+      >
+        All
+      </button>
+      <button
+        v-for="tag in allTags"
+        :key="tag"
+        :class="['filter-btn', { active: activeTag === tag }]"
+        @click="activeTag = activeTag === tag ? null : tag"
+      >
+        {{ tag }}
+      </button>
+    </div>
+
+    <!-- Example list -->
+    <GalleryViewer
+      v-for="example in filtered"
+      :key="example.id"
+      :example="example"
+    />
+
+    <p v-if="filtered.length === 0" class="empty-state">
+      No examples match the selected tag.
+    </p>
+  </div>
+</template>
+
+<style scoped>
+/* ── Tag filter ────────────────────────────────────────────────────────────── */
+.tag-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.filter-btn {
+  padding: 4px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: var(--vp-font-family-base);
+  color: var(--vp-c-text-2);
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.filter-btn:hover {
+  color: var(--vp-c-brand-1);
+  border-color: var(--vp-c-brand-1);
+}
+
+.filter-btn.active {
+  color: var(--vp-c-bg);
+  background: var(--vp-c-brand-1);
+  border-color: var(--vp-c-brand-1);
+}
+
+/* ── Empty state ───────────────────────────────────────────────────────────── */
+.empty-state {
+  color: var(--vp-c-text-3);
+  text-align: center;
+  padding: 40px 0;
+}
+</style>

--- a/docs/.vitepress/components/GalleryViewer.vue
+++ b/docs/.vitepress/components/GalleryViewer.vue
@@ -7,34 +7,61 @@ const props = defineProps<{ example: GalleryExample }>();
 // ── 3D preview ────────────────────────────────────────────────────────────────
 const container = ref<HTMLElement | null>(null);
 let renderer: any = null;
+let unmounted = false;
 
 onMounted(async () => {
   if (!container.value) return;
+
   const { MoleculeRenderer } = await import(
     "../../../src/renderer/MoleculeRenderer"
   );
+  // Guard: component may have unmounted during the dynamic import await
+  if (unmounted || !container.value) return;
+
   renderer = new MoleculeRenderer();
   renderer.mount(container.value);
 
-  const res = await fetch(props.example.snapshotUrl);
-  const data = await res.json();
-  renderer.loadSnapshot({
-    nAtoms: data.nAtoms,
-    nBonds: data.nBonds,
-    nFileBonds: data.nFileBonds,
-    positions: new Float32Array(data.positions),
-    elements: new Uint8Array(data.elements),
-    bonds: new Uint32Array(data.bonds),
-    bondOrders: data.bondOrders ? new Uint8Array(data.bondOrders) : null,
-    box: data.box ? new Float32Array(data.box) : null,
-  });
+  try {
+    const res = await fetch(props.example.snapshotUrl);
+    if (!res.ok) {
+      console.error(
+        "Failed to load gallery snapshot:",
+        props.example.snapshotUrl,
+        "status:",
+        res.status,
+      );
+      return;
+    }
+    // Guard again after the fetch await
+    if (unmounted) return;
+    const data = await res.json();
+    if (unmounted) return;
+    renderer.loadSnapshot({
+      nAtoms: data.nAtoms,
+      nBonds: data.nBonds,
+      nFileBonds: data.nFileBonds,
+      positions: new Float32Array(data.positions),
+      elements: new Uint8Array(data.elements),
+      bonds: new Uint32Array(data.bonds),
+      bondOrders: data.bondOrders ? new Uint8Array(data.bondOrders) : null,
+      box: data.box ? new Float32Array(data.box) : null,
+    });
+  } catch (error) {
+    console.error(
+      "Error loading gallery snapshot:",
+      props.example.snapshotUrl,
+      error,
+    );
+  }
 });
 
 onBeforeUnmount(() => {
+  unmounted = true;
   if (renderer) {
     renderer.dispose();
     renderer = null;
   }
+  clearCopyTimer();
 });
 
 // ── Code tabs ─────────────────────────────────────────────────────────────────
@@ -48,11 +75,40 @@ const activeTab = ref<TabId>("jupyter");
 
 // ── Copy to clipboard ─────────────────────────────────────────────────────────
 const copied = ref(false);
+let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+function clearCopyTimer() {
+  if (copyTimer !== null) {
+    clearTimeout(copyTimer);
+    copyTimer = null;
+  }
+}
+
 async function copyCode() {
   const code = props.example.code[activeTab.value];
-  await navigator.clipboard.writeText(code);
+  try {
+    await navigator.clipboard.writeText(code);
+  } catch {
+    // Fallback for non-secure contexts or denied permissions
+    try {
+      const ta = document.createElement("textarea");
+      ta.value = code;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      document.body.removeChild(ta);
+    } catch {
+      return; // silent — copy just won't show feedback
+    }
+  }
+  clearCopyTimer();
   copied.value = true;
-  setTimeout(() => (copied.value = false), 1500);
+  copyTimer = setTimeout(() => {
+    copied.value = false;
+    copyTimer = null;
+  }, 1500);
 }
 </script>
 

--- a/docs/.vitepress/components/GalleryViewer.vue
+++ b/docs/.vitepress/components/GalleryViewer.vue
@@ -1,0 +1,275 @@
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from "vue";
+import type { GalleryExample } from "../gallery/types";
+
+const props = defineProps<{ example: GalleryExample }>();
+
+// ── 3D preview ────────────────────────────────────────────────────────────────
+const container = ref<HTMLElement | null>(null);
+let renderer: any = null;
+
+onMounted(async () => {
+  if (!container.value) return;
+  const { MoleculeRenderer } = await import(
+    "../../../src/renderer/MoleculeRenderer"
+  );
+  renderer = new MoleculeRenderer();
+  renderer.mount(container.value);
+
+  const res = await fetch(props.example.snapshotUrl);
+  const data = await res.json();
+  renderer.loadSnapshot({
+    nAtoms: data.nAtoms,
+    nBonds: data.nBonds,
+    nFileBonds: data.nFileBonds,
+    positions: new Float32Array(data.positions),
+    elements: new Uint8Array(data.elements),
+    bonds: new Uint32Array(data.bonds),
+    bondOrders: data.bondOrders ? new Uint8Array(data.bondOrders) : null,
+    box: data.box ? new Float32Array(data.box) : null,
+  });
+});
+
+onBeforeUnmount(() => {
+  if (renderer) {
+    renderer.dispose();
+    renderer = null;
+  }
+});
+
+// ── Code tabs ─────────────────────────────────────────────────────────────────
+type TabId = "jupyter" | "react" | "vscode";
+const tabs: { id: TabId; label: string; lang: string }[] = [
+  { id: "jupyter", label: "Jupyter",  lang: "python"     },
+  { id: "react",   label: "React",    lang: "typescript" },
+  { id: "vscode",  label: "VSCode",   lang: "json"       },
+];
+const activeTab = ref<TabId>("jupyter");
+
+// ── Copy to clipboard ─────────────────────────────────────────────────────────
+const copied = ref(false);
+async function copyCode() {
+  const code = props.example.code[activeTab.value];
+  await navigator.clipboard.writeText(code);
+  copied.value = true;
+  setTimeout(() => (copied.value = false), 1500);
+}
+</script>
+
+<template>
+  <div class="gallery-item" :id="example.id">
+    <!-- Header -->
+    <div class="gallery-header">
+      <div class="gallery-title-row">
+        <h3 class="gallery-title">{{ example.title }}</h3>
+        <div class="gallery-tags">
+          <span v-for="tag in example.tags" :key="tag" class="gallery-tag">
+            {{ tag }}
+          </span>
+        </div>
+      </div>
+      <p class="gallery-description">{{ example.description }}</p>
+    </div>
+
+    <!-- Layout: preview left, code right (stacks on small screens) -->
+    <div class="gallery-body">
+      <!-- 3D preview -->
+      <div
+        class="gallery-preview"
+        ref="container"
+        :style="{ height: example.height ?? '380px' }"
+      />
+
+      <!-- Code panel -->
+      <div class="gallery-code">
+        <div class="code-tabs">
+          <button
+            v-for="tab in tabs"
+            :key="tab.id"
+            :class="['code-tab', { active: activeTab === tab.id }]"
+            @click="activeTab = tab.id"
+          >
+            {{ tab.label }}
+          </button>
+          <button class="copy-btn" @click="copyCode">
+            {{ copied ? "Copied!" : "Copy" }}
+          </button>
+        </div>
+        <pre
+          v-for="tab in tabs"
+          v-show="activeTab === tab.id"
+          :key="tab.id"
+          class="code-block"
+        ><code>{{ example.code[tab.id] }}</code></pre>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* ── Card ──────────────────────────────────────────────────────────────────── */
+.gallery-item {
+  margin: 40px 0;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--vp-c-bg-soft);
+}
+
+/* ── Header ────────────────────────────────────────────────────────────────── */
+.gallery-header {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.gallery-title-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 6px;
+}
+
+.gallery-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+}
+
+.gallery-description {
+  margin: 0;
+  font-size: 14px;
+  color: var(--vp-c-text-2);
+  line-height: 1.5;
+}
+
+/* ── Tags ──────────────────────────────────────────────────────────────────── */
+.gallery-tags {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.gallery-tag {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+  background: var(--vp-c-brand-soft);
+  color: var(--vp-c-brand-1);
+}
+
+/* ── Body layout ───────────────────────────────────────────────────────────── */
+.gallery-body {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  min-height: 0;
+}
+
+@media (max-width: 768px) {
+  .gallery-body {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── 3D preview ────────────────────────────────────────────────────────────── */
+.gallery-preview {
+  width: 100%;
+  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+  border-right: 1px solid var(--vp-c-divider);
+  position: relative;
+}
+
+:root.dark .gallery-preview {
+  background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+}
+
+@media (max-width: 768px) {
+  .gallery-preview {
+    border-right: none;
+    border-bottom: 1px solid var(--vp-c-divider);
+    height: 280px !important;
+  }
+}
+
+/* ── Code panel ────────────────────────────────────────────────────────────── */
+.gallery-code {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.code-tabs {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--vp-c-divider);
+  padding: 0 4px;
+  background: var(--vp-c-bg-elv);
+  flex-shrink: 0;
+}
+
+.code-tab {
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: var(--vp-font-family-base);
+  color: var(--vp-c-text-2);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.code-tab:hover {
+  color: var(--vp-c-text-1);
+}
+
+.code-tab.active {
+  color: var(--vp-c-brand-1);
+  border-bottom-color: var(--vp-c-brand-1);
+}
+
+.copy-btn {
+  margin-left: auto;
+  padding: 4px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  font-family: var(--vp-font-family-base);
+  color: var(--vp-c-text-2);
+  background: none;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+}
+
+.copy-btn:hover {
+  color: var(--vp-c-brand-1);
+  border-color: var(--vp-c-brand-1);
+}
+
+.code-block {
+  margin: 0;
+  padding: 16px 20px;
+  font-family: var(--vp-font-family-mono);
+  font-size: 12.5px;
+  line-height: 1.7;
+  overflow: auto;
+  flex: 1;
+  background: transparent;
+  color: var(--vp-c-text-1);
+  white-space: pre;
+  tab-size: 2;
+}
+
+.code-block code {
+  font-family: inherit;
+  font-size: inherit;
+  background: none;
+  padding: 0;
+}
+</style>

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
 
     nav: [
       { text: "Guide", link: "/getting-started" },
+      { text: "Gallery", link: "/gallery/" },
       { text: "Demo", link: "/demo" },
       { text: "API", link: "/api/" },
       {
@@ -55,6 +56,12 @@ export default defineConfig({
           { text: "CLI Server", link: "/guide/cli" },
           { text: "Web / React", link: "/guide/web" },
           { text: "Integrations", link: "/guide/integrations" },
+        ],
+      },
+      {
+        text: "Gallery",
+        items: [
+          { text: "Gallery", link: "/gallery/" },
         ],
       },
       {

--- a/docs/.vitepress/gallery/registry.ts
+++ b/docs/.vitepress/gallery/registry.ts
@@ -1,0 +1,358 @@
+/**
+ * Gallery registry — the single source of truth for all gallery examples.
+ *
+ * ─────────────────────────────────────────────────
+ * HOW TO ADD A NEW EXAMPLE
+ * ─────────────────────────────────────────────────
+ * 1. Add a snapshot JSON to docs/public/data/  (or reuse an existing one).
+ *    A snapshot can be generated with:
+ *      python -c "import megane, json; v = megane.MolecularViewer(); v.load('your.pdb'); print(json.dumps(v._snapshot()))" > docs/public/data/your.json
+ *
+ * 2. Add a new GalleryExample object to the `galleryExamples` array below.
+ *    Fill in:
+ *      - id          : unique kebab-case string (used as HTML anchor)
+ *      - title       : short display name
+ *      - description : one-sentence description
+ *      - tags        : array of lowercase tag strings
+ *      - snapshotUrl : "/megane/data/<filename>.json"
+ *      - code.jupyter: Python code snippet
+ *      - code.react  : TSX snippet using PipelineViewer
+ *      - code.vscode : megane.json (SerializedPipeline JSON)
+ *
+ * That's it — the gallery page renders all entries automatically.
+ * ─────────────────────────────────────────────────
+ */
+
+import type { GalleryExample } from "./types";
+
+export const galleryExamples: GalleryExample[] = [
+  // ──────────────────────────────────────────────
+  // 1. Protein structure (Crambin, 1CRN)
+  // ──────────────────────────────────────────────
+  {
+    id: "protein-structure",
+    title: "Protein Structure",
+    description:
+      "Load and visualize a protein from a PDB file with bond detection.",
+    tags: ["protein", "pdb", "basic"],
+    snapshotUrl: "/megane/data/1crn.json",
+    code: {
+      jupyter: `\
+import megane
+
+viewer = megane.MolecularViewer()
+viewer.load("1crn.pdb")
+viewer`,
+
+      react: `\
+import { PipelineViewer } from "megane-viewer";
+import type { SerializedPipeline } from "megane-viewer";
+
+const pipeline: SerializedPipeline = {
+  version: 3,
+  nodes: [
+    {
+      id: "s1", type: "load_structure",
+      position: { x: 0, y: 0 },
+      fileName: "1crn.pdb",
+      fileUrl: "/path/to/1crn.pdb",
+      hasTrajectory: false, hasCell: false,
+    },
+    {
+      id: "ab1", type: "add_bond",
+      position: { x: 0, y: 150 },
+      mode: "structure", distanceFactor: 1.2,
+    },
+    {
+      id: "v1", type: "viewport",
+      position: { x: 0, y: 300 },
+      perspective: false,
+      cellAxesVisible: false,
+      pivotMarkerVisible: false,
+    },
+  ],
+  edges: [
+    { source: "s1", target: "ab1", sourceHandle: "particle", targetHandle: "particle" },
+    { source: "s1", target: "ab1", sourceHandle: "bond",     targetHandle: "bond"     },
+    { source: "ab1", target: "v1", sourceHandle: "particle", targetHandle: "particle" },
+    { source: "ab1", target: "v1", sourceHandle: "bond",     targetHandle: "bond"     },
+    { source: "s1",  target: "v1", sourceHandle: "cell",     targetHandle: "cell"     },
+  ],
+};
+
+export default function App() {
+  return <PipelineViewer pipeline={pipeline} width="100%" height={500} />;
+}`,
+
+      vscode: `\
+{
+  "version": 3,
+  "nodes": [
+    {
+      "id": "s1",
+      "type": "load_structure",
+      "position": { "x": 0, "y": 0 },
+      "fileName": "1crn.pdb",
+      "fileUrl": "1crn.pdb",
+      "hasTrajectory": false,
+      "hasCell": false
+    },
+    {
+      "id": "ab1",
+      "type": "add_bond",
+      "position": { "x": 0, "y": 150 },
+      "mode": "structure",
+      "distanceFactor": 1.2
+    },
+    {
+      "id": "v1",
+      "type": "viewport",
+      "position": { "x": 0, "y": 300 },
+      "perspective": false,
+      "cellAxesVisible": false,
+      "pivotMarkerVisible": false
+    }
+  ],
+  "edges": [
+    { "source": "s1",  "target": "ab1", "sourceHandle": "particle", "targetHandle": "particle" },
+    { "source": "s1",  "target": "ab1", "sourceHandle": "bond",     "targetHandle": "bond"     },
+    { "source": "ab1", "target": "v1",  "sourceHandle": "particle", "targetHandle": "particle" },
+    { "source": "ab1", "target": "v1",  "sourceHandle": "bond",     "targetHandle": "bond"     },
+    { "source": "s1",  "target": "v1",  "sourceHandle": "cell",     "targetHandle": "cell"     }
+  ]
+}`,
+    },
+  },
+
+  // ──────────────────────────────────────────────
+  // 2. Small molecule system (Caffeine + Water)
+  // ──────────────────────────────────────────────
+  {
+    id: "small-molecule",
+    title: "Small Molecule System",
+    description:
+      "Visualize a solvated small molecule system with distance-based bond detection.",
+    tags: ["small-molecule", "pdb", "basic"],
+    snapshotUrl: "/megane/data/caffeine_water.json",
+    code: {
+      jupyter: `\
+import megane
+
+viewer = megane.MolecularViewer()
+viewer.load("caffeine_water.pdb")
+viewer`,
+
+      react: `\
+import { PipelineViewer } from "megane-viewer";
+import type { SerializedPipeline } from "megane-viewer";
+
+const pipeline: SerializedPipeline = {
+  version: 3,
+  nodes: [
+    {
+      id: "s1", type: "load_structure",
+      position: { x: 0, y: 0 },
+      fileName: "caffeine_water.pdb",
+      fileUrl: "/path/to/caffeine_water.pdb",
+      hasTrajectory: false, hasCell: false,
+    },
+    {
+      id: "ab1", type: "add_bond",
+      position: { x: 0, y: 150 },
+      mode: "distance", distanceFactor: 1.2,
+    },
+    {
+      id: "v1", type: "viewport",
+      position: { x: 0, y: 300 },
+      perspective: false,
+      cellAxesVisible: false,
+      pivotMarkerVisible: false,
+    },
+  ],
+  edges: [
+    { source: "s1", target: "ab1", sourceHandle: "particle", targetHandle: "particle" },
+    { source: "s1", target: "ab1", sourceHandle: "cell",     targetHandle: "cell"     },
+    { source: "ab1", target: "v1", sourceHandle: "particle", targetHandle: "particle" },
+    { source: "ab1", target: "v1", sourceHandle: "bond",     targetHandle: "bond"     },
+    { source: "s1",  target: "v1", sourceHandle: "cell",     targetHandle: "cell"     },
+  ],
+};
+
+export default function App() {
+  return <PipelineViewer pipeline={pipeline} width="100%" height={500} />;
+}`,
+
+      vscode: `\
+{
+  "version": 3,
+  "nodes": [
+    {
+      "id": "s1",
+      "type": "load_structure",
+      "position": { "x": 0, "y": 0 },
+      "fileName": "caffeine_water.pdb",
+      "fileUrl": "caffeine_water.pdb",
+      "hasTrajectory": false,
+      "hasCell": false
+    },
+    {
+      "id": "ab1",
+      "type": "add_bond",
+      "position": { "x": 0, "y": 150 },
+      "mode": "distance",
+      "distanceFactor": 1.2
+    },
+    {
+      "id": "v1",
+      "type": "viewport",
+      "position": { "x": 0, "y": 300 },
+      "perspective": false,
+      "cellAxesVisible": false,
+      "pivotMarkerVisible": false
+    }
+  ],
+  "edges": [
+    { "source": "s1",  "target": "ab1", "sourceHandle": "particle", "targetHandle": "particle" },
+    { "source": "s1",  "target": "ab1", "sourceHandle": "cell",     "targetHandle": "cell"     },
+    { "source": "ab1", "target": "v1",  "sourceHandle": "particle", "targetHandle": "particle" },
+    { "source": "ab1", "target": "v1",  "sourceHandle": "bond",     "targetHandle": "bond"     },
+    { "source": "s1",  "target": "v1",  "sourceHandle": "cell",     "targetHandle": "cell"     }
+  ]
+}`,
+    },
+  },
+
+  // ──────────────────────────────────────────────
+  // 3. Atom filtering (select residue subset)
+  // ──────────────────────────────────────────────
+  {
+    id: "atom-filter",
+    title: "Atom Filter",
+    description:
+      "Select a subset of atoms using a query expression and highlight them with a modify node.",
+    tags: ["filter", "protein", "selection"],
+    snapshotUrl: "/megane/data/1crn.json",
+    code: {
+      jupyter: `\
+import megane
+
+viewer = megane.MolecularViewer()
+viewer.load("1crn.pdb")
+
+# Select residues 1–10 via the pipeline API
+viewer.pipeline.add_filter(query="resid 1-10")
+viewer`,
+
+      react: `\
+import { PipelineViewer } from "megane-viewer";
+import type { SerializedPipeline } from "megane-viewer";
+
+const pipeline: SerializedPipeline = {
+  version: 3,
+  nodes: [
+    {
+      id: "s1", type: "load_structure",
+      position: { x: 0, y: 0 },
+      fileName: "1crn.pdb",
+      fileUrl: "/path/to/1crn.pdb",
+      hasTrajectory: false, hasCell: false,
+    },
+    {
+      id: "ab1", type: "add_bond",
+      position: { x: 0, y: 150 },
+      mode: "structure", distanceFactor: 1.2,
+    },
+    {
+      // Select residues 1–10 only
+      id: "f1", type: "filter",
+      position: { x: 0, y: 300 },
+      query: "resid 1-10",
+    },
+    {
+      // Make the selection stand out
+      id: "m1", type: "modify",
+      position: { x: 0, y: 450 },
+      scale: 1.5, opacity: 1.0,
+    },
+    {
+      id: "v1", type: "viewport",
+      position: { x: 0, y: 600 },
+      perspective: false,
+      cellAxesVisible: false,
+      pivotMarkerVisible: false,
+    },
+  ],
+  edges: [
+    { source: "s1",  target: "ab1", sourceHandle: "particle", targetHandle: "particle" },
+    { source: "s1",  target: "ab1", sourceHandle: "bond",     targetHandle: "bond"     },
+    { source: "ab1", target: "f1",  sourceHandle: "particle", targetHandle: "particle" },
+    { source: "ab1", target: "f1",  sourceHandle: "bond",     targetHandle: "bond"     },
+    { source: "f1",  target: "m1",  sourceHandle: "particle", targetHandle: "particle" },
+    { source: "f1",  target: "m1",  sourceHandle: "bond",     targetHandle: "bond"     },
+    { source: "m1",  target: "v1",  sourceHandle: "particle", targetHandle: "particle" },
+    { source: "m1",  target: "v1",  sourceHandle: "bond",     targetHandle: "bond"     },
+    { source: "s1",  target: "v1",  sourceHandle: "cell",     targetHandle: "cell"     },
+  ],
+};
+
+export default function App() {
+  return <PipelineViewer pipeline={pipeline} width="100%" height={500} />;
+}`,
+
+      vscode: `\
+{
+  "version": 3,
+  "nodes": [
+    {
+      "id": "s1",
+      "type": "load_structure",
+      "position": { "x": 0, "y": 0 },
+      "fileName": "1crn.pdb",
+      "fileUrl": "1crn.pdb",
+      "hasTrajectory": false,
+      "hasCell": false
+    },
+    {
+      "id": "ab1",
+      "type": "add_bond",
+      "position": { "x": 0, "y": 150 },
+      "mode": "structure",
+      "distanceFactor": 1.2
+    },
+    {
+      "id": "f1",
+      "type": "filter",
+      "position": { "x": 0, "y": 300 },
+      "query": "resid 1-10"
+    },
+    {
+      "id": "m1",
+      "type": "modify",
+      "position": { "x": 0, "y": 450 },
+      "scale": 1.5,
+      "opacity": 1.0
+    },
+    {
+      "id": "v1",
+      "type": "viewport",
+      "position": { "x": 0, "y": 600 },
+      "perspective": false,
+      "cellAxesVisible": false,
+      "pivotMarkerVisible": false
+    }
+  ],
+  "edges": [
+    { "source": "s1",  "target": "ab1", "sourceHandle": "particle", "targetHandle": "particle" },
+    { "source": "s1",  "target": "ab1", "sourceHandle": "bond",     "targetHandle": "bond"     },
+    { "source": "ab1", "target": "f1",  "sourceHandle": "particle", "targetHandle": "particle" },
+    { "source": "ab1", "target": "f1",  "sourceHandle": "bond",     "targetHandle": "bond"     },
+    { "source": "f1",  "target": "m1",  "sourceHandle": "particle", "targetHandle": "particle" },
+    { "source": "f1",  "target": "m1",  "sourceHandle": "bond",     "targetHandle": "bond"     },
+    { "source": "m1",  "target": "v1",  "sourceHandle": "particle", "targetHandle": "particle" },
+    { "source": "m1",  "target": "v1",  "sourceHandle": "bond",     "targetHandle": "bond"     },
+    { "source": "s1",  "target": "v1",  "sourceHandle": "cell",     "targetHandle": "cell"     }
+  ]
+}`,
+    },
+  },
+];

--- a/docs/.vitepress/gallery/registry.ts
+++ b/docs/.vitepress/gallery/registry.ts
@@ -5,8 +5,9 @@
  * HOW TO ADD A NEW EXAMPLE
  * ─────────────────────────────────────────────────
  * 1. Add a snapshot JSON to docs/public/data/  (or reuse an existing one).
- *    A snapshot can be generated with:
- *      python -c "import megane, json; v = megane.MolecularViewer(); v.load('your.pdb'); print(json.dumps(v._snapshot()))" > docs/public/data/your.json
+ *    Snapshots are JSON-serialized atom/bond data (see existing files in docs/public/data/).
+ *    To create a new snapshot, copy a similar JSON file in that directory and adapt it,
+ *    or follow the same SerializedPipeline schema used by the viewer.
  *
  * 2. Add a new GalleryExample object to the `galleryExamples` array below.
  *    Fill in:

--- a/docs/.vitepress/gallery/types.ts
+++ b/docs/.vitepress/gallery/types.ts
@@ -1,0 +1,33 @@
+/**
+ * Types for the documentation gallery.
+ *
+ * Each GalleryExample defines a visualization example shown in the gallery page.
+ * The registry (registry.ts) is the single source of truth — add a new entry there
+ * to make a new example appear automatically.
+ */
+
+export interface GalleryCode {
+  /** Python code for Jupyter notebook */
+  jupyter: string;
+  /** TSX code showing PipelineViewer usage */
+  react: string;
+  /** megane.json content (SerializedPipeline JSON for VSCode extension) */
+  vscode: string;
+}
+
+export interface GalleryExample {
+  /** Unique identifier, used as HTML anchor */
+  id: string;
+  /** Display title */
+  title: string;
+  /** Short description of what the example shows */
+  description: string;
+  /** Categorization tags (e.g. "protein", "trajectory", "filter") */
+  tags: string[];
+  /** URL to snapshot JSON for the 3D preview (served from docs/public/) */
+  snapshotUrl: string;
+  /** Height of the 3D preview (CSS value, default: "380px") */
+  height?: string;
+  /** Platform-specific code snippets */
+  code: GalleryCode;
+}

--- a/docs/gallery/index.md
+++ b/docs/gallery/index.md
@@ -1,0 +1,36 @@
+---
+title: Gallery
+---
+
+<script setup>
+import GalleryIndex from '../.vitepress/components/GalleryIndex.vue'
+</script>
+
+# Gallery
+
+A collection of visualization examples. Each example shows a live 3D preview and the code needed to reproduce it in Jupyter, React, or the VSCode extension.
+
+<GalleryIndex />
+
+---
+
+## Adding Your Own Example
+
+To contribute a new gallery example, edit
+[`docs/.vitepress/gallery/registry.ts`](https://github.com/hodakamori/megane/blob/main/docs/.vitepress/gallery/registry.ts)
+and add an entry to the `galleryExamples` array.
+
+Each entry needs:
+
+| Field | Description |
+|---|---|
+| `id` | Unique kebab-case identifier (used as HTML anchor) |
+| `title` | Short display name |
+| `description` | One-sentence description |
+| `tags` | Array of lowercase tag strings |
+| `snapshotUrl` | Path to a snapshot JSON in `docs/public/data/` |
+| `code.jupyter` | Python snippet for Jupyter |
+| `code.react` | TSX snippet using `PipelineViewer` |
+| `code.vscode` | `megane.json` content (SerializedPipeline JSON) |
+
+See the existing entries in `registry.ts` for concrete examples.


### PR DESCRIPTION
## Summary

- Adds a **Gallery** page to the documentation showcasing visualization examples across all supported platforms
- Introduces a data-driven registry system — adding a new example requires only a single entry in `registry.ts`
- Ships 3 initial examples: Protein Structure, Small Molecule System, Atom Filter

## Architecture

| File | Role |
|---|---|
| `docs/.vitepress/gallery/types.ts` | `GalleryExample` TypeScript type |
| `docs/.vitepress/gallery/registry.ts` | Single source of truth — the array users extend |
| `docs/.vitepress/components/GalleryViewer.vue` | Per-example card: 3D preview + code tabs (Jupyter / React / VSCode) with copy button |
| `docs/.vitepress/components/GalleryIndex.vue` | Lists all examples with tag-based filter bar |
| `docs/gallery/index.md` | VitePress page |

**Adding a new example:**
1. Place snapshot JSON in `docs/public/data/`
2. Add one object to `galleryExamples` in `registry.ts`

## Test plan

- [ ] `npm run docs:dev` — visit `/gallery/` and confirm all 3 examples render with live 3D preview
- [ ] Confirm tab switching (Jupyter / React / VSCode) and copy-to-clipboard work
- [ ] Confirm tag filter (protein, filter, small-molecule) hides/shows examples correctly
- [ ] Confirm Gallery link appears in top nav and sidebar
- [ ] `npm run docs:build` — no build errors

https://claude.ai/code/session_01NH4qoDrzAFQtk7G8DahSEm