### PR TITLE
docs: document local-run procedure for VSCode and JupyterLab extensions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,48 @@ maturin develop --release
 
 After setup, you can start the dev server with `npm run dev`.
 
+## Running the VSCode and JupyterLab Extensions Locally
+
+After completing the Development Setup above, you can build and use either extension interactively on your machine.
+
+### VSCode extension (via VSIX)
+
+```bash
+cd vscode-megane
+npm install
+npm run build       # builds webview bundle + extension
+npm run package     # produces vscode-megane-<version>.vsix
+code --install-extension ./vscode-megane-<version>.vsix
+```
+
+Open any `.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf`, `.cif`, `.data`, `.lammps`, `.traj`, or `.megane.json` file in VSCode to launch the megane viewer.
+
+To iterate on the extension code without repackaging, open `vscode-megane/` in VSCode and press `F5` to launch the Extension Development Host (after `npm run build`).
+
+### JupyterLab extension
+
+```bash
+npm run build:lab          # builds labextension into wheel-share/...
+maturin develop --release  # installs python pkg + ships labextension into the env
+jupyter labextension list  # confirm "megane-jupyterlab" is enabled
+jupyter lab
+```
+
+Double-click any supported structure file in the JupyterLab file browser, or use the anywidget API in a notebook:
+
+```python
+import megane
+megane.view("path/to/protein.pdb")
+```
+
+If `jupyter labextension list` does not show megane after `maturin develop`, copy the labextension manually:
+
+```bash
+mkdir -p "$(jupyter --data-dir)/labextensions"
+cp -r wheel-share/data/share/jupyter/labextensions/megane-jupyterlab \
+      "$(jupyter --data-dir)/labextensions/"
+```
+
 ## Running Tests
 
 | Command | Scope |


### PR DESCRIPTION
## Summary

- Add a new "Running the VSCode and JupyterLab Extensions Locally" section to `CONTRIBUTING.md`, covering the VSIX build/install flow (`npm run build` + `npm run package` + `code --install-extension`) and the JupyterLab labextension flow (`npm run build:lab` + `maturin develop --release` + `jupyter lab`).
- Documents the manual `cp -r wheel-share/.../megane-jupyterlab` fallback that the `e2e-coverage` skill already relies on, so the procedure is discoverable for contributors.

## Test plan

- [x] `grep "Running the VSCode and JupyterLab" CONTRIBUTING.md` finds the new heading.
- [x] Markdown renders correctly (no broken nested fences).
- [ ] (Reviewer) Run the documented commands end-to-end on a fresh checkout to confirm the procedure works.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRcq5PAf9cjMC27G64NEoV)_