### PR TITLE
docs: align CLAUDE.md and skills with current implementation

### DIFF
--- a/.claude/skills/e2e-coverage/SKILL.md
+++ b/.claude/skills/e2e-coverage/SKILL.md
@@ -8,7 +8,7 @@ The megane viewer ships through 5 distribution targets. Each one renders the sam
 
 ## CRITICAL: Playwright, NOT Puppeteer
 
-All E2E uses `@playwright/test`. `puppeteer` is in `package.json` but unused. Never invoke Puppeteer.
+All E2E uses `@playwright/test`. `puppeteer` is **not** in `package.json`; only `playwright` 1.56 is installed. Never add or invoke Puppeteer.
 
 E2E is **local-only by policy** — see `.claude/skills/testing/SKILL.md`. CI does not run any E2E project (port-bind races + font-fontconfig pixel drift on hosted runners). Run locally before merging UI-touching PRs.
 
@@ -101,11 +101,13 @@ follow-up.
 Specs that iterate hosts read `MEGANE_HOST=webapp|widget-jupyterlab|widget-vscode|jupyterlab-doc|vscode`. Default = webapp.
 
 ```sh
-# Run measurement on every host:
+# Sweep an existing cross-host-capable spec across every host:
 for host in webapp widget-jupyterlab widget-vscode jupyterlab-doc vscode; do
-  MEGANE_HOST=$host npm run test:e2e:measurement
+  MEGANE_HOST=$host npm run test:e2e:format-loading
 done
 ```
+
+(There is no `test:e2e:measurement` script — measurement coverage was deferred, see the note above.)
 
 ## Run Everything
 

--- a/.claude/skills/post-release/SKILL.md
+++ b/.claude/skills/post-release/SKILL.md
@@ -78,25 +78,29 @@ Verify that the published packages actually work in a clean environment — not 
 
 ### 3.1 Python + npm: widget rendering in fresh virtualenv
 
-Install from PyPI into an isolated virtualenv (no local source files), then run the existing E2E widget test against it. This covers both the Python package (PyO3 native extension, parsers) and the npm package (megane-viewer WASM loaded by anywidget in the browser).
+Install from PyPI into an isolated virtualenv (no local source files), then run the Playwright `widget-jupyterlab` project against it. This covers both the Python package (PyO3 native extension, parsers) and the npm package (megane-viewer WASM loaded by anywidget in the browser).
 
 ```bash
 # Create isolated virtualenv and install from PyPI only
 VENV=/tmp/megane-verify-X.Y.Z
 python -m venv $VENV
-$VENV/bin/pip install megane==X.Y.Z jupyterlab
+$VENV/bin/pip install "megane==X.Y.Z" jupyterlab
 
-# Run the widget E2E test using the PyPI-installed megane
-# PATH override ensures local dev installation is NOT used
-PATH=$VENV/bin:$PATH node tests/e2e/test_widget_render.mjs
+# Make sure local Playwright project deps are present
+npm ci
+npx playwright install chromium
+
+# Run the widget E2E project against the PyPI-installed megane.
+# PATH override ensures the venv `python`/`jupyter` are used, not the local dev install.
+PATH=$VENV/bin:$PATH MEGANE_E2E_MODE=1 npm run test:e2e:widget-jupyterlab
 ```
 
-Expected: all assertions pass — canvas created, non-white pixels rendered (atoms visible), no critical JS errors. Screenshots saved to `tests/e2e/screenshot_1crn.png` and `tests/e2e/screenshot_water_100k.png`.
+Expected: all `widget-jupyterlab` specs pass. Pixel diffs against `tests/e2e/baselines/widget-jupyterlab/` succeed (or are written fresh on first run). On failure, inspect `<name>.diff.png` / `<name>.new.png` next to the baseline.
 
 This test verifies:
-- PyPI install succeeds and PyO3 native extension loads
-- megane-viewer (npm) WASM is bundled correctly and loads in browser
-- Molecule rendering pipeline works end-to-end
+- PyPI install succeeds and the PyO3 native extension loads
+- `megane-viewer` (npm) WASM is bundled correctly and loads in the browser
+- The anywidget rendering pipeline works end-to-end inside JupyterLab
 
 ### 3.2 VS Code extension: rendering via code-server
 
@@ -204,14 +208,17 @@ EOF
 
 ### 4.4 Upload rendering verification screenshots
 
