### PR TITLE
feat: add GROMACS .top topology file loading to AddBond node

### DIFF
--- a/src/components/nodes/AddBondNode.tsx
+++ b/src/components/nodes/AddBondNode.tsx
@@ -1,7 +1,7 @@
 /**
  * Add Bond node.
  * Takes particle input and outputs bond data.
- * Supports bond sources: structure (from file), VDW (distance-based), file (topology).
+ * Supports bond sources: structure (from file), VDW (distance-based), topology file (.top).
  */
 
 import type { NodeProps, Node } from "@xyflow/react";
@@ -9,8 +9,10 @@ import type { PipelineNodeData } from "../../pipeline/execute";
 import type { AddBondParams } from "../../pipeline/types";
 import { usePipelineStore } from "../../pipeline/store";
 import { NodeShell } from "./NodeShell";
-import { TabSelector } from "../ui";
+import { TabSelector, smallBtnStyle, fileNameStyle } from "../ui";
+import { parseTopBonds } from "../../parsers/structure";
 import type { BondSource } from "../../types";
+import { useRef, useCallback } from "react";
 
 const sectionLabelStyle: React.CSSProperties = {
   fontSize: 17,
@@ -22,9 +24,29 @@ const sectionLabelStyle: React.CSSProperties = {
   marginTop: 0,
 };
 
+const TOPOLOGY_ACCEPT = ".top";
+const TOPOLOGY_EXTS = [".top"];
+
 export function AddBondNode({ id, data }: NodeProps<Node<PipelineNodeData>>) {
   const updateNodeParams = usePipelineStore((s) => s.updateNodeParams);
   const params = data.params as AddBondParams;
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleTopologyFile = useCallback(
+    async (file: File) => {
+      const lower = file.name.toLowerCase();
+      if (!TOPOLOGY_EXTS.some((ext) => lower.endsWith(ext))) return;
+      const text = await file.text();
+      // Parse with max n_atoms; executor filters to actual atom count
+      const bondIndices = await parseTopBonds(text, 0xffffffff);
+      updateNodeParams(id, {
+        bondSource: "file" as BondSource,
+        bondFileName: file.name,
+        bondFileData: bondIndices,
+      });
+    },
+    [id, updateNodeParams],
+  );
 
   return (
     <NodeShell id={id} nodeType="add_bond" enabled={data.enabled}>
@@ -33,10 +55,39 @@ export function AddBondNode({ id, data }: NodeProps<Node<PipelineNodeData>>) {
         options={[
           { value: "structure", label: "File" },
           { value: "distance", label: "VDW" },
+          { value: "file", label: "Topology" },
         ]}
         value={params.bondSource}
         onChange={(v) => updateNodeParams(id, { bondSource: v })}
       />
+      {params.bondSource === "file" && (
+        <div style={{ marginTop: 4 }}>
+          {params.bondFileName ? (
+            <div style={{ ...fileNameStyle, fontSize: 18 }}>{params.bondFileName}</div>
+          ) : (
+            <div style={{ fontSize: 18, color: "#94a3b8", fontStyle: "italic" }}>
+              No topology loaded
+            </div>
+          )}
+          <button
+            onClick={() => inputRef.current?.click()}
+            style={{ ...smallBtnStyle, marginTop: 6, width: "100%" }}
+          >
+            Load .top...
+          </button>
+          <input
+            ref={inputRef}
+            type="file"
+            accept={TOPOLOGY_ACCEPT}
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) handleTopologyFile(file);
+              e.target.value = "";
+            }}
+            style={{ display: "none" }}
+          />
+        </div>
+      )}
     </NodeShell>
   );
 }

