### PR TITLE
fix: render Timeline in VSCode and JupyterLab hosts

### DIFF
--- a/src/components/MeganeViewer.tsx
+++ b/src/components/MeganeViewer.tsx
@@ -144,6 +144,21 @@ export function MeganeViewer({
   const frame = usePlaybackStore((s) => s.currentFrameData);
   const currentFrame = usePlaybackStore((s) => s.currentFrame);
   const totalFrames = usePlaybackStore((s) => s.totalFrames);
+  const storePlaying = usePlaybackStore((s) => s.playing);
+  const storeFps = usePlaybackStore((s) => s.fps);
+  const storeSeek = usePlaybackStore((s) => s.seekFrame);
+  const storeTogglePlayPause = usePlaybackStore((s) => s.togglePlayPause);
+  const storeSetFps = usePlaybackStore((s) => s.setFps);
+
+  // Hosts may forward custom playback callbacks (the webapp wraps them to
+  // pause on file uploads). When omitted (VSCode webview, JupyterLab
+  // DocWidget), wire Timeline directly to the playback store so the user
+  // always gets playback controls for multi-frame structures.
+  const effectivePlaying = onPlayPause ? playing : storePlaying;
+  const effectiveFps = onFpsChange ? fps : storeFps;
+  const effectiveOnSeek = onSeek ?? storeSeek;
+  const effectiveOnPlayPause = onPlayPause ?? storeTogglePlayPause;
+  const effectiveOnFpsChange = onFpsChange ?? storeSetFps;
 
   // Per-frame bond recalculation for distance mode
   useEffect(() => {
@@ -246,19 +261,17 @@ export function MeganeViewer({
         rendererRef={rendererRef}
         totalFrames={totalFrames}
         currentFrame={currentFrame}
-        onSeek={onSeek}
+        onSeek={effectiveOnSeek}
       />
-      {onSeek && onPlayPause && onFpsChange && (
-        <Timeline
-          currentFrame={currentFrame}
-          totalFrames={totalFrames}
-          playing={playing}
-          fps={fps}
-          onSeek={onSeek}
-          onPlayPause={onPlayPause}
-          onFpsChange={onFpsChange}
-        />
-      )}
+      <Timeline
+        currentFrame={currentFrame}
+        totalFrames={totalFrames}
+        playing={effectivePlaying}
+        fps={effectiveFps}
+        onSeek={effectiveOnSeek}
+        onPlayPause={effectiveOnPlayPause}
+        onFpsChange={effectiveOnFpsChange}
+      />
       <Tooltip info={hoverInfo} />
       <MeasurementPanel
         selection={selection}


### PR DESCRIPTION
## Summary

When opening multi-frame structure files (`.traj`, multi-frame `.xyz`, multi-MODEL `.pdb`) in the VSCode custom editor or JupyterLab DocWidget, the trajectory provider was correctly delivered to `usePlaybackStore`, but the Timeline UI was never rendered, so users had no way to play or scrub frames. The pipeline graph showed an active `Trajectory` output port, which made it look like everything was wired up — but the bottom playback bar was missing.

### Root cause

`MeganeViewer` gated `<Timeline>` on `onSeek && onPlayPause && onFpsChange` props. Only the webapp (`src/index.tsx`) supplied all three; the VSCode webview, `MeganeDocWidget`, and `MeganePipelineDocWidget` invoked `MeganeViewer` without them, so the Timeline was conditionally skipped even when frames were available.

### Fix

`MeganeViewer` now falls back to `usePlaybackStore` actions (`seekFrame`, `togglePlayPause`, `setFps`) and state (`playing`, `fps`) when host props are absent. The webapp continues to use its prop wrappers (which pause playback on file uploads). The Timeline component itself already returns `null` for `totalFrames <= 1`, so single-frame files are unaffected.

## Test plan

- [x] `npm run build:wasm`
- [x] `npm test` — 330/330 passing
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: open `tests/fixtures/bond_change.traj` in VSCode custom editor → Timeline appears at the bottom and play/seek work
- [ ] Manual: open the same file via JupyterLab `MeganeDocWidget` → Timeline appears
- [ ] Manual: webapp regression — pause-on-upload behaviour unchanged

https://claude.ai/code/session_01Br3zvueVce4YGK3g7bUaaA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Br3zvueVce4YGK3g7bUaaA)_