-Attach the screenshots captured in Phase 3 to the release as visual proof that rendering works correctly after install.
+Attach a small set of Phase 3 visual artefacts to the release as proof that rendering works after install.
+
+The Phase 3.1 Playwright run drops baselines/diffs under `tests/e2e/baselines/widget-jupyterlab/`. Pick one representative full-page baseline (e.g. `default.png`) plus the VSCode rendering screenshot from Phase 3.2:
 
 ```bash
 gh release upload vX.Y.Z \
-  tests/e2e/screenshot_1crn.png \
-  tests/e2e/screenshot_water_100k.png \
+  tests/e2e/baselines/widget-jupyterlab/default.png \
   tests/e2e/screenshot_vscode_render.png
 ```
+
+If you want a hero capture in addition to the baselines, run `node scripts/capture-screenshots.mjs` and upload `docs/public/screenshots/hero.png`.
 
 ### 4.5 Confirm the draft is ready
 ```bash
@@ -267,7 +274,7 @@ Once all phases are complete, the release is done. Key verification:
 | All CI workflows | `gh run list --limit 10` (with remote swap) |
 | PyPI version | `pip index versions megane` |
 | npm version | `npm view megane-viewer@X.Y.Z version` |
-| Python + npm rendering (clean venv) | Phase 3.1: install from PyPI → `node tests/e2e/test_widget_render.mjs` |
+| Python + npm rendering (clean venv) | Phase 3.1: install from PyPI → `PATH=$VENV/bin:$PATH MEGANE_E2E_MODE=1 npm run test:e2e:widget-jupyterlab` |
 | VS Code rendering (code-server) | `node tests/e2e/test_vscode_render.mjs X.Y.Z` |
 | Release notes + screenshots uploaded | `gh release view vX.Y.Z` (with remote swap) |
 | Docs site updated | `gh run list --workflow=docs.yml` (with remote swap) |

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -8,11 +8,16 @@ description: Run tests for megane. Covers TypeScript, Rust, Python, and E2E test
 
 All E2E tests and browser scripts use Playwright. The cross-platform
 3-layer suite (`tests/e2e/*.spec.ts`) uses `@playwright/test` via the
-local `playwright` devDependency installed by `npm ci`.
+local `playwright` 1.56 devDependency installed by `npm ci`.
 
-The legacy `*.mjs` scripts (`tests/e2e/snapshot.test.mjs` etc.) still
-resolve Playwright through `createRequire("/opt/node22/lib/node_modules/")`.
-NEVER try to use Puppeteer, even though it appears in package.json.
+The surviving legacy `*.mjs` scripts (`tests/e2e/perf_app.test.mjs`,
+`perf_widget.test.mjs`, `widget_interaction.test.mjs`,
+`test_notebook_screenshots.mjs`, `test_vscode_render.mjs`,
+`vscode_full_screen.test.mjs`) resolve Playwright through
+`createRequire("/opt/node22/lib/node_modules/")`. The shared helper is
+`tests/e2e/utils/playwright.mjs` — reuse it instead of duplicating the
+`createRequire` block. `puppeteer` is **not** in `package.json`; never
+add it.
 
 ## Unit Tests
 
@@ -121,7 +126,7 @@ is supported by the host fixture but most current specs only have a
 webapp implementation:
 
 ```sh
-MEGANE_HOST=widget-jupyterlab npm run test:e2e:measurement
+MEGANE_HOST=widget-jupyterlab npm run test:e2e:format-loading
 ```
 
 `MEGANE_HOST` accepts `webapp | widget-jupyterlab | widget-vscode |
@@ -188,14 +193,18 @@ fix the regression or replace the baseline.
 ## Legacy E2E (kept for one release)
 
 ```
-node tests/e2e/snapshot.test.mjs            # legacy webapp pixel-diff
-node tests/e2e/test_widget_render.mjs       # legacy widget render
-node tests/e2e/test_notebook_screenshots.mjs
-node tests/e2e/test_vscode_render.mjs       # post-release VSCode
+node tests/e2e/test_notebook_screenshots.mjs   # notebook screenshot capture
+node tests/e2e/test_vscode_render.mjs          # post-release VSCode rendering check
+node tests/e2e/vscode_full_screen.test.mjs     # also wired as `npm run test:e2e:vscode:legacy`
+node tests/e2e/perf_app.test.mjs               # webapp performance probe
+node tests/e2e/perf_widget.test.mjs            # widget performance probe
+node tests/e2e/widget_interaction.test.mjs     # legacy widget interaction screenshots
 ```
 
 These are scheduled to be removed once their coverage is fully
-replicated by the spec.ts suite.
+replicated by the spec.ts suite. The deleted `snapshot.test.mjs` and
+`test_widget_render.mjs` runners have already been retired in favour of
+the Playwright projects.
 
 ## Run All Tests
 

--- a/.claude/skills/validate-skills/SKILL.md
+++ b/.claude/skills/validate-skills/SKILL.md
@@ -15,15 +15,16 @@ The following skills must be available in the system reminder:
 3. **dev-setup** — Development environment setup
 4. **build** — Build commands
 5. **testing** — Test runner instructions
-6. **preview** — Screenshot and video capture
-7. **pre-release** — Pre-release checklist (tests, versioning, dry-run, tag)
-8. **post-release** — Post-release checklist (verify packages, docs, live demo)
-9. **validate-skills** — This skill (self-check)
+6. **e2e-coverage** — E2E coverage runbook (5 platforms)
+7. **preview** — Screenshot and video capture
+8. **pre-release** — Pre-release checklist (tests, versioning, dry-run, tag)
+9. **post-release** — Post-release checklist (verify packages, docs, live demo)
+10. **validate-skills** — This skill (self-check)
 
 ## Validation Steps
 
 1. Check the system reminder in the current conversation for the list of available skills.
-2. Verify that all 9 skills listed above appear in the available skills list.
+2. Verify that all 10 skills listed above appear in the available skills list.
 3. Report the result:
    - If all skills are present: confirm and proceed with the task.
    - If any skill is missing: warn the user which skills are missing and suggest restarting the session or checking `.claude/skills/` directory structure.
@@ -37,9 +38,10 @@ Skills validation: OK
   - dev-setup: loaded
   - build: loaded
   - testing: loaded
+  - e2e-coverage: loaded
   - preview: loaded
   - pre-release: loaded
   - post-release: loaded
   - validate-skills: loaded
-All 9 skills are available. Ready to proceed.
+All 10 skills are available. Ready to proceed.
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,10 @@
 ## CRITICAL RULES
 
 1. **Commit messages MUST be in English.** Never use Japanese or any other language in commit messages.
-2. **NEVER use Puppeteer.** Although `puppeteer` is in package.json, it is NOT used by any script. All E2E tests and screenshot scripts use **Playwright** from the global install at `/opt/node22/lib/node_modules/`. Scripts resolve it via `createRequire("/opt/node22/lib/node_modules/")`.
+2. **NEVER use Puppeteer.** The repo uses **Playwright**:
+   - The current `*.spec.ts` E2E suite uses `@playwright/test` via the local `playwright` 1.56 devDependency (installed by `npm ci`).
+   - Legacy `*.mjs` scripts (`scripts/dev-preview.mjs`, `scripts/capture-screenshots.mjs`, `tests/e2e/test_vscode_render.mjs`, `tests/e2e/vscode_full_screen.test.mjs`, etc.) resolve Playwright from the global install via `createRequire("/opt/node22/lib/node_modules/")`. The shared helper is `tests/e2e/utils/playwright.mjs` — reuse it instead of duplicating the `createRequire` block.
+   - `puppeteer` is **not** a dependency. Do not add it.
 3. **Always build WASM before running the dev server or full build.** The WASM pkg directory (`crates/megane-wasm/pkg/`) does not exist until `npm run build:wasm` is run.
 4. **Always create a PR after pushing changes.** Use `gh pr create` to open a pull request. PR titles and descriptions must be in English. See the `github-cli` skill for remote URL workaround. Before reporting completion, verify CI passes with `gh run list`.
 5. **In plan mode, strictly follow the approved plan.** Do not skip steps, reorder them, or add unplanned work. If the plan needs changes, explain the reason and get approval before deviating.
@@ -25,27 +28,52 @@ uv sync --extra dev          # Python dependencies
 
 ## Project Overview
 
-megane is a molecular viewer: Rust core (parsers) + TypeScript/React frontend (Three.js) + Python backend (FastAPI/anywidget).
+megane is a molecular viewer: Rust core (parsers) + TypeScript/React frontend (Three.js) + Python backend (FastAPI/anywidget) + VSCode extension.
 Rust compiles to both PyO3 (Python) and WASM (browser) via a Cargo workspace with three crates:
-- `megane-core` — Core parsers (PDB, GRO, XYZ, MOL, CIF, LAMMPS, XTC, .traj)
+- `megane-core` — Core parsers (PDB, GRO, XYZ, MOL, CIF, LAMMPS data + LAMMPS trajectory, GROMACS topology, XTC, ASE `.traj`)
 - `megane-wasm` — WASM bindings (wasm-bindgen)
 - `megane-python` — PyO3 Python extension
 
 ## Key Commands
 
+### Build
+
 | Command | What it does |
 |---|---|
 | `npm run build:wasm` | Compile Rust to WASM (MUST run first) |
-| `npm run build` | Full build: WASM + tsc + Vite app + Vite widget + JupyterLab labextension |
+| `npm run build` | Full build: WASM + tsc + Vite app + Vite widget + Vite lib + JupyterLab labextension |
+| `npm run build:app` | WASM + tsc + Vite app only |
+| `npm run build:widget` | Vite widget bundle only |
+| `npm run build:lib` | WASM + widget bundle + npm library bundle (`vite.lib.config.ts`) |
 | `npm run build:lab` | Build only the JupyterLab labextension (`jupyterlab-megane/`) |
 | `npm run dev` | Vite dev server (requires WASM already built) |
 | `maturin develop --release` | Build+install Python extension (editable) |
+
+### Test
+
+| Command | What it does |
+|---|---|
 | `npm test` | TypeScript unit tests (vitest) |
 | `cargo test -p megane-core` | Rust parser tests |
 | `python -m pytest` | Python tests (needs maturin develop first) |
-| `node tests/e2e/snapshot.test.mjs` | E2E visual snapshot tests (Playwright) |
-| `node tests/e2e/snapshot.test.mjs --update` | Update E2E snapshot baselines |
-| `make test-all` | All tests combined |
+| `npm run test:e2e` | Full Playwright suite (all projects) |
+| `npm run test:e2e:webapp` | Webapp project (Vite static, port 15173) |
+| `npm run test:e2e:contract` | Cross-platform contract project |
+| `npm run test:e2e:widget-jupyterlab` | anywidget in JupyterLab |
+| `npm run test:e2e:widget-vscode` | anywidget in code-server (`MEGANE_E2E_MODE=1`) |
+| `npm run test:e2e:jupyterlab-doc` | DocWidget in JupyterLab |
+| `npm run test:e2e:vscode` | VSCode custom editor (`MEGANE_E2E_MODE=1`) |
+| `npm run test:e2e:vscode:legacy[:update]` | Legacy `vscode_full_screen.test.mjs` runner |
+| `MEGANE_E2E_UPDATE=1 npm run test:e2e:<project>` | Re-baseline a project's PNGs |
+| `npm run test:all` | vitest + full Playwright suite |
+| `make test-all` | Python + TypeScript + Rust + active Playwright projects + notebooks + integration |
+
+### Lint / Format / Preview
+
+| Command | What it does |
+|---|---|
+| `npm run lint` / `lint:fix` | ESLint over `src/` |
+| `npm run format` / `format:check` | Prettier over `src/` |
 | `node scripts/dev-preview.mjs --screenshot` | Dev preview screenshots |
 | `node scripts/capture-screenshots.mjs` | Hero screenshot for docs |
 
@@ -55,17 +83,25 @@ Project-specific skills are defined in `.claude/skills/`. Each skill provides in
 
 - **At the start of a task**, run the `validate-skills` skill to confirm all skills are loaded.
 - **Always follow the instructions** in each skill when performing the corresponding workflow.
-- Skills cover: committing (`commit`), GitHub CLI usage (`github-cli`), dev environment setup (`dev-setup`), building (`build`), testing (`testing`), preview capture (`preview`), and skill validation (`validate-skills`).
+- Skills cover: committing (`commit`), GitHub CLI usage (`github-cli`), dev environment setup (`dev-setup`), building (`build`), testing (`testing`), E2E coverage runbook (`e2e-coverage`), preview capture (`preview`), pre-release checklist (`pre-release`), post-release verification (`post-release`), and skill validation (`validate-skills`). Total: 10 skills.
 
 ## Architecture
 
 - TypeScript source: `src/` (import alias `@/` → `src/`)
 - Python source: `python/megane/`
 - Rust crates: `crates/{megane-core,megane-python,megane-wasm}/`
-- Vite configs: `vite.config.ts` (app), `vite.widget.config.ts` (widget), `vite.webview.config.ts` (VSCode)
+- VSCode extension workspace: `vscode-megane/` (extension code + `vite.webview.config.ts` for the webview bundle)
 - JupyterLab labextension source: `jupyterlab-megane/` (built with `@jupyterlab/builder` / webpack, imports the shared `src/` viewer via webpack alias `@megane/*`)
+- Vite configs at repo root:
+  - `vite.config.ts` — webapp
+  - `vite.widget.config.ts` — anywidget bundle
+  - `vite.lib.config.ts` — npm library (`megane-viewer`) bundle
+  - `vite.docs-demo.config.ts` — docs demo build
+  - VSCode webview config lives at `vscode-megane/vite.webview.config.ts` (not at repo root)
+- Playwright config at repo root: `playwright.config.ts` (declares all E2E projects)
 - App builds to: `python/megane/static/app/`
 - Widget builds to: `dist/`
 - JupyterLab labextension builds to: `wheel-share/data/share/jupyter/labextensions/megane-jupyterlab/` and is shipped in the wheel via `[tool.maturin] data = "wheel-share"`
 - Test fixtures: `tests/fixtures/` (PDB, XYZ, XTC files)
-- E2E snapshots: `tests/e2e/snapshots/`
+- E2E baselines: `tests/e2e/baselines/<project>/` (committed PNGs for the `*.spec.ts` 3-layer suite)
+- Legacy `*.test.mjs` snapshots: `tests/e2e/snapshots/` (kept while the legacy runners survive)


### PR DESCRIPTION
## Summary

Audit of `.claude/skills/` and `CLAUDE.md` against the current repo found multiple drifted statements. This PR reconciles them.

### CLAUDE.md
- Drop the false claim that `puppeteer` is in `package.json` — it has been removed; only `playwright` 1.56 is installed. Document the `tests/e2e/utils/playwright.mjs` helper for legacy `.mjs` scripts.
- Replace dead `node tests/e2e/snapshot.test.mjs` rows in the command table with the current `npm run test:e2e:*` Playwright scripts. Add `build:app` / `build:widget` / `build:lib`, `lint`, `format`, `test:all`, `MEGANE_E2E_UPDATE=1` baseline refresh.
- Skills bullet now lists all 10 skills (was 7). Adds `pre-release`, `post-release`, `e2e-coverage`.
- Architecture: add the `vscode-megane/` workspace, the missing `vite.lib.config.ts` and `vite.docs-demo.config.ts`, and `playwright.config.ts`. Move `vite.webview.config.ts` out of the repo-root list (it lives under `vscode-megane/`). Expand the parser list to include LAMMPS trajectory (`lammpstrj`) and GROMACS topology (`top`). Split legacy `tests/e2e/snapshots/` from the current `tests/e2e/baselines/<project>/`.

### Skills
- `validate-skills/SKILL.md`: list 10 expected skills (added `e2e-coverage`).
- `testing/SKILL.md`: drop dead references to `tests/e2e/snapshot.test.mjs` and `tests/e2e/test_widget_render.mjs` (neither file exists). Correct the Puppeteer-in-package.json premise. Replace the `test:e2e:measurement` example with `:format-loading`. Update the legacy file list.
- `e2e-coverage/SKILL.md`: same Puppeteer correction. The for-loop example now sweeps a real cross-host spec (`format-loading`) and explicitly notes the deferred measurement coverage.
- `post-release/SKILL.md`: Phase 3.1 verification swaps the deleted `node tests/e2e/test_widget_render.mjs` for `MEGANE_E2E_MODE=1 npm run test:e2e:widget-jupyterlab` against a PyPI-installed venv. Phase 4.4 release-asset uploads now point at `tests/e2e/baselines/widget-jupyterlab/`. Summary table mirrors the change.

No code paths are touched — documentation only.

## Test plan
- [x] `grep -n "snapshot.test.mjs\|test_widget_render.mjs\|test:e2e:measurement" CLAUDE.md .claude/skills/*/SKILL.md` returns only the explanatory historical note.
- [x] `grep -n puppeteer CLAUDE.md .claude/skills/*/SKILL.md` confirms every mention says it is **not** in `package.json`.
- [x] `ls tests/e2e/snapshot.test.mjs tests/e2e/test_widget_render.mjs` fails (verifies the references really were stale).
- [x] Every `npm run test:e2e:*` command cited (`webapp`, `contract`, `widget-jupyterlab`, `widget-vscode`, `jupyterlab-doc`, `vscode`, `vscode:legacy[:update]`, `format-loading`) appears in `package.json`.
- [x] `npm run test:e2e:webapp -- --list` resolves the script wiring (errors only on missing local Playwright install — expected without `npm ci`).
- [x] `validate-skills` skill now expects 10 skills, matching what is loaded.

---
_Generated by [Claude Code](https://claude.ai/code/session_014DgYRmmC4UetXo4hLZP7Sh)_