### PR TITLE
Simplify default pipeline to match Molecule template

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -123,7 +123,6 @@ function App() {
   useEffect(() => {
     (async () => {
       await ds.local.loadText(defaultPDB);
-      ds.local.loadDemoVectors();
       // Load demo trajectory
       const resp = await fetch(defaultXtcUrl);
       const blob = await resp.blob();

--- a/src/pipeline/defaults.ts
+++ b/src/pipeline/defaults.ts
@@ -6,12 +6,9 @@ import type { Node, Edge } from "@xyflow/react";
 import type { PipelineNodeData } from "./execute";
 
 /**
- * Create the default pipeline: caffeine + semi-transparent water solvent.
- * LoadStructure → Filter(caffeine) → Modify(scale) → Viewport
- *              → Filter(water) → Modify(opacity) → Viewport
- *              → AddBond → Viewport
+ * Create the default pipeline: caffeine with bonds and trajectory.
+ * LoadStructure → AddBond → Viewport
  *              → LoadTrajectory → Viewport
- * Filter(caffeine) → LabelGenerator(element) → Viewport
  */
 export function createDefaultPipeline(): {
   nodes: Node<PipelineNodeData>[];
@@ -19,7 +16,6 @@ export function createDefaultPipeline(): {
 } {
   return {
     nodes: [
-      // Row 0: Source
       {
         id: "loader-1",
         type: "load_structure",
@@ -34,11 +30,10 @@ export function createDefaultPipeline(): {
           enabled: true,
         },
       },
-      // Row 1: Data loading & filtering
       {
         id: "traj-1",
         type: "load_trajectory",
-        position: { x: -85, y: 310 },
+        position: { x: 85, y: 310 },
         data: {
           params: {
             type: "load_trajectory",
@@ -50,7 +45,7 @@ export function createDefaultPipeline(): {
       {
         id: "addbond-1",
         type: "add_bond",
-        position: { x: 255, y: 310 },
+        position: { x: 425, y: 310 },
         data: {
           params: {
             type: "add_bond",
@@ -60,99 +55,9 @@ export function createDefaultPipeline(): {
         },
       },
       {
-        id: "filter-caf",
-        type: "filter",
-        position: { x: 595, y: 310 },
-        data: {
-          params: {
-            type: "filter",
-            query: "index < 24",
-          },
-          enabled: true,
-        },
-      },
-      {
-        id: "filter-sol",
-        type: "filter",
-        position: { x: 935, y: 310 },
-        data: {
-          params: {
-            type: "filter",
-            query: "index >= 24",
-          },
-          enabled: true,
-        },
-      },
-      // Row 2: Processing (labels, modify)
-      {
-        id: "labels-1",
-        type: "label_generator",
-        position: { x: 425, y: 615 },
-        data: {
-          params: {
-            type: "label_generator",
-            source: "element",
-          },
-          enabled: true,
-        },
-      },
-      {
-        id: "modify-caf",
-        type: "modify",
-        position: { x: 680, y: 615 },
-        data: {
-          params: {
-            type: "modify",
-            scale: 1.3,
-            opacity: 1.0,
-          },
-          enabled: true,
-        },
-      },
-      {
-        id: "modify-sol",
-        type: "modify",
-        position: { x: 970, y: 615 },
-        data: {
-          params: {
-            type: "modify",
-            scale: 1.0,
-            opacity: 0.15,
-          },
-          enabled: true,
-        },
-      },
-      {
-        id: "filter-bond-sol",
-        type: "filter",
-        position: { x: 255, y: 615 },
-        data: {
-          params: {
-            type: "filter",
-            query: "",
-            bond_query: "both atom_index >= 24",
-          },
-          enabled: true,
-        },
-      },
-      {
-        id: "modify-bond-sol",
-        type: "modify",
-        position: { x: 255, y: 920 },
-        data: {
-          params: {
-            type: "modify",
-            scale: 1.0,
-            opacity: 0.15,
-          },
-          enabled: true,
-        },
-      },
-      // Row 3: Sink
-      {
         id: "viewport-1",
         type: "viewport",
-        position: { x: 510, y: 920 },
+        position: { x: 425, y: 615 },
         data: {
           params: {
             type: "viewport",
@@ -168,107 +73,44 @@ export function createDefaultPipeline(): {
       {
         id: "e1",
         source: "loader-1",
-        target: "filter-caf",
-        sourceHandle: "particle",
-        targetHandle: "in",
-      },
-      {
-        id: "e2",
-        source: "loader-1",
-        target: "filter-sol",
-        sourceHandle: "particle",
-        targetHandle: "in",
-      },
-      {
-        id: "e3",
-        source: "filter-caf",
-        target: "modify-caf",
-        sourceHandle: "out",
-        targetHandle: "in",
-      },
-      {
-        id: "e4",
-        source: "filter-sol",
-        target: "modify-sol",
-        sourceHandle: "out",
-        targetHandle: "in",
-      },
-      {
-        id: "e5",
-        source: "modify-sol",
-        target: "viewport-1",
-        sourceHandle: "out",
-        targetHandle: "particle",
-      },
-      {
-        id: "e6",
-        source: "loader-1",
         target: "addbond-1",
         sourceHandle: "particle",
         targetHandle: "particle",
       },
       {
-        id: "e7",
-        source: "addbond-1",
-        target: "filter-bond-sol",
-        sourceHandle: "bond",
-        targetHandle: "in",
-      },
-      {
-        id: "e7b",
-        source: "filter-bond-sol",
-        target: "modify-bond-sol",
-        sourceHandle: "out",
-        targetHandle: "in",
-      },
-      {
-        id: "e7c",
-        source: "modify-bond-sol",
-        target: "viewport-1",
-        sourceHandle: "out",
-        targetHandle: "bond",
-      },
-      {
-        id: "e8",
-        source: "loader-1",
-        target: "viewport-1",
-        sourceHandle: "cell",
-        targetHandle: "cell",
-      },
-      {
-        id: "e9",
+        id: "e2",
         source: "loader-1",
         target: "traj-1",
         sourceHandle: "particle",
         targetHandle: "particle",
       },
       {
-        id: "e10",
+        id: "e3",
+        source: "loader-1",
+        target: "viewport-1",
+        sourceHandle: "particle",
+        targetHandle: "particle",
+      },
+      {
+        id: "e4",
+        source: "loader-1",
+        target: "viewport-1",
+        sourceHandle: "cell",
+        targetHandle: "cell",
+      },
+      {
+        id: "e5",
+        source: "addbond-1",
+        target: "viewport-1",
+        sourceHandle: "bond",
+        targetHandle: "bond",
+      },
+      {
+        id: "e6",
         source: "traj-1",
         target: "viewport-1",
         sourceHandle: "trajectory",
         targetHandle: "trajectory",
-      },
-      {
-        id: "e11",
-        source: "modify-caf",
-        target: "viewport-1",
-        sourceHandle: "out",
-        targetHandle: "particle",
-      },
-      {
-        id: "e12",
-        source: "filter-caf",
-        target: "labels-1",
-        sourceHandle: "out",
-        targetHandle: "particle",
-      },
-      {
-        id: "e13",
-        source: "labels-1",
-        target: "viewport-1",
-        sourceHandle: "label",
-        targetHandle: "label",
       },
     ],
   };


### PR DESCRIPTION
## Summary
- Replace the complex default pipeline (caffeine/water filtering, opacity modifications, element labels, solvent bond filtering) with the simpler Molecule template layout: `LoadStructure → AddBond → Viewport` + `LoadTrajectory → Viewport`
- Reduces 11 nodes / 13 edges down to 4 nodes / 6 edges
- Remove unused `loadDemoVectors()` call on startup

## Test plan
- [x] All 319 TypeScript tests pass
- [ ] Open demo site and verify caffeine renders with bonds and trajectory animation
- [ ] Select "Molecule" template from dropdown and confirm it looks the same as the new default

https://claude.ai/code/session_01Pza8syoPJjHrQ5MmFLJkK4