### PR TITLE
feat(jupyterlab): auto-open .megane.json pipeline files

### DIFF
--- a/jupyterlab-megane/src/MeganePipelineDocWidget.tsx
+++ b/jupyterlab-megane/src/MeganePipelineDocWidget.tsx
@@ -1,0 +1,247 @@
+import { ReactWidget } from "@jupyterlab/ui-components";
+import type { DocumentRegistry } from "@jupyterlab/docregistry";
+import type { Contents } from "@jupyterlab/services";
+import { useCallback, useEffect, useState } from "react";
+import { MeganeViewer } from "@megane/components/MeganeViewer";
+import { useMeganeLocal } from "@megane/hooks/useMeganeLocal";
+import { parseStructureFile } from "@megane/parsers/structure";
+import { parseXTCFile, parseLammpstrjFile } from "@megane/parsers/xtc";
+import { usePipelineStore } from "@megane/pipeline/store";
+import type { SerializedPipeline } from "@megane/pipeline/types";
+import "@megane/styles/megane.css";
+import { ensureWasmUrl } from "./wasmLoader";
+
+interface PipelineNode {
+  id: string;
+  type: string;
+  fileName?: string | null;
+}
+
+interface DocBodyProps {
+  context: DocumentRegistry.Context;
+  contents: Contents.IManager;
+}
+
+type LoadState = "loading" | "ready" | { error: string };
+
+function dirname(p: string): string {
+  const idx = p.lastIndexOf("/");
+  return idx >= 0 ? p.slice(0, idx) : "";
+}
+
+function basename(p: string): string {
+  const idx = p.lastIndexOf("/");
+  return idx >= 0 ? p.slice(idx + 1) : p;
+}
+
+function joinUnderDir(dir: string, rel: string): string | null {
+  // Mirror the VSCode extension's safety rules:
+  // - reject absolute paths (leading "/")
+  // - reject paths that escape `dir` via ".." traversal
+  if (rel.startsWith("/")) return null;
+  const parts = (dir ? `${dir}/${rel}` : rel).split("/");
+  const out: string[] = [];
+  for (const seg of parts) {
+    if (seg === "" || seg === ".") continue;
+    if (seg === "..") {
+      if (out.length === 0) return null;
+      out.pop();
+      continue;
+    }
+    out.push(seg);
+  }
+  const joined = out.join("/");
+  if (dir === "") return joined;
+  if (joined !== dir && !joined.startsWith(`${dir}/`)) return null;
+  return joined;
+}
+
+async function fetchFileBytes(
+  contents: Contents.IManager,
+  path: string,
+): Promise<Uint8Array> {
+  // Always fetch as base64 so binary formats (.traj, .xtc) round-trip
+  // unmodified. The shared parsers re-decode via file.text() or
+  // file.arrayBuffer() based on extension.
+  const model = await contents.get(path, { content: true, format: "base64" });
+  const raw = String(model.content ?? "");
+  return Uint8Array.from(atob(raw), (c) => c.charCodeAt(0));
+}
+
+function DocBody({ context, contents }: DocBodyProps): JSX.Element {
+  const local = useMeganeLocal();
+  const [state, setState] = useState<LoadState>("loading");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        await ensureWasmUrl();
+        await context.ready;
+        const pipelineText = context.model.toString();
+        const pipeline = JSON.parse(pipelineText) as SerializedPipeline;
+        if (pipeline.version !== 3) {
+          throw new Error(
+            `Not a valid megane pipeline file (version 3 required, got ${pipeline.version})`,
+          );
+        }
+
+        const dir = dirname(context.path);
+        const store = usePipelineStore.getState();
+        store.deserialize(pipeline);
+
+        // Phase 1: structure files
+        let firstFile: File | null = null;
+        const parsedStructures: Array<{
+          nodeId: string;
+          filename: string;
+          result: Awaited<ReturnType<typeof parseStructureFile>>;
+        }> = [];
+
+        for (const node of (pipeline.nodes ?? []) as PipelineNode[]) {
+          if (node.type !== "load_structure" || !node.fileName) continue;
+          const target = joinUnderDir(dir, String(node.fileName));
+          if (!target) continue;
+          const filename = basename(String(node.fileName));
+          try {
+            const bytes = await fetchFileBytes(contents, target);
+            const file = new File([bytes], filename);
+            const result = await parseStructureFile(file);
+            parsedStructures.push({ nodeId: node.id, filename, result });
+            if (!firstFile) firstFile = file;
+          } catch {
+            // File missing or unreadable — leave the node empty; the user
+            // can re-attach via the node's file picker.
+          }
+        }
+
+        if (firstFile) {
+          await local.loadFile(firstFile);
+        }
+
+        let firstSnapshot: unknown = null;
+        for (const { nodeId, filename, result } of parsedStructures) {
+          store.setNodeSnapshot(nodeId, {
+            snapshot: result.snapshot,
+            frames: result.frames.length > 0 ? result.frames : null,
+            meta: result.meta,
+            labels: result.labels,
+          });
+          store.updateNodeParams(nodeId, {
+            fileName: filename,
+            hasTrajectory: result.frames.length > 0,
+            hasCell: !!result.snapshot.box,
+          });
+          if (!firstSnapshot) firstSnapshot = result.snapshot;
+        }
+
+        // Phase 2: trajectory files (single global trajectory)
+        for (const node of (pipeline.nodes ?? []) as PipelineNode[]) {
+          if (node.type !== "load_trajectory" || !node.fileName) continue;
+          if (!firstSnapshot) break;
+          const target = joinUnderDir(dir, String(node.fileName));
+          if (!target) continue;
+          const filename = basename(String(node.fileName));
+          try {
+            const bytes = await fetchFileBytes(contents, target);
+            const file = new File([bytes], filename);
+            const lower = filename.toLowerCase();
+            const isLammps = lower.endsWith(".lammpstrj") || lower.endsWith(".dump");
+            const parseFn = isLammps ? parseLammpstrjFile : parseXTCFile;
+            const snap = firstSnapshot as { nAtoms: number };
+            const { frames, meta } = await parseFn(file, snap.nAtoms);
+            store.setFileFrames(frames, meta ?? null);
+            store.updateNodeParams(node.id, { fileName: filename });
+          } catch {
+            // Skip silently
+          }
+          break;
+        }
+
+        if (!cancelled) setState("ready");
+      } catch (err) {
+        if (!cancelled) {
+          setState({ error: err instanceof Error ? err.message : String(err) });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // `local` is intentionally omitted (see MeganeDocWidget for rationale).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [context, contents]);
+
+  const handleUploadStructure = useCallback(
+    (file: File) => {
+      local.loadFile(file);
+    },
+    [local],
+  );
+
+  if (typeof state === "object") {
+    return (
+      <div
+        className="megane-jupyter-status error"
+        data-testid="megane-pipeline-doc-root"
+        data-state="error"
+      >
+        <div className="label">Error</div>
+        <div>{state.error}</div>
+      </div>
+    );
+  }
+
+  if (state === "loading") {
+    return (
+      <div
+        className="megane-jupyter-status"
+        data-testid="megane-pipeline-doc-root"
+        data-state="loading"
+      >
+        Loading pipeline...
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="megane-pipeline-doc-root"
+      data-state="ready"
+      style={{ width: "100%", height: "100%" }}
+    >
+      <MeganeViewer
+        testContext="jupyterlab-pipeline"
+        snapshot={local.snapshot}
+        frame={local.frame}
+        currentFrame={local.currentFrame}
+        totalFrames={local.meta?.nFrames ?? 0}
+        onUploadStructure={handleUploadStructure}
+        onBondSourceChange={(s: string) =>
+          local.setBondSource(s as "structure" | "file" | "distance" | "none")
+        }
+        onLabelSourceChange={(s: string) =>
+          local.setLabelSource(s as "none" | "structure" | "file")
+        }
+        onLoadLabelFile={(f: File) => local.loadLabelFile(f)}
+        onVectorSourceChange={(s: string) => local.setVectorSource(s as "none" | "file" | "demo")}
+        onLoadVectorFile={(f: File) => local.loadVectorFile(f)}
+        onLoadDemoVectors={() => local.loadDemoVectors()}
+      />
+    </div>
+  );
+}
+
+export class MeganePipelineReactView extends ReactWidget {
+  constructor(
+    private readonly context: DocumentRegistry.Context,
+    private readonly contents: Contents.IManager,
+  ) {
+    super();
+    this.addClass("megane-jupyter-doc");
+  }
+
+  protected render(): JSX.Element {
+    return <DocBody context={this.context} contents={this.contents} />;
+  }
+}

--- a/jupyterlab-megane/src/factory.ts
+++ b/jupyterlab-megane/src/factory.ts
@@ -1,6 +1,8 @@
 import { ABCWidgetFactory, DocumentWidget } from "@jupyterlab/docregistry";
 import type { DocumentRegistry, IDocumentWidget } from "@jupyterlab/docregistry";
+import type { Contents } from "@jupyterlab/services";
 import { MeganeReactView } from "./MeganeDocWidget";
+import { MeganePipelineReactView } from "./MeganePipelineDocWidget";
 
 export class MeganeDocFactory extends ABCWidgetFactory<
   IDocumentWidget<MeganeReactView>,
@@ -10,6 +12,29 @@ export class MeganeDocFactory extends ABCWidgetFactory<
     context: DocumentRegistry.Context,
   ): IDocumentWidget<MeganeReactView> {
     const content = new MeganeReactView(context);
+    const widget = new DocumentWidget({ content, context });
+    widget.title.iconClass = "jp-MaterialIcon jp-FileIcon";
+    return widget;
+  }
+}
+
+export class MeganePipelineDocFactory extends ABCWidgetFactory<
+  IDocumentWidget<MeganePipelineReactView>,
+  DocumentRegistry.IModel
+> {
+  constructor(
+    options: DocumentRegistry.IWidgetFactoryOptions<
+      IDocumentWidget<MeganePipelineReactView>
+    >,
+    private readonly contents: Contents.IManager,
+  ) {
+    super(options);
+  }
+
+  protected createNewWidget(
+    context: DocumentRegistry.Context,
+  ): IDocumentWidget<MeganePipelineReactView> {
+    const content = new MeganePipelineReactView(context, this.contents);
     const widget = new DocumentWidget({ content, context });
     widget.title.iconClass = "jp-MaterialIcon jp-FileIcon";
     return widget;

--- a/jupyterlab-megane/src/filetypes.ts
+++ b/jupyterlab-megane/src/filetypes.ts
@@ -2,6 +2,18 @@ import type { DocumentRegistry } from "@jupyterlab/docregistry";
 
 export const FACTORY_NAME = "megane Molecular Viewer";
 export const FACTORY_NAME_BINARY = "megane Molecular Viewer (binary)";
+export const FACTORY_NAME_PIPELINE = "megane Pipeline Viewer";
+
+export const PIPELINE_FILETYPE_NAME = "megane-pipeline";
+
+export const PIPELINE_FILETYPE: DocumentRegistry.IFileType = {
+  name: PIPELINE_FILETYPE_NAME,
+  displayName: "megane Pipeline",
+  extensions: [".megane.json"],
+  mimeTypes: ["application/json"],
+  fileFormat: "text",
+  contentType: "file",
+};
 
 export const STRUCTURE_FILETYPES_TEXT: DocumentRegistry.IFileType[] = [
   {

--- a/jupyterlab-megane/src/index.ts
+++ b/jupyterlab-megane/src/index.ts
@@ -5,11 +5,15 @@ import {
 } from "@jupyterlab/application";
 import { WidgetTracker } from "@jupyterlab/apputils";
 import type { IDocumentWidget } from "@jupyterlab/docregistry";
-import { MeganeDocFactory } from "./factory";
+import { MeganeDocFactory, MeganePipelineDocFactory } from "./factory";
 import type { MeganeReactView } from "./MeganeDocWidget";
+import type { MeganePipelineReactView } from "./MeganePipelineDocWidget";
 import {
   FACTORY_NAME,
   FACTORY_NAME_BINARY,
+  FACTORY_NAME_PIPELINE,
+  PIPELINE_FILETYPE,
+  PIPELINE_FILETYPE_NAME,
   STRUCTURE_FILETYPES_TEXT,
   STRUCTURE_FILETYPES_BINARY,
   STRUCTURE_FILETYPE_NAMES_TEXT,
@@ -18,17 +22,19 @@ import {
 
 const PLUGIN_ID = "megane-jupyterlab:plugin";
 const TRACKER_NAMESPACE = "megane";
+const PIPELINE_TRACKER_NAMESPACE = "megane-pipeline";
 
 const plugin: JupyterFrontEndPlugin<void> = {
   id: PLUGIN_ID,
   description:
-    "Open molecular structure files (PDB, GRO, XYZ, MOL, SDF, CIF, LAMMPS data, ASE traj) with megane",
+    "Open molecular structure files (PDB, GRO, XYZ, MOL, SDF, CIF, LAMMPS data, ASE traj) and megane pipelines",
   autoStart: true,
   requires: [ILayoutRestorer],
   activate: (app: JupyterFrontEnd, restorer: ILayoutRestorer) => {
     for (const ft of [...STRUCTURE_FILETYPES_TEXT, ...STRUCTURE_FILETYPES_BINARY]) {
       app.docRegistry.addFileType(ft);
     }
+    app.docRegistry.addFileType(PIPELINE_FILETYPE);
 
     const textFactory = new MeganeDocFactory({
       name: FACTORY_NAME,
@@ -48,8 +54,25 @@ const plugin: JupyterFrontEndPlugin<void> = {
     });
     app.docRegistry.addWidgetFactory(binaryFactory);
 
+    const pipelineFactory = new MeganePipelineDocFactory(
+      {
+        name: FACTORY_NAME_PIPELINE,
+        modelName: "text",
+        fileTypes: [PIPELINE_FILETYPE_NAME],
+        defaultFor: [PIPELINE_FILETYPE_NAME],
+        readOnly: true,
+      },
+      app.serviceManager.contents,
+    );
+    app.docRegistry.addWidgetFactory(pipelineFactory);
+
     const tracker = new WidgetTracker<IDocumentWidget<MeganeReactView>>({
       namespace: TRACKER_NAMESPACE,
+    });
+    const pipelineTracker = new WidgetTracker<
+      IDocumentWidget<MeganePipelineReactView>
+    >({
+      namespace: PIPELINE_TRACKER_NAMESPACE,
     });
 
     for (const factory of [textFactory, binaryFactory]) {
@@ -61,10 +84,18 @@ const plugin: JupyterFrontEndPlugin<void> = {
       });
     }
 
+    pipelineFactory.widgetCreated.connect((_sender, widget) => {
+      widget.context.pathChanged.connect(() => {
+        void pipelineTracker.save(widget);
+      });
+      void pipelineTracker.add(widget);
+    });
+
     const binaryExtensions = new Set(
       STRUCTURE_FILETYPES_BINARY.flatMap((f) => f.extensions ?? []),
     );
     const factoryForPath = (path: string): string => {
+      if (path.toLowerCase().endsWith(".megane.json")) return FACTORY_NAME_PIPELINE;
       const dot = path.lastIndexOf(".");
       const ext = dot >= 0 ? path.slice(dot).toLowerCase() : "";
       return binaryExtensions.has(ext) ? FACTORY_NAME_BINARY : FACTORY_NAME;
@@ -77,6 +108,15 @@ const plugin: JupyterFrontEndPlugin<void> = {
       args: (widget) => ({
         path: widget.context.path,
         factory: factoryForPath(widget.context.path),
+      }),
+      name: (widget) => widget.context.path,
+    });
+
+    void restorer.restore(pipelineTracker, {
+      command: "docmanager:open",
+      args: (widget) => ({
+        path: widget.context.path,
+        factory: FACTORY_NAME_PIPELINE,
       }),
       name: (widget) => widget.context.path,
     });

--- a/jupyterlab-megane/src/megane-modules.d.ts
+++ b/jupyterlab-megane/src/megane-modules.d.ts
@@ -16,4 +16,26 @@ declare module "@megane/hooks/useMeganeLocal" {
   export function useMeganeLocal(): any;
 }
 
+declare module "@megane/parsers/structure" {
+  export function parseStructureFile(file: File): Promise<any>;
+}
+
+declare module "@megane/parsers/xtc" {
+  export function parseXTCFile(file: File, expectedNAtoms: number): Promise<any>;
+  export function parseLammpstrjFile(
+    file: File,
+    expectedNAtoms: number,
+  ): Promise<any>;
+}
+
+declare module "@megane/pipeline/store" {
+  export const usePipelineStore: {
+    getState(): any;
+  };
+}
+
+declare module "@megane/pipeline/types" {
+  export type SerializedPipeline = any;
+}
+
 declare module "@megane/styles/megane.css";


### PR DESCRIPTION
## Summary
- Register `megane-pipeline` filetype + `MeganePipelineDocFactory` so clicking a `.megane.json` in JupyterLab opens the megane viewer with the pipeline graph hydrated, instead of falling back to the default JSON viewer.
- New `MeganePipelineDocWidget` reads the JSON via the document context, validates `version: 3`, fetches each `load_structure` / `load_trajectory` node's companion file as base64 through `Contents.IManager` (resolved relative to the pipeline file's directory, with the same `..`/absolute-path safety as the VSCode provider), parses them via the shared WASM parsers, applies per-node snapshots, and renders `MeganeViewer`.
- Wires the new factory + a dedicated `WidgetTracker` into `index.ts`, including layout-restore routing so `.megane.json` files come back via the pipeline factory.
- Adds ambient declarations for `@megane/parsers/*` and `@megane/pipeline/*` to keep `tsc` happy without forcing the lab extension's `rootDir` outside `jupyterlab-megane/src`.

The VSCode extension already had this behaviour via `megane.pipelineViewer`; this change brings JupyterLab to parity.

## Test plan
- [x] `npm run build:wasm`
- [x] `npx tsc --noEmit --strict` in `jupyterlab-megane/`
- [x] `npm run build` in `jupyterlab-megane/` (`tsc` + `jupyter labextension build .`)
- [x] `npm run lint` (no new errors)
- [x] `npm test` (322/322 passed)
- [ ] Manual: click a `.megane.json` in JupyterLab and confirm the pipeline editor renders with companion files attached

https://claude.ai/code/session_011H7tpwmTiE3hFtAC3YF8Pg

---
_Generated by [Claude Code](https://claude.ai/code/session_011H7tpwmTiE3hFtAC3YF8Pg)_