### PR TITLE
Unify pipeline toolbar buttons to show both icon and text

### DIFF
--- a/src/components/CollapsiblePanel.tsx
+++ b/src/components/CollapsiblePanel.tsx
@@ -116,7 +116,15 @@ export function CollapsiblePanel({
       {containerExtra}
       <div style={panelHeaderStyle}>
         <span style={panelTitleStyle}>{title}</span>
-        <div style={{ display: "flex", alignItems: "center", gap: 8, position: "relative", flexWrap: "wrap" }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            position: "relative",
+            flexWrap: "wrap",
+          }}
+        >
           {headerExtra}
           <button onClick={onToggleCollapse} style={collapseButtonStyle} title="Collapse panel">
             &#9654;

--- a/src/components/CollapsiblePanel.tsx
+++ b/src/components/CollapsiblePanel.tsx
@@ -116,7 +116,7 @@ export function CollapsiblePanel({
       {containerExtra}
       <div style={panelHeaderStyle}>
         <span style={panelTitleStyle}>{title}</span>
-        <div style={{ display: "flex", alignItems: "center", gap: 8, position: "relative" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, position: "relative", flexWrap: "wrap" }}>
           {headerExtra}
           <button onClick={onToggleCollapse} style={collapseButtonStyle} title="Collapse panel">
             &#9654;

--- a/src/components/PipelineEditor.tsx
+++ b/src/components/PipelineEditor.tsx
@@ -334,7 +334,6 @@ const textBtnBase: React.CSSProperties = {
   whiteSpace: "nowrap",
 };
 
-
 const addBtnStyle: React.CSSProperties = {
   ...textBtnBase,
   background: "rgba(59, 130, 246, 0.08)",

--- a/src/components/PipelineEditor.tsx
+++ b/src/components/PipelineEditor.tsx
@@ -331,19 +331,9 @@ const textBtnBase: React.CSSProperties = {
   display: "flex",
   alignItems: "center",
   gap: 4,
+  whiteSpace: "nowrap",
 };
 
-/** Shared base for icon-only buttons */
-const iconOnlyBtnBase: React.CSSProperties = {
-  borderRadius: 6,
-  padding: "5px 8px",
-  cursor: "pointer",
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  lineHeight: 1,
-  border: "none",
-};
 
 const addBtnStyle: React.CSSProperties = {
   ...textBtnBase,
@@ -367,21 +357,21 @@ const templateBtnStyle: React.CSSProperties = {
 };
 
 const layoutIconBtnStyle: React.CSSProperties = {
-  ...iconOnlyBtnBase,
+  ...textBtnBase,
   background: "rgba(16, 185, 129, 0.08)",
   border: "1px solid rgba(16, 185, 129, 0.25)",
   color: "#10b981",
 };
 
 const exportIconBtnStyle: React.CSSProperties = {
-  ...iconOnlyBtnBase,
+  ...textBtnBase,
   background: "rgba(6, 182, 212, 0.08)",
   border: "1px solid rgba(6, 182, 212, 0.25)",
   color: "#06b6d4",
 };
 
 const importIconBtnStyle: React.CSSProperties = {
-  ...iconOnlyBtnBase,
+  ...textBtnBase,
   background: "rgba(99, 102, 241, 0.08)",
   border: "1px solid rgba(99, 102, 241, 0.25)",
   color: "#6366f1",
@@ -659,7 +649,7 @@ function PipelineEditorInner({
         title="Auto Layout"
         aria-label="Auto Layout"
       >
-        {IconLayout}
+        {IconLayout} Layout
       </button>
       <button
         onClick={handleExport}
@@ -667,7 +657,7 @@ function PipelineEditorInner({
         title="Export Pipeline"
         aria-label="Export Pipeline"
       >
-        {IconExport}
+        {IconExport} Export
       </button>
       <button
         onClick={handleImportClick}
@@ -675,7 +665,7 @@ function PipelineEditorInner({
         title="Import Pipeline"
         aria-label="Import Pipeline"
       >
-        {IconImport}
+        {IconImport} Import
       </button>
 
       <div style={toolbarSepStyle} />

--- a/src/components/PipelineEditor.tsx
+++ b/src/components/PipelineEditor.tsx
@@ -355,21 +355,21 @@ const templateBtnStyle: React.CSSProperties = {
   color: "#8b5cf6",
 };
 
-const layoutIconBtnStyle: React.CSSProperties = {
+const layoutBtnStyle: React.CSSProperties = {
   ...textBtnBase,
   background: "rgba(16, 185, 129, 0.08)",
   border: "1px solid rgba(16, 185, 129, 0.25)",
   color: "#10b981",
 };
 
-const exportIconBtnStyle: React.CSSProperties = {
+const exportBtnStyle: React.CSSProperties = {
   ...textBtnBase,
   background: "rgba(6, 182, 212, 0.08)",
   border: "1px solid rgba(6, 182, 212, 0.25)",
   color: "#06b6d4",
 };
 
-const importIconBtnStyle: React.CSSProperties = {
+const importBtnStyle: React.CSSProperties = {
   ...textBtnBase,
   background: "rgba(99, 102, 241, 0.08)",
   border: "1px solid rgba(99, 102, 241, 0.25)",
@@ -641,10 +641,10 @@ function PipelineEditorInner({
 
       <div style={toolbarSepStyle} />
 
-      {/* Group 2: Layout & IO (icon-only) */}
+      {/* Group 2: Layout & IO */}
       <button
         onClick={handleAutoLayout}
-        style={layoutIconBtnStyle}
+        style={layoutBtnStyle}
         title="Auto Layout"
         aria-label="Auto Layout"
       >
@@ -652,7 +652,7 @@ function PipelineEditorInner({
       </button>
       <button
         onClick={handleExport}
-        style={exportIconBtnStyle}
+        style={exportBtnStyle}
         title="Export Pipeline"
         aria-label="Export Pipeline"
       >
@@ -660,7 +660,7 @@ function PipelineEditorInner({
       </button>
       <button
         onClick={handleImportClick}
-        style={importIconBtnStyle}
+        style={importBtnStyle}
         title="Import Pipeline"
         aria-label="Import Pipeline"
       >
@@ -670,73 +670,77 @@ function PipelineEditorInner({
       <div style={toolbarSepStyle} />
 
       {/* Group 3: Templates & Add Node */}
-      <button
-        onClick={() => {
-          setShowTemplateMenu(!showTemplateMenu);
-          setShowAddMenu(false);
-        }}
-        style={templateBtnStyle}
-        title="Templates"
-      >
-        {IconTemplates} Templates
-      </button>
-      {showTemplateMenu && (
-        <div style={{ ...dropdownStyle, right: "auto", left: 0 }}>
-          {PIPELINE_TEMPLATES.map((template) => (
-            <button
-              key={template.id}
-              onClick={() => handleApplyTemplate(template.id)}
-              style={{ ...dropdownItemStyle, padding: "8px 14px" }}
-              onMouseEnter={(e) => {
-                (e.target as HTMLElement).style.background = "rgba(139,92,246,0.06)";
-              }}
-              onMouseLeave={(e) => {
-                (e.target as HTMLElement).style.background = "none";
-              }}
-            >
-              <div style={{ fontWeight: 500 }}>{template.label}</div>
-              <div style={templateItemDescStyle}>{template.description}</div>
-            </button>
-          ))}
-        </div>
-      )}
-      <button
-        onClick={() => {
-          setShowAddMenu(!showAddMenu);
-          setShowTemplateMenu(false);
-        }}
-        style={addBtnStyle}
-        title="Add Node"
-      >
-        {IconPlus} Add Node
-      </button>
-      {showAddMenu && (
-        <div style={dropdownStyle}>
-          {ADD_NODE_GROUPS.map((group) => (
-            <div key={group.category}>
-              <div style={{ ...groupHeaderStyle, color: NODE_CATEGORY_COLORS[group.category] }}>
-                {CATEGORY_ICONS[group.category]}
-                <span style={{ color: "#94a3b8" }}>{group.label}</span>
+      <div style={{ position: "relative" }}>
+        <button
+          onClick={() => {
+            setShowTemplateMenu(!showTemplateMenu);
+            setShowAddMenu(false);
+          }}
+          style={templateBtnStyle}
+          title="Templates"
+        >
+          {IconTemplates} Templates
+        </button>
+        {showTemplateMenu && (
+          <div style={{ ...dropdownStyle, right: "auto", left: 0 }}>
+            {PIPELINE_TEMPLATES.map((template) => (
+              <button
+                key={template.id}
+                onClick={() => handleApplyTemplate(template.id)}
+                style={{ ...dropdownItemStyle, padding: "8px 14px" }}
+                onMouseEnter={(e) => {
+                  (e.target as HTMLElement).style.background = "rgba(139,92,246,0.06)";
+                }}
+                onMouseLeave={(e) => {
+                  (e.target as HTMLElement).style.background = "none";
+                }}
+              >
+                <div style={{ fontWeight: 500 }}>{template.label}</div>
+                <div style={templateItemDescStyle}>{template.description}</div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+      <div style={{ position: "relative" }}>
+        <button
+          onClick={() => {
+            setShowAddMenu(!showAddMenu);
+            setShowTemplateMenu(false);
+          }}
+          style={addBtnStyle}
+          title="Add Node"
+        >
+          {IconPlus} Add Node
+        </button>
+        {showAddMenu && (
+          <div style={dropdownStyle}>
+            {ADD_NODE_GROUPS.map((group) => (
+              <div key={group.category}>
+                <div style={{ ...groupHeaderStyle, color: NODE_CATEGORY_COLORS[group.category] }}>
+                  {CATEGORY_ICONS[group.category]}
+                  <span style={{ color: "#94a3b8" }}>{group.label}</span>
+                </div>
+                {group.types.map((type) => (
+                  <button
+                    key={type}
+                    onClick={() => handleAddNode(type)}
+                    style={dropdownItemStyle}
+                    onMouseEnter={(e) => {
+                      (e.target as HTMLElement).style.background = "rgba(59,130,246,0.06)";
+                    }}
+                    onMouseLeave={(e) => {
+                      (e.target as HTMLElement).style.background = "none";
+                    }}
+                  >
+                    {NODE_TYPE_LABELS[type]}
+                  </button>
+                ))}
               </div>
-              {group.types.map((type) => (
-                <button
-                  key={type}
-                  onClick={() => handleAddNode(type)}
-                  style={dropdownItemStyle}
-                  onMouseEnter={(e) => {
-                    (e.target as HTMLElement).style.background = "rgba(59,130,246,0.06)";
-                  }}
-                  onMouseLeave={(e) => {
-                    (e.target as HTMLElement).style.background = "none";
-                  }}
-                >
-                  {NODE_TYPE_LABELS[type]}
-                </button>
-              ))}
-            </div>
-          ))}
-        </div>
-      )}
+            ))}
+          </div>
+        )}
+      </div>
     </>
   );
 


### PR DESCRIPTION
## Summary
- **Layout**, **Export**, **Import** buttons now display both icon and text, matching **Render**, **Templates**, and **Add Node** buttons
- Added `whiteSpace: "nowrap"` to prevent text wrapping within individual buttons
- Added `flexWrap: "wrap"` to the toolbar container so buttons can flow to multiple rows when space is limited
- Removed unused `iconOnlyBtnBase` style

## Test plan
- [x] All 319 TypeScript unit tests pass
- [ ] Visually confirm all 6 toolbar buttons show icon + text
- [ ] Verify buttons wrap to multiple rows on narrow panels without internal line breaks

https://claude.ai/code/session_01QWZfZXrPqjSaeKXqFqRjxS