### PR TITLE
Add view() and view_traj() convenience wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,22 +96,20 @@ npm install megane-viewer
 ### Jupyter Notebook
 
 ```python
-from megane import Pipeline, LoadStructure, AddBonds, Viewport, MolecularViewer
+import megane
 
-# Build a pipeline
-pipe = Pipeline()
-s = pipe.add_node(LoadStructure("protein.pdb"))
-bonds = pipe.add_node(AddBonds(source="distance"))
-v = pipe.add_node(Viewport())
-pipe.add_edge(s.out.particle, bonds.inp.particle)
-pipe.add_edge(s.out.particle, v.inp.particle)
-pipe.add_edge(bonds.out.bond, v.inp.bond)
-
-# Display in notebook
-viewer = MolecularViewer()
-viewer.set_pipeline(pipe)
-viewer
+viewer = megane.view("protein.pdb")
+viewer  # displays in notebook
 ```
+
+With a trajectory:
+
+```python
+viewer = megane.view_traj("protein.pdb", xtc="trajectory.xtc")
+viewer.frame_index = 50  # jump to frame 50
+```
+
+For advanced usage (filtering, multi-layer rendering, custom pipelines), see the [Pipeline API](https://hodakamori.github.io/megane/guide/pipeline#python-pipeline-api).
 
 ### CLI (Docker)
 

--- a/docs/docs/api/index.md
+++ b/docs/docs/api/index.md
@@ -15,18 +15,13 @@ The Python API is used for:
 - **Data loading** — Parse PDB files and read XTC trajectories
 
 ```python
-from megane import Pipeline, LoadStructure, LoadTrajectory, Viewport, MolecularViewer
+import megane
 
-pipe = Pipeline()
-s = pipe.add_node(LoadStructure("protein.pdb"))
-t = pipe.add_node(LoadTrajectory(xtc="trajectory.xtc"))
-v = pipe.add_node(Viewport())
-pipe.add_edge(s.out.particle, t.inp.particle)
-pipe.add_edge(s.out.particle, v.inp.particle)
-pipe.add_edge(t.out.traj, v.inp.traj)
+# Quick start
+viewer = megane.view("protein.pdb")
 
-viewer = MolecularViewer()
-viewer.set_pipeline(pipe)
+# With trajectory
+viewer = megane.view_traj("protein.pdb", xtc="trajectory.xtc")
 ```
 
 [Python API Reference →](/api/python/)

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -28,40 +28,22 @@ npm install megane-viewer
 ### Jupyter Notebook
 
 ```python
-from megane import Pipeline, LoadStructure, AddBonds, Viewport, MolecularViewer
+import megane
 
-# Build a pipeline
-pipe = Pipeline()
-s = pipe.add_node(LoadStructure("protein.pdb"))
-bonds = pipe.add_node(AddBonds(source="distance"))
-v = pipe.add_node(Viewport())
-pipe.add_edge(s.out.particle, bonds.inp.particle)
-pipe.add_edge(s.out.particle, v.inp.particle)
-pipe.add_edge(bonds.out.bond, v.inp.bond)
-
-# Display in notebook
-viewer = MolecularViewer()
-viewer.set_pipeline(pipe)
-viewer
+viewer = megane.view("protein.pdb")
+viewer  # displays in notebook
 ```
 
 With a trajectory:
 
 ```python
-from megane import Pipeline, LoadStructure, LoadTrajectory, Viewport, MolecularViewer
+import megane
 
-pipe = Pipeline()
-s = pipe.add_node(LoadStructure("protein.pdb"))
-t = pipe.add_node(LoadTrajectory(xtc="trajectory.xtc"))
-v = pipe.add_node(Viewport())
-pipe.add_edge(s.out.particle, t.inp.particle)
-pipe.add_edge(s.out.particle, v.inp.particle)
-pipe.add_edge(t.out.traj, v.inp.traj)
-
-viewer = MolecularViewer()
-viewer.set_pipeline(pipe)
-viewer.frame_index = 50  # Jump to frame 50
+viewer = megane.view_traj("protein.pdb", xtc="trajectory.xtc")
+viewer.frame_index = 50  # jump to frame 50
 ```
+
+For advanced usage (filtering, multi-layer rendering, custom pipelines), see [Visual Pipeline — Python API](/guide/pipeline#python-pipeline-api).
 
 ### CLI Server (Docker)
 

--- a/docs/docs/guide/integrations.md
+++ b/docs/docs/guide/integrations.md
@@ -17,16 +17,7 @@ import plotly.graph_objects as go
 import ipywidgets as widgets
 import megane
 
-viewer = megane.MolecularViewer()
-
-pipe = megane.Pipeline()
-s = pipe.add_node(megane.LoadStructure("protein.pdb"))
-t = pipe.add_node(megane.LoadTrajectory(xtc="trajectory.xtc"))
-v = pipe.add_node(megane.Viewport())
-pipe.add_edge(s.out.particle, t.inp.particle)
-pipe.add_edge(s.out.particle, v.inp.particle)
-pipe.add_edge(t.out.traj, v.inp.traj)
-viewer.set_pipeline(pipe)
+viewer = megane.view_traj("protein.pdb", xtc="trajectory.xtc")
 
 # Create a Plotly time-series chart
 fig = go.FigureWidget(
@@ -118,11 +109,7 @@ Use `on_event()` as a decorator or method call:
 ```python
 import megane
 
-viewer = megane.MolecularViewer()
-
-pipe = megane.Pipeline()
-s = pipe.add_node(megane.LoadStructure("protein.pdb"))
-viewer.set_pipeline(pipe)
+viewer = megane.view("protein.pdb")
 
 # As decorator
 @viewer.on_event("measurement")

--- a/docs/docs/guide/jupyter.mdx
+++ b/docs/docs/guide/jupyter.mdx
@@ -25,19 +25,9 @@ jupyter lab
 ### Display a structure
 
 ```python
-from megane import Pipeline, LoadStructure, AddBonds, Viewport, MolecularViewer
+import megane
 
-pipe = Pipeline()
-s     = pipe.add_node(LoadStructure("caffeine.pdb"))
-bonds = pipe.add_node(AddBonds(source="distance"))
-v     = pipe.add_node(Viewport())
-
-pipe.add_edge(s.out.particle, bonds.inp.particle)
-pipe.add_edge(s.out.particle, v.inp.particle)
-pipe.add_edge(bonds.out.bond, v.inp.bond)
-
-viewer = MolecularViewer()
-viewer.set_pipeline(pipe)
+viewer = megane.view("caffeine.pdb")
 viewer  # display inline
 ```
 
@@ -46,26 +36,25 @@ The last expression in a cell renders the widget. Use `display(viewer)` to rende
 ### Play a trajectory
 
 ```python
-from megane import Pipeline, LoadStructure, LoadTrajectory, AddBonds, Viewport, MolecularViewer
+import megane
 
-pipe = Pipeline()
-s     = pipe.add_node(LoadStructure("protein.pdb"))
-traj  = pipe.add_node(LoadTrajectory(xtc="trajectory.xtc"))
-bonds = pipe.add_node(AddBonds(source="structure"))
-v     = pipe.add_node(Viewport())
-
-pipe.add_edge(s.out.particle, traj.inp.particle)
-pipe.add_edge(s.out.particle, bonds.inp.particle)
-pipe.add_edge(s.out.particle, v.inp.particle)
-pipe.add_edge(traj.out.traj,  v.inp.traj)
-pipe.add_edge(bonds.out.bond, v.inp.bond)
-
-viewer = MolecularViewer()
-viewer.set_pipeline(pipe)
+viewer = megane.view_traj("protein.pdb", xtc="trajectory.xtc", bonds="structure")
 viewer
 ```
 
-The timeline scrubber appears automatically when a trajectory is connected to the viewport.
+The timeline scrubber appears automatically when a trajectory is loaded.
+
+### Options
+
+Both `view()` and `view_traj()` accept these keyword arguments:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `bonds` | `"distance"` \| `"structure"` \| `None` | `"distance"` | Bond detection method. `None` to hide bonds |
+| `perspective` | `bool` | `False` | Perspective projection instead of orthographic |
+| `cell_axes_visible` | `bool` | `True` | Show unit cell axes |
+
+For full control over the visualization (filtering, multi-layer rendering, custom nodes), see [Visual Pipeline — Python API](./pipeline#python-pipeline-api).
 
 ## Widget API
 
@@ -142,8 +131,7 @@ import plotly.graph_objects as go
 import ipywidgets as widgets
 import megane
 
-viewer = megane.MolecularViewer()
-# ... set up pipeline with trajectory ...
+viewer = megane.view_traj("protein.pdb", xtc="trajectory.xtc")
 
 fig = go.FigureWidget(
     data=[go.Scatter(x=list(range(n_frames)), y=energy, mode="lines+markers")],
@@ -215,18 +203,18 @@ Event handling, Plotly integration, bidirectional sync, dihedral analysis, and c
 
 ## Pipeline API Reference
 
-See [Visual Pipeline — Python API](./pipeline#python-pipeline-api) for the complete list of node classes, port names, and parameters.
+For simple visualization, use `megane.view()` and `megane.view_traj()`. For advanced customization (filtering, multi-layer rendering, custom nodes), build a pipeline manually with the `Pipeline` class. See [Visual Pipeline — Python API](./pipeline#python-pipeline-api) for the complete list of node classes, port names, and parameters.
 
-All node classes are importable from `megane`:
+All classes and convenience functions are importable from `megane`:
 
 ```python
 from megane import (
-    Pipeline,
-    LoadStructure, LoadTrajectory, LoadVector, Streaming,
-    Filter, Modify,
-    AddBonds, AddLabels, AddPolyhedra,
-    VectorOverlay,
-    Viewport,
+    view, view_traj,                                    # convenience wrappers
+    Pipeline,                                            # pipeline builder
+    LoadStructure, LoadTrajectory, LoadVector, Streaming, # source nodes
+    Filter, Modify,                                      # processing nodes
+    AddBonds, AddLabels, AddPolyhedra,                   # overlay nodes
+    VectorOverlay, Viewport,                             # display nodes
 )
 ```
 

--- a/docs/docs/guide/pipeline.md
+++ b/docs/docs/guide/pipeline.md
@@ -504,7 +504,16 @@ pipe.addEdge(bonds.out.bond,        v.inp.bond)
 
 ## Python Pipeline API
 
-Pipelines can be built programmatically in Python using the `Pipeline` class. This is the recommended way to use megane in Jupyter notebooks and scripts.
+For simple visualization, use the convenience wrappers `megane.view()` and `megane.view_traj()`:
+
+```python
+import megane
+
+viewer = megane.view("protein.pdb")                                     # structure
+viewer = megane.view_traj("protein.pdb", xtc="trajectory.xtc")         # with trajectory
+```
+
+When you need more control — filtering atoms, multi-layer rendering, labels, polyhedra, or custom styling — build a pipeline manually with the `Pipeline` class.
 
 ### Overview
 

--- a/python/megane/__init__.py
+++ b/python/megane/__init__.py
@@ -17,6 +17,8 @@ from megane.pipeline import (
     Streaming,
     VectorOverlay,
     Viewport,
+    view,
+    view_traj,
 )
 from megane.widget import MolecularViewer
 
@@ -38,5 +40,7 @@ __all__ = [
     "load_pdb",
     "load_traj",
     "load_trajectory",
+    "view",
+    "view_traj",
 ]
 __version__ = "0.5.0"

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
-    pass
+    from megane.widget import MolecularViewer
 
 # ─── Port Objects ────────────────────────────────────────────────────
 

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -767,8 +767,10 @@ def view(
 ) -> "MolecularViewer":
     """Open a molecular viewer for a structure file.
 
-    Builds a minimal pipeline (LoadStructure → AddBonds → Viewport)
-    and returns a :class:`~megane.widget.MolecularViewer` widget.
+    Builds a minimal pipeline with :class:`LoadStructure` and
+    :class:`Viewport` nodes and, when *bonds* is not ``None``
+    (the default), an additional :class:`AddBonds` node, then
+    returns a :class:`~megane.widget.MolecularViewer` widget.
 
     Args:
         path: Path to a structure file (PDB, GRO, XYZ, MOL, LAMMPS data).
@@ -815,8 +817,9 @@ def view_traj(
 ) -> "MolecularViewer":
     """Open a molecular viewer with a trajectory.
 
-    Builds a pipeline (LoadStructure → LoadTrajectory → AddBonds → Viewport)
-    and returns a :class:`~megane.widget.MolecularViewer` widget.
+    Builds a pipeline (LoadStructure → LoadTrajectory → Viewport, with an
+    optional AddBonds node when *bonds* is not None) and returns a
+    :class:`~megane.widget.MolecularViewer` widget.
 
     Args:
         path: Path to a structure file (PDB, GRO, XYZ, MOL, LAMMPS data).
@@ -831,7 +834,8 @@ def view_traj(
         A :class:`~megane.widget.MolecularViewer` widget ready for display.
 
     Raises:
-        ValueError: If neither *xtc* nor *traj* is provided.
+        ValueError: If neither *xtc* nor *traj* is provided, or if both are
+            provided.
 
     Example::
 
@@ -841,6 +845,8 @@ def view_traj(
     """
     if xtc is None and traj is None:
         raise ValueError("Either 'xtc' or 'traj' must be provided. Use view() for structure-only display.")
+    if xtc is not None and traj is not None:
+        raise ValueError("Only one of 'xtc' or 'traj' can be provided, not both.")
 
     from megane.widget import MolecularViewer
 

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -753,3 +753,112 @@ class Pipeline:
 
             _, trajectory = load_traj(node.traj)
             self._trajectories[node._id] = trajectory
+
+
+# ─── Convenience wrappers ────────────────────────────────────────────
+
+
+def view(
+    path: str,
+    *,
+    bonds: Literal["distance", "structure"] | None = "distance",
+    perspective: bool = False,
+    cell_axes_visible: bool = True,
+) -> "MolecularViewer":
+    """Open a molecular viewer for a structure file.
+
+    Builds a minimal pipeline (LoadStructure → AddBonds → Viewport)
+    and returns a :class:`~megane.widget.MolecularViewer` widget.
+
+    Args:
+        path: Path to a structure file (PDB, GRO, XYZ, MOL, LAMMPS data).
+        bonds: Bond detection method. ``"distance"`` (default) uses VDW radii,
+            ``"structure"`` reads bonds from the file, ``None`` disables bonds.
+        perspective: Use perspective projection instead of orthographic.
+        cell_axes_visible: Show unit cell axes.
+
+    Returns:
+        A :class:`~megane.widget.MolecularViewer` widget ready for display.
+
+    Example::
+
+        import megane
+        viewer = megane.view("protein.pdb")
+        viewer  # displays in notebook
+    """
+    from megane.widget import MolecularViewer
+
+    pipe = Pipeline()
+    s = pipe.add_node(LoadStructure(path))
+    v = pipe.add_node(Viewport(perspective=perspective, cell_axes_visible=cell_axes_visible))
+    pipe.add_edge(s.out.particle, v.inp.particle)
+    pipe.add_edge(s.out.cell, v.inp.cell)
+
+    if bonds is not None:
+        b = pipe.add_node(AddBonds(source=bonds))
+        pipe.add_edge(s.out.particle, b.inp.particle)
+        pipe.add_edge(b.out.bond, v.inp.bond)
+
+    viewer = MolecularViewer()
+    viewer.set_pipeline(pipe)
+    return viewer
+
+
+def view_traj(
+    path: str,
+    *,
+    xtc: str | None = None,
+    traj: str | None = None,
+    bonds: Literal["distance", "structure"] | None = "distance",
+    perspective: bool = False,
+    cell_axes_visible: bool = True,
+) -> "MolecularViewer":
+    """Open a molecular viewer with a trajectory.
+
+    Builds a pipeline (LoadStructure → LoadTrajectory → AddBonds → Viewport)
+    and returns a :class:`~megane.widget.MolecularViewer` widget.
+
+    Args:
+        path: Path to a structure file (PDB, GRO, XYZ, MOL, LAMMPS data).
+        xtc: Path to an XTC trajectory file.
+        traj: Path to an ASE ``.traj`` file.
+        bonds: Bond detection method. ``"distance"`` (default) uses VDW radii,
+            ``"structure"`` reads bonds from the file, ``None`` disables bonds.
+        perspective: Use perspective projection instead of orthographic.
+        cell_axes_visible: Show unit cell axes.
+
+    Returns:
+        A :class:`~megane.widget.MolecularViewer` widget ready for display.
+
+    Raises:
+        ValueError: If neither *xtc* nor *traj* is provided.
+
+    Example::
+
+        import megane
+        viewer = megane.view_traj("protein.pdb", xtc="trajectory.xtc")
+        viewer.frame_index = 50
+    """
+    if xtc is None and traj is None:
+        raise ValueError("Either 'xtc' or 'traj' must be provided. Use view() for structure-only display.")
+
+    from megane.widget import MolecularViewer
+
+    pipe = Pipeline()
+    s = pipe.add_node(LoadStructure(path))
+    t = pipe.add_node(LoadTrajectory(xtc=xtc, traj=traj))
+    v = pipe.add_node(Viewport(perspective=perspective, cell_axes_visible=cell_axes_visible))
+
+    pipe.add_edge(s.out.particle, t.inp.particle)
+    pipe.add_edge(s.out.particle, v.inp.particle)
+    pipe.add_edge(s.out.cell, v.inp.cell)
+    pipe.add_edge(t.out.traj, v.inp.traj)
+
+    if bonds is not None:
+        b = pipe.add_node(AddBonds(source=bonds))
+        pipe.add_edge(s.out.particle, b.inp.particle)
+        pipe.add_edge(b.out.bond, v.inp.bond)
+
+    viewer = MolecularViewer()
+    viewer.set_pipeline(pipe)
+    return viewer

--- a/tests/python/test_pipeline.py
+++ b/tests/python/test_pipeline.py
@@ -1,5 +1,6 @@
 """Tests for the Python pipeline builder."""
 
+import importlib.util
 from pathlib import Path
 
 import pytest
@@ -791,6 +792,31 @@ class TestViewTrajWrapper:
     def test_raises_without_trajectory(self):
         with pytest.raises(ValueError, match="Either 'xtc' or 'traj'"):
             view_traj(str(FIXTURES / "1crn.pdb"))
+
+    @pytest.mark.skipif(
+        not importlib.util.find_spec("ase"),
+        reason="ASE not installed",
+    )
+    def test_returns_molecular_viewer_traj(self):
+        from megane.widget import MolecularViewer
+
+        viewer = view_traj(
+            str(FIXTURES / "water_100k.pdb"),
+            traj=str(FIXTURES / "water.traj"),
+        )
+        assert isinstance(viewer, MolecularViewer)
+        pipe = viewer._pipeline_ref
+        node_types = [cfg["type"] for _, cfg in pipe._nodes.values()]
+        assert "load_trajectory" in node_types
+        assert viewer.total_frames > 0
+
+    def test_raises_both_xtc_and_traj(self):
+        with pytest.raises(ValueError, match="Only one of"):
+            view_traj(
+                str(FIXTURES / "caffeine_water.pdb"),
+                xtc=str(FIXTURES / "caffeine_water_vibration.xtc"),
+                traj=str(FIXTURES / "water.traj"),
+            )
 
     def test_bonds_none(self):
         viewer = view_traj(

--- a/tests/python/test_pipeline.py
+++ b/tests/python/test_pipeline.py
@@ -18,6 +18,8 @@ from megane.pipeline import (
     PortNamespace,
     VectorOverlay,
     Viewport,
+    view,
+    view_traj,
 )
 
 FIXTURES = Path(__file__).parent.parent / "fixtures"
@@ -708,3 +710,94 @@ class TestPipelineJsonImportErrors:
     def test_load_nonexistent_file_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError):
             Pipeline.load(tmp_path / "does_not_exist.json")
+
+
+class TestViewWrapper:
+    """view() convenience function builds correct pipelines."""
+
+    def test_returns_molecular_viewer(self):
+        from megane.widget import MolecularViewer
+
+        viewer = view(str(FIXTURES / "1crn.pdb"))
+        assert isinstance(viewer, MolecularViewer)
+
+    def test_pipeline_has_structure_bonds_viewport(self):
+        viewer = view(str(FIXTURES / "1crn.pdb"))
+        pipe = viewer._pipeline_ref
+        node_types = [cfg["type"] for _, cfg in pipe._nodes.values()]
+        assert "load_structure" in node_types
+        assert "add_bond" in node_types
+        assert "viewport" in node_types
+
+    def test_bonds_none_omits_add_bond(self):
+        viewer = view(str(FIXTURES / "1crn.pdb"), bonds=None)
+        pipe = viewer._pipeline_ref
+        node_types = [cfg["type"] for _, cfg in pipe._nodes.values()]
+        assert "add_bond" not in node_types
+
+    def test_bonds_structure(self):
+        viewer = view(str(FIXTURES / "1crn.pdb"), bonds="structure")
+        pipe = viewer._pipeline_ref
+        bond_cfg = next(cfg for _, cfg in pipe._nodes.values() if cfg["type"] == "add_bond")
+        assert bond_cfg["bondSource"] == "structure"
+
+    def test_viewport_params(self):
+        viewer = view(str(FIXTURES / "1crn.pdb"), perspective=True, cell_axes_visible=False)
+        pipe = viewer._pipeline_ref
+        vp_cfg = next(cfg for _, cfg in pipe._nodes.values() if cfg["type"] == "viewport")
+        assert vp_cfg["perspective"] is True
+        assert vp_cfg["cellAxesVisible"] is False
+
+    def test_pipeline_enabled(self):
+        viewer = view(str(FIXTURES / "1crn.pdb"))
+        assert viewer._pipeline_enabled is True
+
+    def test_has_node_data(self):
+        viewer = view(str(FIXTURES / "1crn.pdb"))
+        pipe = viewer._pipeline_ref
+        assert len(pipe._node_data) > 0
+
+
+class TestViewTrajWrapper:
+    """view_traj() convenience function builds correct pipelines."""
+
+    def test_returns_molecular_viewer_xtc(self):
+        from megane.widget import MolecularViewer
+
+        viewer = view_traj(
+            str(FIXTURES / "caffeine_water.pdb"),
+            xtc=str(FIXTURES / "caffeine_water_vibration.xtc"),
+        )
+        assert isinstance(viewer, MolecularViewer)
+
+    def test_pipeline_has_trajectory_node(self):
+        viewer = view_traj(
+            str(FIXTURES / "caffeine_water.pdb"),
+            xtc=str(FIXTURES / "caffeine_water_vibration.xtc"),
+        )
+        pipe = viewer._pipeline_ref
+        node_types = [cfg["type"] for _, cfg in pipe._nodes.values()]
+        assert "load_trajectory" in node_types
+        assert "load_structure" in node_types
+        assert "viewport" in node_types
+
+    def test_total_frames_set(self):
+        viewer = view_traj(
+            str(FIXTURES / "caffeine_water.pdb"),
+            xtc=str(FIXTURES / "caffeine_water_vibration.xtc"),
+        )
+        assert viewer.total_frames > 0
+
+    def test_raises_without_trajectory(self):
+        with pytest.raises(ValueError, match="Either 'xtc' or 'traj'"):
+            view_traj(str(FIXTURES / "1crn.pdb"))
+
+    def test_bonds_none(self):
+        viewer = view_traj(
+            str(FIXTURES / "caffeine_water.pdb"),
+            xtc=str(FIXTURES / "caffeine_water_vibration.xtc"),
+            bonds=None,
+        )
+        pipe = viewer._pipeline_ref
+        node_types = [cfg["type"] for _, cfg in pipe._nodes.values()]
+        assert "add_bond" not in node_types


### PR DESCRIPTION
## Summary
- Add `megane.view(path)` and `megane.view_traj(path, xtc=...)` as short convenience functions
- These build a minimal Pipeline (LoadStructure → AddBonds → Viewport) and return a ready-to-display MolecularViewer widget
- Support `bonds`, `perspective`, and `cell_axes_visible` parameters
- Both functions are exported from `megane.__init__`

## Usage
```python
import megane

# Structure only
viewer = megane.view("protein.pdb")

# With trajectory
viewer = megane.view_traj("protein.pdb", xtc="trajectory.xtc")
viewer.frame_index = 50
```

## Test plan
- [x] Unit tests for `view()` — widget type, pipeline nodes, bonds options, viewport params
- [x] Unit tests for `view_traj()` — XTC loading, total_frames, error on missing trajectory
- [x] All 91 pipeline tests pass

https://claude.ai/code/session_01FAFnxSVSVZVs16UV2enkan