### PR TITLE
feat: add JavaScript/TypeScript pipeline builder API

### DIFF
--- a/docs/guide/pipeline.md
+++ b/docs/guide/pipeline.md
@@ -317,6 +317,187 @@ Pipelines serialize to JSON (v3 format) and can be saved, loaded, and version-co
 
 Each node entry can include `"enabled": false` to bypass that node (equivalent to deleting it from the execution graph while keeping it in the editor). Omitting `enabled` or setting it to `true` is the default active state.
 
+## JavaScript/TypeScript Pipeline API
+
+Pipelines can be built programmatically in JavaScript/TypeScript using the `Pipeline` builder in `@/pipeline/builder`. The API mirrors the Python interface exactly, making it straightforward to port pipelines between languages.
+
+### Overview
+
+```typescript
+import { Pipeline, LoadStructure, AddBonds, Viewport } from '@/pipeline/builder'
+
+const pipe = new Pipeline()
+const s = pipe.addNode(new LoadStructure('protein.pdb'))
+const b = pipe.addNode(new AddBonds())
+const v = pipe.addNode(new Viewport())
+
+pipe.addEdge(s.out.particle, b.inp.particle)
+pipe.addEdge(s.out.particle, v.inp.particle)
+pipe.addEdge(b.out.bond,     v.inp.bond)
+
+// Serialize to SerializedPipeline v3 JSON
+const json = pipe.toJSON()
+const obj  = pipe.toObject()  // plain object version
+```
+
+After `addNode()`, each node exposes `.out` and `.inp` accessors for its ports. Pass these `NodePort` objects to `addEdge()` to wire nodes together. The pipeline serializes to the same `SerializedPipeline` v3 format used by the TypeScript engine — `toObject()` output can be passed directly to `deserializePipeline()`.
+
+### Pipeline class
+
+| Method | Description |
+|--------|-------------|
+| `addNode(node)` | Add a node to the pipeline. Returns the same node (with `.out`/`.inp` ports) for use in `addEdge()` |
+| `addEdge(sourcePort, targetPort)` | Connect `node.out.<name>` → `node.inp.<name>` |
+| `toObject()` | Serialize to v3 plain object (`SerializedPipeline`) |
+| `toJSON(indent?)` | Serialize to a JSON string (default indent = 2) |
+
+### Node classes
+
+All node classes are importable from `@/pipeline/builder`:
+
+```typescript
+import {
+  LoadStructure,
+  LoadTrajectory,
+  Streaming,
+  LoadVector,
+  Filter,
+  Modify,
+  AddBonds,
+  AddLabels,
+  AddPolyhedra,
+  VectorOverlay,
+  Viewport,
+  Pipeline,
+} from '@/pipeline/builder'
+```
+
+Constructor parameters mirror the Python API (using an options object instead of keyword args):
+
+| Python | JavaScript/TypeScript |
+|--------|----------------------|
+| `LoadStructure("path")` | `new LoadStructure('path')` |
+| `Filter(query="element == 'C'")` | `new Filter({ query: "element == 'C'" })` |
+| `Modify(scale=1.3, opacity=0.8)` | `new Modify({ scale: 1.3, opacity: 0.8 })` |
+| `AddBonds(source="distance")` | `new AddBonds({ source: 'distance' })` |
+| `AddLabels(source="element")` | `new AddLabels({ source: 'element' })` |
+| `AddPolyhedra(center_elements=[22])` | `new AddPolyhedra({ centerElements: [22] })` |
+| `VectorOverlay(scale=2.0)` | `new VectorOverlay({ scale: 2.0 })` |
+| `LoadTrajectory(xtc="traj.xtc")` | `new LoadTrajectory({ xtc: 'traj.xtc' })` |
+| `Viewport(perspective=True)` | `new Viewport({ perspective: true })` |
+
+### Ports
+
+After `addNode()`, each node exposes two port accessors:
+
+- `node.out.<name>` — output port (first arg to `addEdge`)
+- `node.inp.<name>` — input port (second arg to `addEdge`)
+
+Port names are identical to Python. The `.traj` port maps to the `"trajectory"` wire handle internally. Accessing an undefined port throws an `Error` with a message listing available ports.
+
+### Example: Basic Structure with Bonds
+
+```typescript
+import { Pipeline, LoadStructure, AddBonds, Viewport } from '@/pipeline/builder'
+
+const pipe = new Pipeline()
+const s = pipe.addNode(new LoadStructure('protein.pdb'))
+const b = pipe.addNode(new AddBonds({ source: 'distance' }))
+const v = pipe.addNode(new Viewport())
+
+pipe.addEdge(s.out.particle, b.inp.particle)
+pipe.addEdge(s.out.particle, v.inp.particle)
+pipe.addEdge(b.out.bond,     v.inp.bond)
+
+const json = pipe.toJSON()
+```
+
+### Example: Filter and Modify
+
+```typescript
+import { Pipeline, LoadStructure, Filter, Modify, AddBonds, Viewport } from '@/pipeline/builder'
+
+const pipe = new Pipeline()
+const s      = pipe.addNode(new LoadStructure('protein.pdb'))
+const carbons = pipe.addNode(new Filter({ query: "element == 'C'" }))
+const big    = pipe.addNode(new Modify({ scale: 1.5, opacity: 0.8 }))
+const bonds  = pipe.addNode(new AddBonds())
+const v      = pipe.addNode(new Viewport())
+
+pipe.addEdge(s.out.particle,       carbons.inp.particle)
+pipe.addEdge(carbons.out.particle, big.inp.particle)
+pipe.addEdge(s.out.particle,       bonds.inp.particle)
+pipe.addEdge(big.out.particle,     v.inp.particle)
+pipe.addEdge(bonds.out.bond,       v.inp.bond)
+```
+
+### Example: Trajectory Playback
+
+```typescript
+import { Pipeline, LoadStructure, LoadTrajectory, AddBonds, Viewport } from '@/pipeline/builder'
+
+const pipe = new Pipeline()
+const s     = pipe.addNode(new LoadStructure('protein.pdb'))
+const traj  = pipe.addNode(new LoadTrajectory({ xtc: 'trajectory.xtc' }))
+const bonds = pipe.addNode(new AddBonds({ source: 'structure' }))
+const v     = pipe.addNode(new Viewport())
+
+pipe.addEdge(s.out.particle, traj.inp.particle)
+pipe.addEdge(s.out.particle, bonds.inp.particle)
+pipe.addEdge(s.out.particle, v.inp.particle)
+pipe.addEdge(traj.out.traj,  v.inp.traj)
+pipe.addEdge(bonds.out.bond, v.inp.bond)
+```
+
+### Example: TiO₆ Coordination Polyhedra
+
+```typescript
+import { Pipeline, LoadStructure, AddBonds, AddPolyhedra, Viewport } from '@/pipeline/builder'
+
+const pipe      = new Pipeline()
+const s         = pipe.addNode(new LoadStructure('SrTiO3_supercell.pdb'))
+const bonds     = pipe.addNode(new AddBonds())
+const polyhedra = pipe.addNode(new AddPolyhedra({
+  centerElements: [22],  // Ti
+  ligandElements: [8],   // O
+  maxDistance: 2.5,
+  opacity: 0.5,
+  showEdges: true,
+}))
+const v = pipe.addNode(new Viewport())
+
+pipe.addEdge(s.out.particle,       bonds.inp.particle)
+pipe.addEdge(s.out.particle,       polyhedra.inp.particle)
+pipe.addEdge(s.out.particle,       v.inp.particle)
+pipe.addEdge(bonds.out.bond,       v.inp.bond)
+pipe.addEdge(polyhedra.out.mesh,   v.inp.mesh)
+```
+
+### Example: DAG Branching (Multiple Filters)
+
+```typescript
+import { Pipeline, LoadStructure, Filter, AddLabels, AddBonds, Viewport } from '@/pipeline/builder'
+
+const pipe     = new Pipeline()
+const s        = pipe.addNode(new LoadStructure('protein.pdb'))
+const carbon   = pipe.addNode(new Filter({ query: "element == 'C'" }))
+const nitrogen = pipe.addNode(new Filter({ query: "element == 'N'" }))
+const labels   = pipe.addNode(new AddLabels({ source: 'element' }))
+const bonds    = pipe.addNode(new AddBonds())
+const v        = pipe.addNode(new Viewport())
+
+pipe.addEdge(s.out.particle,        carbon.inp.particle)
+pipe.addEdge(s.out.particle,        nitrogen.inp.particle)
+pipe.addEdge(s.out.particle,        labels.inp.particle)
+pipe.addEdge(s.out.particle,        bonds.inp.particle)
+pipe.addEdge(carbon.out.particle,   v.inp.particle)
+pipe.addEdge(nitrogen.out.particle, v.inp.particle)
+pipe.addEdge(labels.out.label,      v.inp.label)
+pipe.addEdge(bonds.out.bond,        v.inp.bond)
+```
+
+---
+
 ## Python Pipeline API
 
 Pipelines can be built programmatically in Python using the `Pipeline` class. This is the recommended way to use megane in Jupyter notebooks and scripts.

