### PR TITLE
fix: escape MDX braces in generated API docs and migrate onBrokenMarkdownLinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,8 @@ python/megane/static/caffeine_water.pdb
 docs/node_modules
 docs/.docusaurus/
 docs/build/
-docs/api/python/
-docs/api/typescript/
+docs/docs/api/python/
+docs/docs/api/typescript/
 docs/notebooks/
 docs/public/notebooks/
 dev-preview/

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -15,12 +15,17 @@ const config: Config = {
   organizationName: "hodakamori",
   projectName: "megane",
   onBrokenLinks: "warn",
-  onBrokenMarkdownLinks: "warn",
   staticDirectories: ["public"],
 
   i18n: {
     defaultLocale: "en",
     locales: ["en"],
+  },
+
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: "warn",
+    },
   },
 
   presets: [

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,8 +11,8 @@
     "clear": "docusaurus clear"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.7.0",
-    "@docusaurus/preset-classic": "^3.7.0",
+    "@docusaurus/core": "^3.9.0",
+    "@docusaurus/preset-classic": "^3.9.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
@@ -21,9 +21,9 @@
     "three": "^0.172.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.7.0",
-    "@docusaurus/tsconfig": "^3.7.0",
-    "@docusaurus/types": "^3.7.0",
+    "@docusaurus/module-type-aliases": "^3.9.0",
+    "@docusaurus/tsconfig": "^3.9.0",
+    "@docusaurus/types": "^3.9.0",
     "@easyops-cn/docusaurus-search-local": "^0.47.0",
     "docusaurus-plugin-image-zoom": "^2.0.0",
     "typedoc": "^0.28.0",

--- a/docs/scripts/generate-python-api.py
+++ b/docs/scripts/generate-python-api.py
@@ -159,11 +159,26 @@ def _parse_class(
     )
 
 
+def _escape_mdx_braces(text: str) -> str:
+    """Escape { and } in text so MDX does not treat them as JSX expressions.
+
+    Preserves braces inside backtick-delimited inline code spans.
+    """
+    import re
+
+    parts = re.split(r"(`[^`]*`)", text)
+    for i, part in enumerate(parts):
+        if not part.startswith("`"):
+            parts[i] = part.replace("{", "\\{").replace("}", "\\}")
+    return "".join(parts)
+
+
 def _format_docstring(docstring: str) -> str:
     """Format a docstring for markdown output."""
     if not docstring:
         return ""
-    return textwrap.dedent(docstring).strip()
+    text = textwrap.dedent(docstring).strip()
+    return _escape_mdx_braces(text)
 
 
 def _func_to_markdown(func: FuncInfo, heading_level: int = 3) -> str:

--- a/docs/scripts/generate-python-api.py
+++ b/docs/scripts/generate-python-api.py
@@ -7,6 +7,7 @@ avoiding the need to build the Rust extension (megane_parser) in CI.
 from __future__ import annotations
 
 import ast
+import re
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
@@ -164,8 +165,6 @@ def _escape_mdx_braces(text: str) -> str:
 
     Preserves braces inside backtick-delimited inline code spans.
     """
-    import re
-
     parts = re.split(r"(`[^`]*`)", text)
     for i, part in enumerate(parts):
         if not part.startswith("`"):
@@ -244,7 +243,7 @@ def generate_python_api() -> str:
                     all_functions.append(_parse_function(node))
 
     if module_docstring:
-        lines.append(module_docstring)
+        lines.append(_escape_mdx_braces(module_docstring))
         lines.append("")
 
     lines.append("## Installation")


### PR DESCRIPTION
## Summary
- Escape `{` and `}` in docstring text output by the Python API doc generator (`docs/scripts/generate-python-api.py`) so MDX/acorn does not misinterpret them as JSX expressions — fixes the CI docs build error
- Migrate deprecated `siteConfig.onBrokenMarkdownLinks` to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` per Docusaurus v4 requirements
- Fix `.gitignore` paths for generated API docs (`docs/api/` → `docs/docs/api/`)

## Test plan
- [ ] CI docs build passes without the MDX acorn parse error
- [ ] Deprecation warning for `onBrokenMarkdownLinks` no longer appears
- [ ] Generated Python API page renders correctly with curly braces visible as plain text

https://claude.ai/code/session_01BnnfeiUkebjD6n2AguQKkm