### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-03-25
+
+### Fixed
+
+- VSCode extension blank screen when opening .gro files
+- MDX brace escaping in generated API documentation
+- Migrate `onBrokenMarkdownLinks` config from VitePress to Docusaurus
+- Remove old VitePress documentation remnants
+
 ## [0.6.0] - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,14 +69,14 @@ dependencies = [
 
 [[package]]
 name = "megane-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "megane-python"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "megane-core",
  "numpy",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "megane-wasm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "js-sys",
  "megane-core",

--- a/crates/megane-core/Cargo.toml
+++ b/crates/megane-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megane-core"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Core molecular structure parsers (PDB, GRO, XYZ, MOL, CIF, LAMMPS, XTC, .traj)"
 authors = ["hodakamori"]

--- a/crates/megane-python/Cargo.toml
+++ b/crates/megane-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megane-python"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "PyO3 Python bindings for megane molecular parsers"
 authors = ["hodakamori"]

--- a/crates/megane-wasm/Cargo.toml
+++ b/crates/megane-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megane-wasm"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "WASM bindings for megane molecular viewer"
 authors = ["hodakamori"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "megane-viewer",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "megane-viewer",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "megane-viewer",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "description": "A fast, beautiful molecular viewer – anywidget-compatible",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "megane"
-version = "0.6.0"
+version = "0.6.1"
 description = "A fast, beautiful molecular viewer"
 requires-python = ">=3.10"
 license = "MIT"
@@ -85,7 +85,7 @@ show_missing = true
 skip_empty = true
 
 [tool.bumpversion]
-current_version = "0.6.0"
+current_version = "0.6.1"
 commit = false
 tag = false
 allow_dirty = true

--- a/python/megane/__init__.py
+++ b/python/megane/__init__.py
@@ -45,4 +45,4 @@ __all__ = [
     "view",
     "view_traj",
 ]
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/vscode-megane/package-lock.json
+++ b/vscode-megane/package-lock.json
@@ -2815,7 +2815,7 @@
       }
     },
     "node_modules/deep-extend": {
-      "version": "0.6.1",
+      "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,

--- a/vscode-megane/package-lock.json
+++ b/vscode-megane/package-lock.json
@@ -5622,7 +5622,7 @@
       }
     },
     "node_modules/tunnel-agent": {
-      "version": "0.6.1",
+      "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,

--- a/vscode-megane/package-lock.json
+++ b/vscode-megane/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-megane",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-megane",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@xyflow/react": "^12.0.0",
@@ -2815,7 +2815,7 @@
       }
     },
     "node_modules/deep-extend": {
-      "version": "0.6.0",
+      "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
@@ -5622,7 +5622,7 @@
       }
     },
     "node_modules/tunnel-agent": {
-      "version": "0.6.0",
+      "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,

--- a/vscode-megane/package.json
+++ b/vscode-megane/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-megane",
   "displayName": "megane - Molecular Viewer",
   "description": "View molecular structure files (PDB, GRO, XYZ, MOL, SDF) with megane",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "publisher": "hodakamori",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- Bump version from 0.6.0 to 0.6.1 (patch release — bug fixes only)
- Update CHANGELOG.md with v0.6.1 Fixed entries

## Changes since v0.6.0

- Fix VSCode extension blank screen when opening .gro files (#262)
- Fix MDX brace escaping in generated API documentation (#261)
- Migrate `onBrokenMarkdownLinks` config from VitePress to Docusaurus (#261)
- Remove old VitePress documentation remnants (#260)

## After merging

Create and push the release tag to trigger publish workflows:

```bash
git tag v0.6.1
git push origin v0.6.1
```

https://claude.ai/code/session_01SzNuHhSvf8LGFXsRR7HPhA