--- a/src/pipeline/builder.ts
+++ b/src/pipeline/builder.ts
@@ -53,9 +53,7 @@ function makePortNamespace(node: PipelineNode, portMap: Record<string, string>):
       if (typeof prop !== "string" || prop.startsWith("__") || prop === "then") return undefined;
       if (prop in portMap) return new NodePort(node, portMap[prop]);
       const available = Object.keys(portMap).sort().join(", ") || "(none)";
-      throw new Error(
-        `No port "${prop}" on "${node.nodeType}" node. Available: ${available}`,
-      );
+      throw new Error(`No port "${prop}" on "${node.nodeType}" node. Available: ${available}`);
     },
     has(_, prop: string) {
       return prop in portMap;

--- a/src/pipeline/builder.ts
+++ b/src/pipeline/builder.ts
@@ -47,22 +47,27 @@ export interface PortAccessor {
   [portName: string]: NodePort;
 }
 
+const hasOwn = (obj: Record<string, string>, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(obj, key);
+
 function makePortNamespace(node: PipelineNode, portMap: Record<string, string>): PortAccessor {
   return new Proxy({} as PortAccessor, {
     get(_, prop: string) {
       if (typeof prop !== "string" || prop.startsWith("__") || prop === "then") return undefined;
-      if (prop in portMap) return new NodePort(node, portMap[prop]);
+      if (hasOwn(portMap, prop)) return new NodePort(node, portMap[prop]);
       const available = Object.keys(portMap).sort().join(", ") || "(none)";
       throw new Error(`No port "${prop}" on "${node.nodeType}" node. Available: ${available}`);
     },
     has(_, prop: string) {
-      return prop in portMap;
+      return typeof prop === "string" && hasOwn(portMap, prop);
     },
     ownKeys() {
       return Object.keys(portMap);
     },
     getOwnPropertyDescriptor(_, prop: string) {
-      if (prop in portMap) return { configurable: true, enumerable: true };
+      if (typeof prop === "string" && hasOwn(portMap, prop)) {
+        return { configurable: true, enumerable: true };
+      }
       return undefined;
     },
   });
@@ -477,6 +482,12 @@ export class Pipeline {
    *   pipe.addEdge(s.out.particle, ...)
    */
   addNode<T extends PipelineNode>(node: T): T {
+    if (node._id !== null && this._nodes.has(node._id)) {
+      throw new Error(
+        `Node "${node._id}" has already been added to this pipeline. ` +
+          "Create a new node instance instead of reusing the same one.",
+      );
+    }
     this._counter++;
     node._id = `${node.nodeType}-${this._counter}`;
     const params = node._toSerializedParams();

--- a/src/pipeline/builder.ts
+++ b/src/pipeline/builder.ts
@@ -1,0 +1,540 @@
+/**
+ * JavaScript/TypeScript pipeline builder for megane molecular viewer.
+ *
+ * Mirrors the Python Pipeline API: add nodes, wire ports explicitly, then
+ * serialize to the SerializedPipeline v3 JSON format understood by the
+ * TypeScript pipeline engine.
+ *
+ * Example:
+ *
+ *   import { Pipeline, LoadStructure, Filter, Modify, AddBonds, Viewport } from '@/pipeline/builder'
+ *
+ *   const pipe = new Pipeline()
+ *   const s = pipe.addNode(new LoadStructure('protein.pdb'))
+ *   const f = pipe.addNode(new Filter({ query: "element == 'C'" }))
+ *   const m = pipe.addNode(new Modify({ scale: 1.3 }))
+ *   const b = pipe.addNode(new AddBonds())
+ *   const v = pipe.addNode(new Viewport())
+ *
+ *   pipe.addEdge(s.out.particle, f.inp.particle)
+ *   pipe.addEdge(f.out.particle, m.inp.particle)
+ *   pipe.addEdge(s.out.particle, b.inp.particle)
+ *   pipe.addEdge(m.out.particle, v.inp.particle)
+ *   pipe.addEdge(b.out.bond,     v.inp.bond)
+ *
+ *   const json = pipe.toJSON()
+ */
+
+import type { SerializedPipeline } from "./types";
+
+// ─── Port Objects ────────────────────────────────────────────────────
+
+/** A single typed I/O port on a pipeline node. */
+export class NodePort {
+  constructor(
+    public readonly node: PipelineNode,
+    public readonly handle: string,
+  ) {}
+}
+
+/**
+ * Attribute-access namespace that returns NodePort instances.
+ *
+ * Example: node.out.particle → NodePort(node, 'particle')
+ * Accessing an undefined port throws an Error with available port names.
+ */
+export interface PortAccessor {
+  [portName: string]: NodePort;
+}
+
+function makePortNamespace(node: PipelineNode, portMap: Record<string, string>): PortAccessor {
+  return new Proxy({} as PortAccessor, {
+    get(_, prop: string) {
+      if (typeof prop !== "string" || prop.startsWith("__") || prop === "then") return undefined;
+      if (prop in portMap) return new NodePort(node, portMap[prop]);
+      const available = Object.keys(portMap).sort().join(", ") || "(none)";
+      throw new Error(
+        `No port "${prop}" on "${node.nodeType}" node. Available: ${available}`,
+      );
+    },
+    has(_, prop: string) {
+      return prop in portMap;
+    },
+    ownKeys() {
+      return Object.keys(portMap);
+    },
+    getOwnPropertyDescriptor(_, prop: string) {
+      if (prop in portMap) return { configurable: true, enumerable: true };
+      return undefined;
+    },
+  });
+}
+
+// ─── Node Base Class ─────────────────────────────────────────────────
+
+export abstract class PipelineNode {
+  abstract readonly nodeType: string;
+  protected abstract readonly _outPorts: Record<string, string>;
+  protected abstract readonly _inpPorts: Record<string, string>;
+
+  _id: string | null = null;
+
+  /** Output port namespace. Access ports via node.out.portName */
+  get out(): PortAccessor {
+    return makePortNamespace(this, this._outPorts);
+  }
+
+  /** Input port namespace. Access ports via node.inp.portName */
+  get inp(): PortAccessor {
+    return makePortNamespace(this, this._inpPorts);
+  }
+
+  /** Serialize node parameters to the SerializedPipeline v3 node dict. */
+  abstract _toSerializedParams(): Record<string, unknown>;
+}
+
+// ─── Node Classes ────────────────────────────────────────────────────
+
+/**
+ * Load a molecular structure file.
+ *
+ * Supported formats: PDB, GRO, XYZ, MOL, LAMMPS data.
+ *
+ * Ports:
+ *   out.particle — atom data
+ *   out.traj     — trajectory channel
+ *   out.cell     — simulation cell
+ */
+export class LoadStructure extends PipelineNode {
+  readonly nodeType = "load_structure";
+  protected readonly _outPorts = { particle: "particle", traj: "trajectory", cell: "cell" };
+  protected readonly _inpPorts: Record<string, string> = {};
+
+  constructor(public path: string) {
+    super();
+  }
+
+  _toSerializedParams() {
+    return {
+      type: this.nodeType,
+      fileName: this.path,
+      hasTrajectory: false,
+      hasCell: false,
+    };
+  }
+}
+
+/**
+ * Load an external trajectory file (XTC or ASE .traj).
+ *
+ * Requires connection from a LoadStructure node.
+ *
+ * Ports:
+ *   inp.particle — atom topology source
+ *   out.traj     — trajectory frames
+ */
+export class LoadTrajectory extends PipelineNode {
+  readonly nodeType = "load_trajectory";
+  protected readonly _outPorts = { traj: "trajectory" };
+  protected readonly _inpPorts = { particle: "particle" };
+
+  public xtc: string | null;
+  public traj: string | null;
+
+  constructor({ xtc = null, traj = null }: { xtc?: string | null; traj?: string | null } = {}) {
+    super();
+    this.xtc = xtc;
+    this.traj = traj;
+  }
+
+  _toSerializedParams() {
+    return {
+      type: this.nodeType,
+      fileName: this.xtc ?? this.traj,
+    };
+  }
+}
+
+/**
+ * Streaming source node for WebSocket-based real-time data delivery.
+ *
+ * Ports:
+ *   out.particle — atom data
+ *   out.bond     — bond data
+ *   out.traj     — trajectory channel
+ *   out.cell     — simulation cell
+ */
+export class Streaming extends PipelineNode {
+  readonly nodeType = "streaming";
+  protected readonly _outPorts = {
+    particle: "particle",
+    bond: "bond",
+    traj: "trajectory",
+    cell: "cell",
+  };
+  protected readonly _inpPorts: Record<string, string> = {};
+
+  _toSerializedParams() {
+    return { type: this.nodeType, connected: false };
+  }
+}
+
+/**
+ * Load per-atom vector data from a file.
+ *
+ * Ports:
+ *   out.vector — vector field
+ */
+export class LoadVector extends PipelineNode {
+  readonly nodeType = "load_vector";
+  protected readonly _outPorts = { vector: "vector" };
+  protected readonly _inpPorts: Record<string, string> = {};
+
+  constructor(public path: string) {
+    super();
+  }
+
+  _toSerializedParams() {
+    return { type: this.nodeType, fileName: this.path };
+  }
+}
+
+/**
+ * Filter atoms by a selection query.
+ *
+ * Query syntax examples:
+ *   element == 'C'
+ *   element == 'O' and x > 5.0
+ *   resname == 'ALA'
+ *   index >= 100 and index < 200
+ *
+ * Ports:
+ *   inp.particle — atom data in
+ *   out.particle — filtered atom data
+ */
+export class Filter extends PipelineNode {
+  readonly nodeType = "filter";
+  protected readonly _outPorts = { particle: "out" };
+  protected readonly _inpPorts = { particle: "in" };
+
+  public query: string;
+  public bondQuery: string;
+
+  constructor({ query = "all", bondQuery = "" }: { query?: string; bondQuery?: string } = {}) {
+    super();
+    this.query = query;
+    this.bondQuery = bondQuery;
+  }
+
+  _toSerializedParams() {
+    return { type: this.nodeType, query: this.query, bond_query: this.bondQuery };
+  }
+}
+
+/**
+ * Override per-atom visual properties (scale, opacity).
+ *
+ * Ports:
+ *   inp.particle — atom data in
+ *   out.particle — modified atom data
+ */
+export class Modify extends PipelineNode {
+  readonly nodeType = "modify";
+  protected readonly _outPorts = { particle: "out" };
+  protected readonly _inpPorts = { particle: "in" };
+
+  public scale: number;
+  public opacity: number;
+
+  constructor({ scale = 1.0, opacity = 1.0 }: { scale?: number; opacity?: number } = {}) {
+    super();
+    this.scale = scale;
+    this.opacity = opacity;
+  }
+
+  _toSerializedParams() {
+    return { type: this.nodeType, scale: this.scale, opacity: this.opacity };
+  }
+}
+
+/**
+ * Compute and display bonds.
+ *
+ * Ports:
+ *   inp.particle — atom data
+ *   out.bond     — computed bonds
+ */
+export class AddBonds extends PipelineNode {
+  readonly nodeType = "add_bond";
+  protected readonly _outPorts = { bond: "bond" };
+  protected readonly _inpPorts = { particle: "particle" };
+
+  public source: "distance" | "structure";
+
+  constructor({ source = "distance" }: { source?: "distance" | "structure" } = {}) {
+    super();
+    this.source = source;
+  }
+
+  _toSerializedParams() {
+    return { type: this.nodeType, bondSource: this.source };
+  }
+}
+
+/**
+ * Generate text labels at atom positions.
+ *
+ * Ports:
+ *   inp.particle — atom data
+ *   out.label    — label data
+ */
+export class AddLabels extends PipelineNode {
+  readonly nodeType = "label_generator";
+  protected readonly _outPorts = { label: "label" };
+  protected readonly _inpPorts = { particle: "particle" };
+
+  public source: "element" | "resname" | "index";
+
+  constructor({ source = "element" }: { source?: "element" | "resname" | "index" } = {}) {
+    super();
+    this.source = source;
+  }
+
+  _toSerializedParams() {
+    return { type: this.nodeType, source: this.source };
+  }
+}
+
+/**
+ * Generate coordination polyhedra mesh.
+ *
+ * Ports:
+ *   inp.particle — atom data
+ *   out.mesh     — polyhedra mesh
+ */
+export class AddPolyhedra extends PipelineNode {
+  readonly nodeType = "polyhedron_generator";
+  protected readonly _outPorts = { mesh: "mesh" };
+  protected readonly _inpPorts = { particle: "particle" };
+
+  public centerElements: number[];
+  public ligandElements: number[];
+  public maxDistance: number;
+  public opacity: number;
+  public showEdges: boolean;
+  public edgeColor: string;
+  public edgeWidth: number;
+
+  constructor({
+    centerElements,
+    ligandElements = [8],
+    maxDistance = 2.5,
+    opacity = 0.5,
+    showEdges = false,
+    edgeColor = "#dddddd",
+    edgeWidth = 3.0,
+  }: {
+    centerElements: number[];
+    ligandElements?: number[];
+    maxDistance?: number;
+    opacity?: number;
+    showEdges?: boolean;
+    edgeColor?: string;
+    edgeWidth?: number;
+  }) {
+    super();
+    this.centerElements = centerElements;
+    this.ligandElements = ligandElements;
+    this.maxDistance = maxDistance;
+    this.opacity = opacity;
+    this.showEdges = showEdges;
+    this.edgeColor = edgeColor;
+    this.edgeWidth = edgeWidth;
+  }
+
+  _toSerializedParams() {
+    return {
+      type: this.nodeType,
+      centerElements: this.centerElements,
+      ligandElements: this.ligandElements,
+      maxDistance: this.maxDistance,
+      opacity: this.opacity,
+      showEdges: this.showEdges,
+      edgeColor: this.edgeColor,
+      edgeWidth: this.edgeWidth,
+    };
+  }
+}
+
+/**
+ * Configure per-atom vector visualization (e.g. forces, velocities).
+ *
+ * Ports:
+ *   inp.vector — vector data in
+ *   out.vector — configured vector data
+ */
+export class VectorOverlay extends PipelineNode {
+  readonly nodeType = "vector_overlay";
+  protected readonly _outPorts = { vector: "vector" };
+  protected readonly _inpPorts = { vector: "vector" };
+
+  public scale: number;
+
+  constructor({ scale = 1.0 }: { scale?: number } = {}) {
+    super();
+    this.scale = scale;
+  }
+
+  _toSerializedParams() {
+    return { type: this.nodeType, scale: this.scale };
+  }
+}
+
+/**
+ * 3D rendering output node. All data to be rendered must be connected here.
+ *
+ * Ports:
+ *   inp.particle — atom data
+ *   inp.bond     — bond data
+ *   inp.cell     — simulation cell
+ *   inp.traj     — trajectory channel
+ *   inp.label    — text labels
+ *   inp.mesh     — polyhedra mesh
+ *   inp.vector   — vector field
+ */
+export class Viewport extends PipelineNode {
+  readonly nodeType = "viewport";
+  protected readonly _outPorts: Record<string, string> = {};
+  protected readonly _inpPorts = {
+    particle: "particle",
+    bond: "bond",
+    cell: "cell",
+    traj: "trajectory",
+    label: "label",
+    mesh: "mesh",
+    vector: "vector",
+  };
+
+  public perspective: boolean;
+  public cellAxesVisible: boolean;
+  public pivotMarkerVisible: boolean;
+
+  constructor({
+    perspective = false,
+    cellAxesVisible = true,
+    pivotMarkerVisible = true,
+  }: {
+    perspective?: boolean;
+    cellAxesVisible?: boolean;
+    pivotMarkerVisible?: boolean;
+  } = {}) {
+    super();
+    this.perspective = perspective;
+    this.cellAxesVisible = cellAxesVisible;
+    this.pivotMarkerVisible = pivotMarkerVisible;
+  }
+
+  _toSerializedParams() {
+    return {
+      type: this.nodeType,
+      perspective: this.perspective,
+      cellAxesVisible: this.cellAxesVisible,
+      pivotMarkerVisible: this.pivotMarkerVisible,
+    };
+  }
+}
+
+// ─── Pipeline Builder ─────────────────────────────────────────────────
+
+type SerializedNode = SerializedPipeline["nodes"][number];
+type SerializedEdge = SerializedPipeline["edges"][number];
+
+/**
+ * Pipeline graph builder.
+ *
+ * Build a DAG of processing nodes and serialize to the SerializedPipeline
+ * v3 JSON format understood by the TypeScript pipeline engine.
+ *
+ * A Viewport node must be explicitly added and connected for data to be rendered.
+ *
+ * Example:
+ *
+ *   const pipe = new Pipeline()
+ *   const s = pipe.addNode(new LoadStructure('protein.pdb'))
+ *   const v = pipe.addNode(new Viewport())
+ *   pipe.addEdge(s.out.particle, v.inp.particle)
+ *   const json = pipe.toJSON()
+ */
+export class Pipeline {
+  private _nodes: Map<string, SerializedNode> = new Map();
+  private _edges: SerializedEdge[] = [];
+  private _counter = 0;
+
+  /**
+   * Add a node to the pipeline.
+   *
+   * Returns the same node instance so its ports can be used in addEdge():
+   *
+   *   const s = pipe.addNode(new LoadStructure('protein.pdb'))
+   *   pipe.addEdge(s.out.particle, ...)
+   */
+  addNode<T extends PipelineNode>(node: T): T {
+    this._counter++;
+    node._id = `${node.nodeType}-${this._counter}`;
+    const params = node._toSerializedParams();
+    this._nodes.set(node._id, {
+      ...(params as PipelineNode["_toSerializedParams"] extends () => infer R ? R : never),
+      id: node._id,
+      position: { x: 0, y: 0 },
+    } as SerializedNode);
+    return node;
+  }
+
+  /**
+   * Connect a source port to a target port.
+   *
+   * Both ports must belong to nodes already added to this pipeline:
+   *
+   *   pipe.addEdge(s.out.particle, f.inp.particle)
+   *   pipe.addEdge(f.out.particle, v.inp.particle)
+   */
+  addEdge(source: NodePort, target: NodePort): void {
+    if (!(source instanceof NodePort) || !(target instanceof NodePort)) {
+      throw new TypeError(
+        "addEdge() requires NodePort arguments. " +
+          "Use node.out.<name> and node.inp.<name>, " +
+          "e.g. pipe.addEdge(s.out.particle, f.inp.particle).",
+      );
+    }
+    if (source.node._id === null || !this._nodes.has(source.node._id)) {
+      throw new Error("Source node must be added to this pipeline before connecting.");
+    }
+    if (target.node._id === null || !this._nodes.has(target.node._id)) {
+      throw new Error("Target node must be added to this pipeline before connecting.");
+    }
+    this._edges.push({
+      source: source.node._id,
+      target: target.node._id,
+      sourceHandle: source.handle,
+      targetHandle: target.handle,
+    });
+  }
+
+  /**
+   * Serialize to SerializedPipeline v3 format as a plain object.
+   */
+  toObject(): SerializedPipeline {
+    return {
+      version: 3,
+      nodes: Array.from(this._nodes.values()),
+      edges: [...this._edges],
+    };
+  }
+
+  /**
+   * Serialize to a JSON string (SerializedPipeline v3).
+   */
+  toJSON(indent = 2): string {
+    return JSON.stringify(this.toObject(), null, indent);
+  }
+}

--- a/tests/ts/pipeline/builder.test.ts
+++ b/tests/ts/pipeline/builder.test.ts
@@ -60,6 +60,15 @@ describe("PortAccessor", () => {
     const node = new Viewport();
     expect(() => node.inp.nonexistent).toThrow(/No port "nonexistent" on "viewport"/);
   });
+
+  it("does not produce a NodePort for prototype-chain keys (toString, valueOf)", () => {
+    const node = new LoadStructure("x.pdb");
+    // Before the hasOwn fix, "toString" in portMap was true (via prototype chain),
+    // which caused new NodePort(node, Object.prototype.toString) — handle as a function.
+    // After the fix, these throw "No port" instead of silently returning a broken NodePort.
+    expect(() => (node.out as any).toString).toThrow(/No port "toString"/);
+    expect(() => (node.out as any).valueOf).toThrow(/No port "valueOf"/);
+  });
 });
 
 // ─── Node Classes ─────────────────────────────────────────────────────
@@ -136,7 +145,11 @@ describe("Streaming", () => {
 describe("Filter", () => {
   it("uses default query 'all'", () => {
     const node = new Filter();
-    expect(node._toSerializedParams()).toMatchObject({ type: "filter", query: "all", bond_query: "" });
+    expect(node._toSerializedParams()).toMatchObject({
+      type: "filter",
+      query: "all",
+      bond_query: "",
+    });
   });
 
   it("accepts custom query", () => {
@@ -178,12 +191,19 @@ describe("AddBonds", () => {
 describe("AddLabels", () => {
   it("defaults to source 'element'", () => {
     const node = new AddLabels();
-    expect(node._toSerializedParams()).toMatchObject({ type: "label_generator", source: "element" });
+    expect(node._toSerializedParams()).toMatchObject({
+      type: "label_generator",
+      source: "element",
+    });
   });
 
   it("accepts 'resname' and 'index'", () => {
-    expect(new AddLabels({ source: "resname" })._toSerializedParams()).toMatchObject({ source: "resname" });
-    expect(new AddLabels({ source: "index" })._toSerializedParams()).toMatchObject({ source: "index" });
+    expect(new AddLabels({ source: "resname" })._toSerializedParams()).toMatchObject({
+      source: "resname",
+    });
+    expect(new AddLabels({ source: "index" })._toSerializedParams()).toMatchObject({
+      source: "index",
+    });
   });
 });
 
@@ -271,6 +291,12 @@ describe("Pipeline.addNode", () => {
     const pipe = new Pipeline();
     const node = new LoadStructure("x.pdb");
     expect(pipe.addNode(node)).toBe(node);
+  });
+
+  it("throws when the same node instance is added twice", () => {
+    const pipe = new Pipeline();
+    const node = pipe.addNode(new LoadStructure("x.pdb"));
+    expect(() => pipe.addNode(node)).toThrow(/already been added/);
   });
 
   it("increments counter across different node types", () => {
@@ -399,9 +425,7 @@ describe("Pipeline full example", () => {
     expect(obj.edges).toHaveLength(5);
 
     // Verify filter → modify edge uses the correct handles
-    const fmEdge = obj.edges.find(
-      (e) => e.source === "filter-2" && e.target === "modify-3",
-    );
+    const fmEdge = obj.edges.find((e) => e.source === "filter-2" && e.target === "modify-3");
     expect(fmEdge).toEqual({
       source: "filter-2",
       target: "modify-3",

--- a/tests/ts/pipeline/builder.test.ts
+++ b/tests/ts/pipeline/builder.test.ts
@@ -1,0 +1,445 @@
+import { describe, it, expect } from "vitest";
+import {
+  Pipeline,
+  NodePort,
+  LoadStructure,
+  LoadTrajectory,
+  LoadVector,
+  Streaming,
+  Filter,
+  Modify,
+  AddBonds,
+  AddLabels,
+  AddPolyhedra,
+  VectorOverlay,
+  Viewport,
+} from "@/pipeline/builder";
+
+// ─── NodePort ─────────────────────────────────────────────────────────
+
+describe("NodePort", () => {
+  it("holds node reference and handle", () => {
+    const node = new LoadStructure("test.pdb");
+    const port = new NodePort(node, "particle");
+    expect(port.node).toBe(node);
+    expect(port.handle).toBe("particle");
+  });
+});
+
+// ─── PortAccessor (Proxy) ─────────────────────────────────────────────
+
+describe("PortAccessor", () => {
+  it("returns NodePort for valid output port", () => {
+    const node = new LoadStructure("test.pdb");
+    node._id = "n1";
+    const port = node.out.particle;
+    expect(port).toBeInstanceOf(NodePort);
+    expect(port.handle).toBe("particle");
+    expect(port.node).toBe(node);
+  });
+
+  it("maps traj alias to trajectory handle", () => {
+    const node = new LoadStructure("test.pdb");
+    expect(node.out.traj.handle).toBe("trajectory");
+  });
+
+  it("throws for unknown output port with helpful message", () => {
+    const node = new LoadStructure("test.pdb");
+    expect(() => node.out.nonexistent).toThrow(/No port "nonexistent" on "load_structure"/);
+    expect(() => node.out.nonexistent).toThrow(/Available:/);
+  });
+
+  it("returns NodePort for valid input port", () => {
+    const node = new Filter({ query: "all" });
+    const port = node.inp.particle;
+    expect(port).toBeInstanceOf(NodePort);
+    expect(port.handle).toBe("in");
+  });
+
+  it("throws for unknown input port", () => {
+    const node = new Viewport();
+    expect(() => node.inp.nonexistent).toThrow(/No port "nonexistent" on "viewport"/);
+  });
+});
+
+// ─── Node Classes ─────────────────────────────────────────────────────
+
+describe("LoadStructure", () => {
+  it("serializes to v3 format", () => {
+    const node = new LoadStructure("protein.pdb");
+    node._id = "load_structure-1";
+    const params = node._toSerializedParams();
+    expect(params).toMatchObject({
+      type: "load_structure",
+      fileName: "protein.pdb",
+      hasTrajectory: false,
+      hasCell: false,
+    });
+  });
+
+  it("exposes out.particle, out.traj, out.cell", () => {
+    const node = new LoadStructure("x.pdb");
+    expect(node.out.particle.handle).toBe("particle");
+    expect(node.out.traj.handle).toBe("trajectory");
+    expect(node.out.cell.handle).toBe("cell");
+  });
+
+  it("has no input ports", () => {
+    const node = new LoadStructure("x.pdb");
+    expect(() => node.inp.particle).toThrow(/Available: \(none\)/);
+  });
+});
+
+describe("LoadTrajectory", () => {
+  it("serializes xtc path", () => {
+    const node = new LoadTrajectory({ xtc: "traj.xtc" });
+    const params = node._toSerializedParams();
+    expect(params).toMatchObject({ type: "load_trajectory", fileName: "traj.xtc" });
+  });
+
+  it("serializes traj path when xtc is null", () => {
+    const node = new LoadTrajectory({ traj: "sim.traj" });
+    const params = node._toSerializedParams();
+    expect(params).toMatchObject({ fileName: "sim.traj" });
+  });
+
+  it("exposes inp.particle and out.traj", () => {
+    const node = new LoadTrajectory({ xtc: "traj.xtc" });
+    expect(node.inp.particle.handle).toBe("particle");
+    expect(node.out.traj.handle).toBe("trajectory");
+  });
+});
+
+describe("LoadVector", () => {
+  it("serializes fileName", () => {
+    const node = new LoadVector("forces.json");
+    const params = node._toSerializedParams();
+    expect(params).toMatchObject({ type: "load_vector", fileName: "forces.json" });
+  });
+});
+
+describe("Streaming", () => {
+  it("serializes with connected=false", () => {
+    const node = new Streaming();
+    expect(node._toSerializedParams()).toMatchObject({ type: "streaming", connected: false });
+  });
+
+  it("exposes out.particle, out.bond, out.traj, out.cell", () => {
+    const node = new Streaming();
+    expect(node.out.particle.handle).toBe("particle");
+    expect(node.out.bond.handle).toBe("bond");
+    expect(node.out.traj.handle).toBe("trajectory");
+    expect(node.out.cell.handle).toBe("cell");
+  });
+});
+
+describe("Filter", () => {
+  it("uses default query 'all'", () => {
+    const node = new Filter();
+    expect(node._toSerializedParams()).toMatchObject({ type: "filter", query: "all", bond_query: "" });
+  });
+
+  it("accepts custom query", () => {
+    const node = new Filter({ query: "element == 'C'" });
+    expect(node._toSerializedParams()).toMatchObject({ query: "element == 'C'" });
+  });
+
+  it("maps inp.particle → handle 'in', out.particle → handle 'out'", () => {
+    const node = new Filter();
+    expect(node.inp.particle.handle).toBe("in");
+    expect(node.out.particle.handle).toBe("out");
+  });
+});
+
+describe("Modify", () => {
+  it("uses default scale=1.0 opacity=1.0", () => {
+    const node = new Modify();
+    expect(node._toSerializedParams()).toMatchObject({ type: "modify", scale: 1.0, opacity: 1.0 });
+  });
+
+  it("accepts custom values", () => {
+    const node = new Modify({ scale: 1.5, opacity: 0.3 });
+    expect(node._toSerializedParams()).toMatchObject({ scale: 1.5, opacity: 0.3 });
+  });
+});
+
+describe("AddBonds", () => {
+  it("uses default source 'distance'", () => {
+    const node = new AddBonds();
+    expect(node._toSerializedParams()).toMatchObject({ type: "add_bond", bondSource: "distance" });
+  });
+
+  it("accepts source 'structure'", () => {
+    const node = new AddBonds({ source: "structure" });
+    expect(node._toSerializedParams()).toMatchObject({ bondSource: "structure" });
+  });
+});
+
+describe("AddLabels", () => {
+  it("defaults to source 'element'", () => {
+    const node = new AddLabels();
+    expect(node._toSerializedParams()).toMatchObject({ type: "label_generator", source: "element" });
+  });
+
+  it("accepts 'resname' and 'index'", () => {
+    expect(new AddLabels({ source: "resname" })._toSerializedParams()).toMatchObject({ source: "resname" });
+    expect(new AddLabels({ source: "index" })._toSerializedParams()).toMatchObject({ source: "index" });
+  });
+});
+
+describe("AddPolyhedra", () => {
+  it("serializes all parameters", () => {
+    const node = new AddPolyhedra({
+      centerElements: [22],
+      ligandElements: [8],
+      maxDistance: 2.5,
+      opacity: 0.5,
+      showEdges: true,
+      edgeColor: "#ff0000",
+      edgeWidth: 2.0,
+    });
+    expect(node._toSerializedParams()).toMatchObject({
+      type: "polyhedron_generator",
+      centerElements: [22],
+      ligandElements: [8],
+      maxDistance: 2.5,
+      opacity: 0.5,
+      showEdges: true,
+      edgeColor: "#ff0000",
+      edgeWidth: 2.0,
+    });
+  });
+
+  it("uses defaults for optional params", () => {
+    const node = new AddPolyhedra({ centerElements: [14] });
+    expect(node._toSerializedParams()).toMatchObject({
+      ligandElements: [8],
+      maxDistance: 2.5,
+      opacity: 0.5,
+      showEdges: false,
+      edgeColor: "#dddddd",
+      edgeWidth: 3.0,
+    });
+  });
+});
+
+describe("VectorOverlay", () => {
+  it("serializes scale", () => {
+    const node = new VectorOverlay({ scale: 2.0 });
+    expect(node._toSerializedParams()).toMatchObject({ type: "vector_overlay", scale: 2.0 });
+  });
+});
+
+describe("Viewport", () => {
+  it("uses default params", () => {
+    const node = new Viewport();
+    expect(node._toSerializedParams()).toMatchObject({
+      type: "viewport",
+      perspective: false,
+      cellAxesVisible: true,
+      pivotMarkerVisible: true,
+    });
+  });
+
+  it("exposes all input ports", () => {
+    const node = new Viewport();
+    expect(node.inp.particle.handle).toBe("particle");
+    expect(node.inp.bond.handle).toBe("bond");
+    expect(node.inp.cell.handle).toBe("cell");
+    expect(node.inp.traj.handle).toBe("trajectory");
+    expect(node.inp.label.handle).toBe("label");
+    expect(node.inp.mesh.handle).toBe("mesh");
+    expect(node.inp.vector.handle).toBe("vector");
+  });
+
+  it("has no output ports", () => {
+    const node = new Viewport();
+    expect(() => node.out.anything).toThrow(/Available: \(none\)/);
+  });
+});
+
+// ─── Pipeline ─────────────────────────────────────────────────────────
+
+describe("Pipeline.addNode", () => {
+  it("assigns auto-incremented id to node", () => {
+    const pipe = new Pipeline();
+    const s = pipe.addNode(new LoadStructure("x.pdb"));
+    expect(s._id).toBe("load_structure-1");
+  });
+
+  it("returns the same node instance", () => {
+    const pipe = new Pipeline();
+    const node = new LoadStructure("x.pdb");
+    expect(pipe.addNode(node)).toBe(node);
+  });
+
+  it("increments counter across different node types", () => {
+    const pipe = new Pipeline();
+    const s = pipe.addNode(new LoadStructure("x.pdb"));
+    const v = pipe.addNode(new Viewport());
+    expect(s._id).toBe("load_structure-1");
+    expect(v._id).toBe("viewport-2");
+  });
+});
+
+describe("Pipeline.addEdge", () => {
+  it("records edge between two nodes", () => {
+    const pipe = new Pipeline();
+    const s = pipe.addNode(new LoadStructure("x.pdb"));
+    const v = pipe.addNode(new Viewport());
+    pipe.addEdge(s.out.particle, v.inp.particle);
+
+    const obj = pipe.toObject();
+    expect(obj.edges).toHaveLength(1);
+    expect(obj.edges[0]).toEqual({
+      source: "load_structure-1",
+      target: "viewport-2",
+      sourceHandle: "particle",
+      targetHandle: "particle",
+    });
+  });
+
+  it("throws when source is not a NodePort", () => {
+    const pipe = new Pipeline();
+    pipe.addNode(new Viewport());
+    expect(() => pipe.addEdge("particle" as any, new NodePort(new Viewport(), "bond"))).toThrow(
+      /requires NodePort arguments/,
+    );
+  });
+
+  it("throws when source node was not added to pipeline", () => {
+    const pipe = new Pipeline();
+    const v = pipe.addNode(new Viewport());
+    const orphan = new LoadStructure("x.pdb"); // NOT added
+    expect(() => pipe.addEdge(orphan.out.particle, v.inp.particle)).toThrow(
+      /Source node must be added/,
+    );
+  });
+
+  it("throws when target node was not added to pipeline", () => {
+    const pipe = new Pipeline();
+    const s = pipe.addNode(new LoadStructure("x.pdb"));
+    const orphan = new Viewport(); // NOT added
+    expect(() => pipe.addEdge(s.out.particle, orphan.inp.particle)).toThrow(
+      /Target node must be added/,
+    );
+  });
+});
+
+describe("Pipeline.toObject", () => {
+  it("produces SerializedPipeline v3", () => {
+    const pipe = new Pipeline();
+    const s = pipe.addNode(new LoadStructure("protein.pdb"));
+    const v = pipe.addNode(new Viewport());
+    pipe.addEdge(s.out.particle, v.inp.particle);
+
+    const obj = pipe.toObject();
+    expect(obj.version).toBe(3);
+    expect(obj.nodes).toHaveLength(2);
+    expect(obj.edges).toHaveLength(1);
+
+    const sNode = obj.nodes.find((n) => n.id === "load_structure-1")!;
+    expect(sNode.type).toBe("load_structure");
+    expect((sNode as any).fileName).toBe("protein.pdb");
+    expect(sNode.position).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe("Pipeline.toJSON", () => {
+  it("returns valid JSON string", () => {
+    const pipe = new Pipeline();
+    pipe.addNode(new LoadStructure("x.pdb"));
+    const json = pipe.toJSON();
+    expect(() => JSON.parse(json)).not.toThrow();
+    expect(JSON.parse(json).version).toBe(3);
+  });
+
+  it("is compatible with deserializePipeline", async () => {
+    const { deserializePipeline } = await import("@/pipeline/serialize");
+
+    const pipe = new Pipeline();
+    const s = pipe.addNode(new LoadStructure("protein.pdb"));
+    const f = pipe.addNode(new Filter({ query: "element == 'C'" }));
+    const b = pipe.addNode(new AddBonds());
+    const v = pipe.addNode(new Viewport());
+
+    pipe.addEdge(s.out.particle, f.inp.particle);
+    pipe.addEdge(f.out.particle, v.inp.particle);
+    pipe.addEdge(s.out.particle, b.inp.particle);
+    pipe.addEdge(b.out.bond, v.inp.bond);
+
+    const { nodes, edges } = deserializePipeline(pipe.toObject());
+    expect(nodes).toHaveLength(4);
+    expect(edges).toHaveLength(4);
+
+    const filterNode = nodes.find((n) => n.type === "filter")!;
+    expect((filterNode.data.params as any).query).toBe("element == 'C'");
+  });
+});
+
+// ─── Full pipeline round-trip ─────────────────────────────────────────
+
+describe("Pipeline full example", () => {
+  it("builds filter+modify+bonds pipeline", () => {
+    const pipe = new Pipeline();
+    const s = pipe.addNode(new LoadStructure("protein.pdb"));
+    const f = pipe.addNode(new Filter({ query: "element == 'C'" }));
+    const m = pipe.addNode(new Modify({ scale: 1.3 }));
+    const b = pipe.addNode(new AddBonds());
+    const v = pipe.addNode(new Viewport());
+
+    pipe.addEdge(s.out.particle, f.inp.particle);
+    pipe.addEdge(f.out.particle, m.inp.particle);
+    pipe.addEdge(s.out.particle, b.inp.particle);
+    pipe.addEdge(m.out.particle, v.inp.particle);
+    pipe.addEdge(b.out.bond, v.inp.bond);
+
+    const obj = pipe.toObject();
+    expect(obj.nodes).toHaveLength(5);
+    expect(obj.edges).toHaveLength(5);
+
+    // Verify filter → modify edge uses the correct handles
+    const fmEdge = obj.edges.find(
+      (e) => e.source === "filter-2" && e.target === "modify-3",
+    );
+    expect(fmEdge).toEqual({
+      source: "filter-2",
+      target: "modify-3",
+      sourceHandle: "out",
+      targetHandle: "in",
+    });
+  });
+
+  it("supports DAG with fan-out from single source", () => {
+    const pipe = new Pipeline();
+    const s = pipe.addNode(new LoadStructure("crystal.pdb"));
+    const ca = pipe.addNode(new Filter({ query: "element == 'Ca'" }));
+    const other = pipe.addNode(new Filter({ query: "element != 'Ca'" }));
+    const vp = pipe.addNode(new Viewport());
+
+    pipe.addEdge(s.out.particle, ca.inp.particle);
+    pipe.addEdge(s.out.particle, other.inp.particle);
+    pipe.addEdge(ca.out.particle, vp.inp.particle);
+    pipe.addEdge(other.out.particle, vp.inp.particle);
+
+    const obj = pipe.toObject();
+    const sourcedges = obj.edges.filter((e) => e.source === "load_structure-1");
+    expect(sourcedges).toHaveLength(2);
+  });
+
+  it("trajectory pipeline wires traj port to viewport", () => {
+    const pipe = new Pipeline();
+    const s = pipe.addNode(new LoadStructure("protein.pdb"));
+    const t = pipe.addNode(new LoadTrajectory({ xtc: "traj.xtc" }));
+    const v = pipe.addNode(new Viewport());
+
+    pipe.addEdge(s.out.particle, t.inp.particle);
+    pipe.addEdge(s.out.particle, v.inp.particle);
+    pipe.addEdge(t.out.traj, v.inp.traj);
+
+    const obj = pipe.toObject();
+    const trajEdge = obj.edges.find((e) => e.sourceHandle === "trajectory");
+    expect(trajEdge).toBeDefined();
+    expect(trajEdge!.targetHandle).toBe("trajectory");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/pipeline/builder.ts` — a programmatic pipeline builder for JS/TS that mirrors the Python `Pipeline` API exactly
- Users can now build pipelines with the same coding style as Python: `addNode()`, `addEdge()`, `node.out.particle`, `pipe.toJSON()`
- `toObject()` / `toJSON()` emit `SerializedPipeline` v3 format, fully compatible with the existing TypeScript execution engine
- Add 43 unit tests in `tests/ts/pipeline/builder.test.ts`
- Add "JavaScript/TypeScript Pipeline API" section to `docs/guide/pipeline.md` with examples matching all Python pipeline examples

## Key design

- `PortAccessor` uses a JS `Proxy` to enable `node.out.particle` attribute-style access (mirrors Python `__getattr__`-based `PortNamespace`)
- Accessing an undefined port throws an `Error` listing available ports
- All 11 node types implemented: `LoadStructure`, `LoadTrajectory`, `LoadVector`, `Streaming`, `Filter`, `Modify`, `AddBonds`, `AddLabels`, `AddPolyhedra`, `VectorOverlay`, `Viewport`

## Test plan

- [x] `npm test` — 317 tests pass (43 new builder tests + 274 existing)
- [x] `pipe.toObject()` output passes through `deserializePipeline()` without errors
- [x] Port name validation throws with helpful error messages

https://claude.ai/code/session_015JtaHbR1t4YEFqJM8o17xR