### PR TITLE
Bump version from 0.5.0 to 0.6.0

### DIFF
--- a/crates/megane-core/Cargo.toml
+++ b/crates/megane-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megane-core"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Core molecular structure parsers (PDB, GRO, XYZ, MOL, CIF, LAMMPS, XTC, .traj)"
 authors = ["hodakamori"]

--- a/crates/megane-python/Cargo.toml
+++ b/crates/megane-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megane-python"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "PyO3 Python bindings for megane molecular parsers"
 authors = ["hodakamori"]

--- a/crates/megane-wasm/Cargo.toml
+++ b/crates/megane-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megane-wasm"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "WASM bindings for megane molecular viewer"
 authors = ["hodakamori"]

--- a/docs/scripts/prepare-notebooks.py
+++ b/docs/scripts/prepare-notebooks.py
@@ -11,6 +11,7 @@ Usage:
 """
 
 import os
+import tomllib
 
 import nbformat
 from nbconvert import HTMLExporter
@@ -19,6 +20,9 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.join(SCRIPT_DIR, "..", "..")
 EXAMPLES_DIR = os.path.join(ROOT, "examples")
 OUTPUT_DIR = os.path.join(ROOT, "docs", "public", "notebooks")
+
+with open(os.path.join(ROOT, "pyproject.toml"), "rb") as _f:
+    _VERSION = tomllib.load(_f)["project"]["version"]
 
 
 def make_stream(text: str) -> nbformat.NotebookNode:
@@ -43,7 +47,7 @@ def inject_demo_outputs(nb: nbformat.NotebookNode) -> None:
         cell_id = cell.get("id", "")
 
         if cell_id == "cell-1" or 'print(f"megane v' in source:
-            cell.outputs = [make_stream("megane v0.6.0\n")]
+            cell.outputs = [make_stream(f"megane v{_VERSION}\n")]
 
         elif cell_id == "cell-3" or (
             source.strip().endswith("viewer")
@@ -89,7 +93,7 @@ def inject_external_events_outputs(nb: nbformat.NotebookNode) -> None:
         cell.outputs = []
 
         if 'print(f"megane v' in source:
-            cell.outputs = [make_stream("megane v0.6.0\n")]
+            cell.outputs = [make_stream(f"megane v{_VERSION}\n")]
 
         elif "viewer.load" in source and "xtc=" in source and "print" in source:
             cell.outputs = [make_stream("Loaded trajectory: 100 frames\n")]

--- a/docs/scripts/prepare-notebooks.py
+++ b/docs/scripts/prepare-notebooks.py
@@ -43,7 +43,7 @@ def inject_demo_outputs(nb: nbformat.NotebookNode) -> None:
         cell_id = cell.get("id", "")
 
         if cell_id == "cell-1" or 'print(f"megane v' in source:
-            cell.outputs = [make_stream("megane v0.5.0\n")]
+            cell.outputs = [make_stream("megane v0.6.0\n")]
 
         elif cell_id == "cell-3" or (
             source.strip().endswith("viewer")
@@ -89,7 +89,7 @@ def inject_external_events_outputs(nb: nbformat.NotebookNode) -> None:
         cell.outputs = []
 
         if 'print(f"megane v' in source:
-            cell.outputs = [make_stream("megane v0.5.0\n")]
+            cell.outputs = [make_stream("megane v0.6.0\n")]
 
         elif "viewer.load" in source and "xtc=" in source and "print" in source:
             cell.outputs = [make_stream("Loaded trajectory: 100 frames\n")]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "megane-viewer",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "megane-viewer",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "megane-viewer",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "description": "A fast, beautiful molecular viewer – anywidget-compatible",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,12 +121,17 @@ search = '__version__ = "{current_version}"'
 replace = '__version__ = "{new_version}"'
 
 [[tool.bumpversion.files]]
-filename = "docs/scripts/prepare-notebooks.py"
-search = 'megane v{current_version}'
-replace = 'megane v{new_version}'
+filename = "vscode-megane/package.json"
+search = '"version": "{current_version}"'
+replace = '"version": "{new_version}"'
 
 [[tool.bumpversion.files]]
-filename = "vscode-megane/package.json"
+filename = "package-lock.json"
+search = '"version": "{current_version}"'
+replace = '"version": "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "vscode-megane/package-lock.json"
 search = '"version": "{current_version}"'
 replace = '"version": "{new_version}"'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "megane"
-version = "0.5.0"
+version = "0.6.0"
 description = "A fast, beautiful molecular viewer"
 requires-python = ">=3.10"
 license = "MIT"
@@ -85,7 +85,7 @@ show_missing = true
 skip_empty = true
 
 [tool.bumpversion]
-current_version = "0.5.0"
+current_version = "0.6.0"
 commit = false
 tag = false
 allow_dirty = true

--- a/python/megane/__init__.py
+++ b/python/megane/__init__.py
@@ -43,4 +43,4 @@ __all__ = [
     "view",
     "view_traj",
 ]
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/vscode-megane/package-lock.json
+++ b/vscode-megane/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-megane",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-megane",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@xyflow/react": "^12.0.0",

--- a/vscode-megane/package.json
+++ b/vscode-megane/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-megane",
   "displayName": "megane - Molecular Viewer",
   "description": "View molecular structure files (PDB, GRO, XYZ, MOL, SDF) with megane",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "publisher": "hodakamori",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump all version numbers from 0.5.0 to 0.6.0 across the project
- Updated 10 files: pyproject.toml, package.json, package-lock.json, all 3 Cargo.toml crates, Python __init__.py, vscode-megane package.json/lock, and docs scripts

## Test plan
- [ ] Verify `cargo check` passes
- [ ] Verify `npm install` succeeds
- [ ] Verify `maturin develop` builds correctly

https://claude.ai/code/session_0189x2G8msZhPawFd1RkCqbg