### PR TITLE
docs: add per-platform compatibility reference page

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ One codebase, every environment.
 | **React** | `<MeganeViewer />` component | `npm install megane-viewer` |
 | **VSCode** | Custom editor for .pdb, .gro, .xyz, .mol, .sdf, .cif | Extension |
 
+For a per-platform breakdown of supported formats and UI features (including known gaps), see [Platform Support](https://hodakamori.github.io/megane/platform-support).
+
 The secret: PDB, GRO, XYZ, MOL, CIF, XTC, LAMMPS, and ASE .traj parsers are written in **Rust** and compiled to both **PyO3** (Python) and **WASM** (browser). Parse once, run anywhere.
 
 ### Visual Pipelines

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ One codebase, every environment.
 | **JupyterLab** | Open .pdb, .gro, .xyz, .mol, .sdf, .cif from the file browser | `pip install megane` |
 | **Browser** | `megane serve` local server | `pip install megane` |
 | **React** | `<MeganeViewer />` component | `npm install megane-viewer` |
-| **VSCode** | Custom editor for .pdb, .gro, .xyz, .mol, .sdf, .cif | Extension |
+| **VSCode** | Custom editor for .pdb, .gro, .xyz, .mol, .sdf | Extension |
 
 For a per-platform breakdown of supported formats and UI features (including known gaps), see [Platform Support](https://hodakamori.github.io/megane/platform-support).
 

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -23,6 +23,8 @@ sidebar_position: 1
 | **CLI (Docker)** | `docker pull hodakamori/megane` | [CLI Guide](./guide/cli) |
 | **VSCode** | Install the megane extension | [Pipeline Editor](./guide/pipeline/index) |
 
+For a side-by-side comparison of which formats and UI features each environment supports — including known gaps — see [Platform Support](./platform-support).
+
 ## Supported file formats
 
 | Format | Extension |

--- a/docs/docs/platform-support.md
+++ b/docs/docs/platform-support.md
@@ -1,0 +1,91 @@
+---
+sidebar_position: 5
+---
+
+# Platform Support
+
+megane ships in five distributions. They share the same Rust parser core (compiled to WASM and PyO3), but the host UI and the set of registered file types differ. This page is the single reference for **what works on which platform**, and it is descriptive of the current state — including known gaps.
+
+## Platforms
+
+| Platform | Entry | What it is |
+|---|---|---|
+| **Standalone web app** | `src/index.tsx`, served by `megane serve` | Full-featured viewer with pipeline editor, drag-and-drop, file dialogs, and WebSocket trajectory streaming. |
+| **Jupyter widget** (anywidget) | `src/widget.ts` + `python/megane/widget.py` | Embedded viewer in a notebook cell, driven by Python (`MolecularViewer`). |
+| **JupyterLab labextension** | `jupyterlab-megane/src/index.ts` | Document-style viewer launched from the JupyterLab file browser. |
+| **VSCode extension** | `vscode-megane/webview/main.tsx` | Custom editor activated when a registered file type is opened in VS Code. |
+| **Python package** (PyO3) | `python/megane/parsers/` | Programmatic API for parsing files into Python objects. No viewer. |
+
+## File-format support
+
+Legend:
+
+- **✓** — openable directly from the platform's native UI (file browser, drag-drop, customEditor, `LoadStructure`/`LoadTrajectory` node, etc.)
+- **API** — parser exists and is reachable programmatically, but the platform does not expose a UI opener for this format
+- **—** — not supported
+
+### Structure formats
+
+| Format | Extensions | Standalone | Jupyter widget | JupyterLab | VSCode | Python |
+|---|---|:---:|:---:|:---:|:---:|:---:|
+| PDB | `.pdb` | ✓ | API | ✓ | ✓ | ✓ |
+| GRO | `.gro` | ✓ | API | ✓ | ✓ | ✓ |
+| XYZ | `.xyz` | ✓ | API | ✓ | ✓ | ✓ |
+| MOL | `.mol` | ✓ | API | ✓ | ✓ | ✓ |
+| SDF | `.sdf` | ✓ | API | ✓ | ✓ | ✓ |
+| CIF | `.cif` | ✓ | API | ✓ | — | ✓ |
+| LAMMPS data | `.data`, `.lammps` | ✓ | API | — | — | ✓ |
+
+### Trajectory formats
+
+| Format | Extensions | Standalone | Jupyter widget | JupyterLab | VSCode | Python |
+|---|---|:---:|:---:|:---:|:---:|:---:|
+| XTC | `.xtc` | ✓ | API | — | — | ✓ |
+| ASE trajectory | `.traj` | ✓ | API | — | — | ✓ |
+| LAMMPS dump | `.lammpstrj`, `.dump` | ✓ | API | — | — | ✓ |
+
+Sources of truth: `crates/megane-wasm/src/lib.rs` (browser parsers), `crates/megane-python/src/lib.rs` (Python parsers), `src/components/nodes/LoadStructureNode.tsx` and `src/components/nodes/LoadTrajectoryNode.tsx` (standalone accept lists), `jupyterlab-megane/src/filetypes.ts` (JupyterLab `IFileType` registrations), `vscode-megane/package.json` (VSCode `customEditors`).
+
+## UI features
+
+| Feature | Standalone | Jupyter widget | JupyterLab | VSCode | Python |
+|---|:---:|:---:|:---:|:---:|:---:|
+| Drag-and-drop into viewer | ✓ | — | — | — | n/a |
+| Built-in file picker | ✓ | — | host | host | n/a |
+| Visual pipeline editor | ✓ | opt-in | — | ✓ (`.megane.json`) | n/a |
+| Trajectory timeline / scrubbing | ✓ | ✓ | — | — | n/a |
+| WebSocket trajectory streaming | ✓ | — | — | — | n/a |
+| Multi-layer rendering | ✓ | ✓ (via pipeline) | — | — | n/a |
+| `frame_change` / `selection_change` / `measurement` events | — | ✓ | — | — | n/a |
+| Programmatic frame seek (`frame_index = N`) | ✓ | ✓ | — | — | n/a |
+
+Notes:
+
+- **host** means the parent app provides the file picker (the JupyterLab file browser, the VS Code explorer); megane itself does not render one.
+- **opt-in** for the widget pipeline editor means it is shown only when the widget is instantiated with `pipeline=True` (see `src/components/WidgetViewer.tsx`).
+- The standalone app is the only platform with `megane serve` WebSocket streaming; other platforms load full trajectories into memory.
+
+## Load methods / APIs
+
+How data gets into the viewer on each platform:
+
+| Platform | Primary load path | API surface |
+|---|---|---|
+| **Standalone** | Drag-and-drop, file dialog, `megane serve <file>`, WebSocket | `parseStructureFile(file)` (TypeScript), pipeline node `LoadStructure` / `LoadTrajectory` |
+| **Jupyter widget** | Python only — no in-cell file picker | `MolecularViewer.load(pdb_path, xtc=, traj=)` (deprecated) or `MolecularViewer.set_pipeline(Pipeline)` (recommended) |
+| **JupyterLab** | Click a registered file type in the file browser | Internally reads `context.model` (`jupyterlab-megane/src/MeganeDocWidget.tsx`) |
+| **VSCode** | Open a registered file from the explorer; extension host posts `loadFile` / `loadPipeline` to the webview | `postMessage({ type: "loadFile", … })` (`vscode-megane/webview/main.tsx`) |
+| **Python** | `from megane.parsers import …` | `load_pdb`, `load_cif`, `load_lammps_data`, `load_traj`, `load_trajectory` (XTC), and the `parse_*` PyO3 functions |
+
+## Known gaps
+
+These are formats or features that the parser layer supports but a given platform does not yet wire into its UI. They are documented here so users do not file bugs against expected-but-absent behaviour.
+
+- **VSCode does not register `.cif`.** The `customEditors` selector lists only `.pdb / .gro / .xyz / .mol / .sdf`. CIF files parse correctly when loaded via WASM, but VS Code will not auto-open them in the megane viewer.
+- **VSCode does not register any trajectory format.** `.xtc`, `.traj`, and `.lammpstrj` cannot be opened via the VS Code custom editor.
+- **VSCode does not register LAMMPS data.** `.data` / `.lammps` cannot be opened via the VS Code custom editor.
+- **JupyterLab does not register any trajectory format.** Only the six structure file types in `jupyterlab-megane/src/filetypes.ts` are registered.
+- **JupyterLab does not register LAMMPS data.** `.data` / `.lammps` is not in the `IFileType` list.
+- **Jupyter widget has no in-cell file picker or drag-and-drop.** This is intentional — the widget is Python-driven. Use `set_pipeline()` with a `Pipeline` to load any supported format.
+- **Jupyter widget pipeline editor is off by default.** It is rendered only when the widget is created with `pipeline=True`.
+- **Plotly / ipywidgets event integration is widget-only.** Other platforms do not emit `frame_change`, `selection_change`, or `measurement` events to a host.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -37,6 +37,7 @@ const sidebars: SidebarsConfig = {
       type: "category",
       label: "Reference",
       items: [
+        "platform-support",
         {
           type: "doc",
           id: "configuration",


### PR DESCRIPTION
## Summary

- Add `docs/docs/platform-support.md` with three matrices (file formats, UI features, load methods/APIs) and a "Known gaps" section comparing the standalone web app, Jupyter widget, JupyterLab labextension, VSCode extension, and Python package.
- Register the new page under the **Reference** category in `docs/sidebars.ts`, and cross-link from `README.md` and `docs/docs/introduction.md`.
- Fix `README.md`: drop `.cif` from the VSCode row in the Anywhere table — `vscode-megane/package.json` `customEditors` only registers `.pdb / .gro / .xyz / .mol / .sdf`.

## Why

The Rust parser core is shared across distributions, but each platform's host UI registers a different set of openers. The existing tables in `README.md` and `docs/docs/introduction.md` listed formats and environments separately, with no single place to look up "is `.cif` openable in VSCode?" — and in fact the README claimed it was when the extension manifest does not register it. This page consolidates the truth and explicitly documents known gaps so users can distinguish parser-level support from UI-level support.

Sources of truth referenced in the new page:
- `crates/megane-wasm/src/lib.rs` — browser parsers
- `crates/megane-python/src/lib.rs` — Python parsers
- `src/components/nodes/LoadStructureNode.tsx`, `LoadTrajectoryNode.tsx` — standalone accept lists
- `jupyterlab-megane/src/filetypes.ts` — JupyterLab `IFileType` registrations
- `vscode-megane/package.json` — VSCode `customEditors` selectors
- `python/megane/widget.py` — anywidget API surface

## Known gaps documented (current state, not a TODO list)

- VSCode does not register `.cif` or any trajectory format (`.xtc`, `.traj`, `.lammpstrj`) or LAMMPS data
- JupyterLab does not register any trajectory format or LAMMPS data
- Jupyter widget has no in-cell file picker / drag-and-drop (Python-driven by design)
- Widget pipeline editor is opt-in (`pipeline=True`)

## Test plan

- [x] `npx docusaurus build` in `docs/` succeeds; new page renders and the Reference sidebar entry appears
- [x] Cross-links from `introduction.md` and `README.md` resolve to the new page
- [ ] Manual visual check on a deployed/preview build (optional — table formatting matches existing pages)

https://claude.ai/code/session_01ULdwrN7G7zX36sY42Tsg6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULdwrN7G7zX36sY42Tsg6Q)_