--- a/src/pipeline/builder.ts
+++ b/src/pipeline/builder.ts
@@ -275,9 +275,9 @@ export class AddBonds extends PipelineNode {
   protected readonly _outPorts = { bond: "bond" };
   protected readonly _inpPorts = { particle: "particle" };
 
-  public source: "distance" | "structure";
+  public source: "distance" | "structure" | "file";
 
-  constructor({ source = "distance" }: { source?: "distance" | "structure" } = {}) {
+  constructor({ source = "distance" }: { source?: "distance" | "structure" | "file" } = {}) {
     super();
     this.source = source;
   }

--- a/src/pipeline/executors/addBond.ts
+++ b/src/pipeline/executors/addBond.ts
@@ -236,6 +236,59 @@ export function executeAddBond(
         outputs.set("bond", bond);
       }
     }
+  } else if (params.bondSource === "file") {
+    const raw = params.bondFileData;
+    if (raw && raw.length >= 2) {
+      // Filter bond indices to valid atom range
+      const nAtoms = snapshot.nAtoms;
+      const validPairs: number[] = [];
+      for (let i = 0; i < raw.length; i += 2) {
+        const a = raw[i];
+        const b = raw[i + 1];
+        if (a < nAtoms && b < nAtoms) {
+          validPairs.push(a, b);
+        }
+      }
+      let bondIndices = new Uint32Array(validPairs);
+      let nBonds = bondIndices.length / 2;
+
+      if (nBonds > 0) {
+        let extPositions: Float32Array | null = null;
+        let extElements: Uint8Array | null = null;
+        let extNAtoms = 0;
+
+        const result = processPbcBonds(
+          bondIndices,
+          null,
+          snapshot.positions,
+          snapshot.elements,
+          snapshot.nAtoms,
+          snapshot.box,
+        );
+        bondIndices = result.bondIndices;
+        nBonds = result.nBonds;
+        extPositions = result.positions;
+        extElements = result.elements;
+        extNAtoms = result.nAtoms;
+
+        const bond: BondData = {
+          type: "bond",
+          sourceNodeId: particleData.sourceNodeId,
+          bondIndices,
+          bondOrders: null,
+          nBonds,
+          scale: 1.0,
+          opacity: 1.0,
+          positions: extPositions,
+          elements: extElements,
+          nAtoms: extNAtoms,
+          atomElements: snapshot.elements,
+          selectedBondIndices: null,
+          bondOpacityOverrides: null,
+        };
+        outputs.set("bond", bond);
+      }
+    }
   } else if (params.bondSource === "distance") {
     let bondIndices = inferBondsVdwJS(
       snapshot.positions,

--- a/src/pipeline/executors/addBond.ts
+++ b/src/pipeline/executors/addBond.ts
@@ -249,7 +249,7 @@ export function executeAddBond(
           validPairs.push(a, b);
         }
       }
-      let bondIndices = new Uint32Array(validPairs);
+      let bondIndices: Uint32Array = new Uint32Array(validPairs);
       let nBonds = bondIndices.length / 2;
 
       if (nBonds > 0) {

--- a/src/pipeline/serialize.ts
+++ b/src/pipeline/serialize.ts
@@ -25,6 +25,12 @@ const VALID_NODE_TYPES: Set<string> = new Set([
 /**
  * Serialize xyflow nodes and edges into the portable JSON format.
  */
+/** Strip ephemeral (non-serializable) fields from node params. */
+function cleanParams(params: Record<string, unknown>): Record<string, unknown> {
+  const { bondFileData, ...rest } = params;
+  return rest;
+}
+
 export function serializePipeline(
   nodes: Node<PipelineNodeData>[],
   edges: Edge[],
@@ -32,7 +38,7 @@ export function serializePipeline(
   return {
     version: 3,
     nodes: nodes.map((n) => ({
-      ...n.data.params,
+      ...cleanParams(n.data.params as unknown as Record<string, unknown>),
       id: n.id,
       position: n.position,
       enabled: n.data.enabled,

--- a/src/pipeline/serialize.ts
+++ b/src/pipeline/serialize.ts
@@ -25,24 +25,24 @@ const VALID_NODE_TYPES: Set<string> = new Set([
 /**
  * Serialize xyflow nodes and edges into the portable JSON format.
  */
-/** Strip ephemeral (non-serializable) fields from node params. */
-function cleanParams(params: Record<string, unknown>): Record<string, unknown> {
-  const { bondFileData, ...rest } = params;
-  return rest;
-}
-
 export function serializePipeline(
   nodes: Node<PipelineNodeData>[],
   edges: Edge[],
 ): SerializedPipeline {
   return {
     version: 3,
-    nodes: nodes.map((n) => ({
-      ...cleanParams(n.data.params as unknown as Record<string, unknown>),
-      id: n.id,
-      position: n.position,
-      enabled: n.data.enabled,
-    })),
+    nodes: nodes.map((n) => {
+      // Strip ephemeral (non-serializable) fields from params
+      const { bondFileData, ...params } = n.data.params as typeof n.data.params & {
+        bondFileData?: unknown;
+      };
+      return {
+        ...params,
+        id: n.id,
+        position: n.position,
+        enabled: n.data.enabled,
+      };
+    }),
     edges: edges.map((e) => ({
       source: e.source,
       target: e.target,

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -329,6 +329,9 @@ export interface StreamingParams {
 export interface AddBondParams {
   type: "add_bond";
   bondSource: BondSource;
+  bondFileName?: string | null;
+  /** Ephemeral: parsed bond indices from topology file. Not serialized. */
+  bondFileData?: Uint32Array | null;
 }
 
 export interface ViewportParams {


### PR DESCRIPTION
## Summary

- Add a "Topology" tab to the AddBond pipeline node for loading bond connectivity from GROMACS `.top` topology files
- Wire the existing Rust `parse_top_bonds` parser (already exposed via WASM) into the pipeline execution engine
- Bond indices from the `.top` file are validated against the actual atom count at execution time, with full PBC ghost-atom support

## Changes

- **`src/pipeline/types.ts`**: Extend `AddBondParams` with `bondFileName` and `bondFileData` fields
- **`src/pipeline/executors/addBond.ts`**: Handle `bondSource === "file"` with atom index filtering and PBC processing
- **`src/components/nodes/AddBondNode.tsx`**: Add "Topology" tab with `.top` file picker UI
- **`src/pipeline/serialize.ts`**: Exclude ephemeral `bondFileData` (Uint32Array) from pipeline JSON serialization
- **`src/pipeline/builder.ts`**: Support `"file"` source option in `AddBonds` builder class

## Test plan

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] All 319 TypeScript tests pass (`vitest run`)
- [x] All 75 Rust parser tests pass (`cargo test -p megane-core`)
- [ ] Manual: load a structure (e.g. `.gro`), switch AddBond to "Topology", upload a matching `.top` file, verify bonds render correctly
- [ ] Manual: verify bonds crossing PBC boundaries display as half-bonds with ghost atoms
- [ ] Manual: verify "File" (structure) and "VDW" tabs still work as before

https://claude.ai/code/session_019gct9f7jdJoUtKC9DxLc3T