### PR TITLE
feat: add first-time user guide tour with driver.js

### DIFF
--- a/jupyterlab-megane/src/MeganeDocWidget.tsx
+++ b/jupyterlab-megane/src/MeganeDocWidget.tsx
@@ -3,6 +3,7 @@ import type { DocumentRegistry } from "@jupyterlab/docregistry";
 import { useCallback, useEffect, useState } from "react";
 import { MeganeViewer } from "@megane/components/MeganeViewer";
 import { useMeganeLocal } from "@megane/hooks/useMeganeLocal";
+import { useTour } from "@megane/tour/useTour";
 import "@megane/styles/megane.css";
 import { ensureWasmUrl } from "./wasmLoader";
 import { STRUCTURE_FILETYPES_BINARY } from "./filetypes";
@@ -20,6 +21,7 @@ type LoadState = "loading" | "ready" | { error: string };
 function DocBody({ context }: DocBodyProps): JSX.Element {
   const local = useMeganeLocal();
   const [state, setState] = useState<LoadState>("loading");
+  useTour({ host: "jupyterlab" });
 
   useEffect(() => {
     let cancelled = false;

--- a/jupyterlab-megane/src/MeganePipelineDocWidget.tsx
+++ b/jupyterlab-megane/src/MeganePipelineDocWidget.tsx
@@ -4,6 +4,7 @@ import type { Contents } from "@jupyterlab/services";
 import { useCallback, useEffect, useState } from "react";
 import { MeganeViewer } from "@megane/components/MeganeViewer";
 import { usePipelineStore } from "@megane/pipeline/store";
+import { useTour } from "@megane/tour/useTour";
 import "@megane/styles/megane.css";
 import { ensureWasmUrl } from "./wasmLoader";
 
@@ -68,6 +69,7 @@ async function fetchCompanion(
 
 function DocBody({ context, contents }: DocBodyProps): JSX.Element {
   const [state, setState] = useState<LoadState>("loading");
+  useTour({ host: "jupyterlab" });
 
   useEffect(() => {
     let cancelled = false;

--- a/jupyterlab-megane/src/megane-modules.d.ts
+++ b/jupyterlab-megane/src/megane-modules.d.ts
@@ -26,3 +26,10 @@ declare module "@megane/pipeline/store" {
 }
 
 declare module "@megane/styles/megane.css";
+
+declare module "@megane/tour/useTour" {
+  export function useTour(opts: {
+    host: "webapp" | "vscode" | "jupyterlab" | "ipywidget";
+    autoStartDelayMs?: number;
+  }): { startTour: () => void };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@dagrejs/dagre": "^2.0.4",
         "@xyflow/react": "^12.0.0",
+        "driver.js": "^1.4.0",
         "gif.js": "^0.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -3039,6 +3040,12 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/driver.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-1.4.0.tgz",
+      "integrity": "sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   "dependencies": {
     "@dagrejs/dagre": "^2.0.4",
     "@xyflow/react": "^12.0.0",
+    "driver.js": "^1.4.0",
     "gif.js": "^0.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/components/MeganeViewer.tsx
+++ b/src/components/MeganeViewer.tsx
@@ -223,16 +223,33 @@ export function MeganeViewer({
     setPipelineCollapsed((prev) => !prev);
   }, []);
 
-  const handlePipelineWidthChange = useCallback((w: number) => {
-    pipelineWidthRef.current = w;
-    if (!pipelineCollapsedRef.current) {
-      rendererRef.current?.setViewInsets(0, w + 12);
-    }
+  // Tour anchor — invisible rectangle the guide tour highlights when it
+  // points to the Viewport. Sized to fill the visible 3D canvas region,
+  // staying clear of the Pipeline panel on the right and the Timeline at
+  // the bottom. Updated imperatively (no re-render) when the panel resizes.
+  const tourAnchorRef = useRef<HTMLDivElement | null>(null);
+  const updateTourAnchor = useCallback(() => {
+    const el = tourAnchorRef.current;
+    if (!el) return;
+    const right = pipelineCollapsedRef.current ? 60 : pipelineWidthRef.current + 24;
+    el.style.right = `${right}px`;
   }, []);
+
+  const handlePipelineWidthChange = useCallback(
+    (w: number) => {
+      pipelineWidthRef.current = w;
+      if (!pipelineCollapsedRef.current) {
+        rendererRef.current?.setViewInsets(0, w + 12);
+      }
+      updateTourAnchor();
+    },
+    [updateTourAnchor],
+  );
 
   useEffect(() => {
     rendererRef.current?.setViewInsets(0, pipelineCollapsed ? 0 : pipelineWidthRef.current + 12);
-  }, [pipelineCollapsed]);
+    updateTourAnchor();
+  }, [pipelineCollapsed, updateTourAnchor]);
 
   return (
     <div
@@ -253,6 +270,20 @@ export function MeganeViewer({
         onHover={setHoverInfo}
         onAtomRightClick={handleAtomRightClick}
         onFrameUpdated={handleFrameUpdated}
+      />
+      <div
+        ref={tourAnchorRef}
+        data-tour-anchor="viewport"
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          top: 24,
+          left: 24,
+          right: pipelineCollapsed ? 60 : pipelineWidthRef.current + 24,
+          bottom: 80,
+          pointerEvents: "none",
+          opacity: 0,
+        }}
       />
       <PipelineEditor
         collapsed={pipelineCollapsed}

--- a/src/components/PipelineEditor.tsx
+++ b/src/components/PipelineEditor.tsx
@@ -41,6 +41,7 @@ import { VectorOverlayNode } from "./nodes/VectorOverlayNode";
 import { StreamingNode } from "./nodes/StreamingNode";
 import { PipelineChatBox } from "./PipelineChatBox";
 import { RenderModal } from "./RenderModal";
+import { startTour } from "../tour/MeganeTour";
 import type { MoleculeRenderer } from "../renderer/MoleculeRenderer";
 
 const nodeTypes = {
@@ -131,6 +132,14 @@ const IconPlus = (
   <svg {...iconProps} strokeWidth="2.5">
     <line x1="12" y1="5" x2="12" y2="19" />
     <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+);
+
+const IconGuide = (
+  <svg {...iconProps}>
+    <circle cx="12" cy="12" r="10" />
+    <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+    <line x1="12" y1="17" x2="12" y2="17" />
   </svg>
 );
 
@@ -315,6 +324,13 @@ const importBtnStyle: React.CSSProperties = {
   background: "rgba(99, 102, 241, 0.08)",
   border: "1px solid rgba(99, 102, 241, 0.25)",
   color: "#6366f1",
+};
+
+const guideBtnStyle: React.CSSProperties = {
+  ...textBtnBase,
+  background: "rgba(100, 116, 139, 0.08)",
+  border: "1px solid rgba(100, 116, 139, 0.3)",
+  color: "#64748b",
 };
 
 const dropdownStyle: React.CSSProperties = {
@@ -603,9 +619,19 @@ function PipelineEditorInner({
         {IconImport} Import
       </button>
 
-      {/* Group 3: Templates & Add Node */}
+      {/* Group 3: Guide, Templates & Add Node */}
+      <button
+        data-testid="pipeline-editor-guide"
+        onClick={() => startTour()}
+        style={guideBtnStyle}
+        title="Show user guide"
+        aria-label="Show user guide"
+      >
+        {IconGuide} Guide
+      </button>
       <div style={{ position: "relative" }}>
         <button
+          data-testid="pipeline-editor-templates"
           onClick={() => {
             setShowTemplateMenu(!showTemplateMenu);
             setShowAddMenu(false);

--- a/src/components/Viewport.tsx
+++ b/src/components/Viewport.tsx
@@ -179,23 +179,6 @@ export function Viewport({
         position: "relative",
         background: "#ffffff",
       }}
-    >
-      {/* Invisible anchor that frames a representative region of the 3D
-          canvas (away from the right-hand Pipeline panel) so the guide tour
-          can highlight just the viewport area instead of the whole view. */}
-      <div
-        data-tour-anchor="viewport"
-        aria-hidden="true"
-        style={{
-          position: "absolute",
-          top: "18%",
-          left: "12%",
-          width: "46%",
-          height: "60%",
-          pointerEvents: "none",
-          opacity: 0,
-        }}
-      />
-    </div>
+    />
   );
 }

--- a/src/components/Viewport.tsx
+++ b/src/components/Viewport.tsx
@@ -179,6 +179,23 @@ export function Viewport({
         position: "relative",
         background: "#ffffff",
       }}
-    />
+    >
+      {/* Invisible anchor that frames a representative region of the 3D
+          canvas (away from the right-hand Pipeline panel) so the guide tour
+          can highlight just the viewport area instead of the whole view. */}
+      <div
+        data-tour-anchor="viewport"
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          top: "18%",
+          left: "12%",
+          width: "46%",
+          height: "60%",
+          pointerEvents: "none",
+          opacity: 0,
+        }}
+      />
+    </div>
   );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ import { MeganeViewer } from "./components/MeganeViewer";
 import { useDataSource } from "./hooks/useDataSource";
 import { usePipelineStore } from "./pipeline/store";
 import { usePlaybackStore } from "./stores/usePlaybackStore";
+import { useTour } from "./tour/useTour";
 import { parseXTCFile } from "./parsers/xtc";
 import { MemoryFrameProvider } from "./pipeline/types";
 import defaultPDB from "../tests/fixtures/caffeine_water.pdb?raw";
@@ -28,6 +29,7 @@ export type { DataMode };
 function App() {
   const [mode] = useState<DataMode>("local");
   const ds = useDataSource(mode);
+  useTour({ host: "webapp" });
 
   // Playback store state
   const playing = usePlaybackStore((s) => s.playing);

--- a/src/tour/MeganeTour.ts
+++ b/src/tour/MeganeTour.ts
@@ -1,0 +1,80 @@
+/**
+ * Thin wrapper around driver.js that owns tour lifecycle: configuring steps,
+ * rendering a "don't show again" checkbox in the footer, and forwarding state
+ * changes to the tour store so React components stay in sync.
+ */
+import { driver, type Driver } from "driver.js";
+import "driver.js/dist/driver.css";
+import "./tour.css";
+import { useTourStore } from "./tourStore";
+import { buildTourSteps } from "./tourSteps";
+
+const CHECKBOX_ID = "megane-tour-dont-show";
+
+let activeDriver: Driver | null = null;
+
+function injectDontShowCheckbox(footer: HTMLElement): void {
+  if (footer.querySelector(`#${CHECKBOX_ID}`)) return;
+
+  const wrapper = document.createElement("label");
+  wrapper.className = "megane-tour-dont-show";
+  wrapper.htmlFor = CHECKBOX_ID;
+
+  const input = document.createElement("input");
+  input.type = "checkbox";
+  input.id = CHECKBOX_ID;
+  input.checked = useTourStore.getState().dontShowAgain;
+  input.addEventListener("change", () => {
+    useTourStore.getState().setDontShowAgain(input.checked);
+  });
+
+  const text = document.createElement("span");
+  text.textContent = "Don't show this again";
+
+  wrapper.appendChild(input);
+  wrapper.appendChild(text);
+
+  // Place the checkbox at the very start of the footer so it sits left of
+  // the progress text and navigation buttons.
+  footer.insertBefore(wrapper, footer.firstChild);
+}
+
+export function startTour(): void {
+  // Re-create the driver on every start so steps reflect the latest DOM
+  // (panels can be collapsed/expanded between sessions).
+  if (activeDriver) {
+    activeDriver.destroy();
+    activeDriver = null;
+  }
+
+  const tour = driver({
+    showProgress: true,
+    progressText: "{{current}} / {{total}}",
+    nextBtnText: "Next",
+    prevBtnText: "Back",
+    doneBtnText: "Done",
+    allowClose: true,
+    overlayOpacity: 0.55,
+    overlayColor: "#0f172a",
+    stagePadding: 6,
+    stageRadius: 10,
+    popoverClass: "megane-tour",
+    steps: buildTourSteps(),
+    onPopoverRender: (popover) => {
+      injectDontShowCheckbox(popover.footer);
+    },
+    onDestroyed: () => {
+      useTourStore.getState().setActive(false);
+      activeDriver = null;
+    },
+  });
+
+  activeDriver = tour;
+  useTourStore.getState().setActive(true);
+  tour.drive();
+}
+
+export function stopTour(): void {
+  activeDriver?.destroy();
+  activeDriver = null;
+}

--- a/src/tour/tour.css
+++ b/src/tour/tour.css
@@ -2,7 +2,12 @@
    viewer (Inter font, slate text, blue/violet accents, soft shadow). */
 
 .driver-popover.megane-tour {
-  font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+  font-family:
+    "Inter",
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    sans-serif;
   border-radius: 10px;
   border: 1px solid #e2e8f0;
   box-shadow:

--- a/src/tour/tour.css
+++ b/src/tour/tour.css
@@ -136,6 +136,102 @@
   cursor: pointer;
 }
 
+/* Welcome (intro) step formatting. */
+.megane-tour-welcome {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.megane-tour-welcome-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.megane-tour-welcome-name {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: #0f172a;
+  background: linear-gradient(120deg, #3b82f6 0%, #8b5cf6 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.megane-tour-welcome-version {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  color: #64748b;
+  background: rgba(100, 116, 139, 0.1);
+  border: 1px solid rgba(100, 116, 139, 0.2);
+  border-radius: 999px;
+  padding: 2px 8px;
+  letter-spacing: 0.02em;
+}
+
+.megane-tour-welcome-tagline {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1e293b;
+  font-style: italic;
+}
+
+.megane-tour-welcome-blurb {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: #475569;
+}
+
+.megane-tour-welcome-author {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 4px;
+  padding-top: 10px;
+  border-top: 1px solid #e2e8f0;
+}
+
+.megane-tour-welcome-author-label {
+  font-size: 11.5px;
+  font-weight: 500;
+  color: #64748b;
+}
+
+.megane-tour-welcome-author-icons {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.megane-tour-icon-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  color: #475569;
+  border: 1px solid transparent;
+  transition:
+    color 140ms ease,
+    background-color 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease;
+}
+
+.megane-tour-icon-link:hover {
+  color: #0f172a;
+  background: rgba(59, 130, 246, 0.08);
+  border-color: rgba(59, 130, 246, 0.25);
+  transform: translateY(-1px);
+}
+
 /* Mouse-controls step formatting. */
 .megane-tour-keys {
   list-style: none;

--- a/src/tour/tour.css
+++ b/src/tour/tour.css
@@ -1,0 +1,198 @@
+/* megane tour theme — overrides driver.js defaults to match the rest of the
+   viewer (Inter font, slate text, blue/violet accents, soft shadow). */
+
+.driver-popover.megane-tour {
+  font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+  border-radius: 10px;
+  border: 1px solid #e2e8f0;
+  box-shadow:
+    0 12px 32px rgba(15, 23, 42, 0.18),
+    0 2px 6px rgba(15, 23, 42, 0.08);
+  padding: 18px 20px 14px;
+  max-width: 360px;
+  color: #1e293b;
+  background: #ffffff;
+}
+
+.driver-popover.megane-tour .driver-popover-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+  margin-bottom: 6px;
+  padding-right: 24px;
+}
+
+.driver-popover.megane-tour .driver-popover-description {
+  font-size: 13px;
+  line-height: 1.55;
+  color: #334155;
+}
+
+.driver-popover.megane-tour .driver-popover-close-btn {
+  color: #94a3b8;
+  font-size: 18px;
+  top: 8px;
+  right: 8px;
+}
+.driver-popover.megane-tour .driver-popover-close-btn:hover {
+  color: #475569;
+}
+
+.driver-popover.megane-tour .driver-popover-footer {
+  margin-top: 14px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.driver-popover.megane-tour .driver-popover-progress-text {
+  font-size: 11px;
+  font-weight: 600;
+  color: #94a3b8;
+  letter-spacing: 0.04em;
+}
+
+.driver-popover.megane-tour .driver-popover-navigation-btns {
+  display: inline-flex;
+  gap: 6px;
+  margin-left: auto;
+}
+
+.driver-popover.megane-tour .driver-popover-prev-btn,
+.driver-popover.megane-tour .driver-popover-next-btn {
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  border-radius: 6px;
+  padding: 6px 12px;
+  cursor: pointer;
+  text-shadow: none;
+  line-height: 1.2;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
+}
+
+.driver-popover.megane-tour .driver-popover-prev-btn {
+  background: rgba(148, 163, 184, 0.1);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: #475569;
+}
+.driver-popover.megane-tour .driver-popover-prev-btn:hover {
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.driver-popover.megane-tour .driver-popover-next-btn {
+  background: #3b82f6;
+  border: 1px solid #3b82f6;
+  color: #ffffff;
+}
+.driver-popover.megane-tour .driver-popover-next-btn:hover {
+  background: #2563eb;
+  border-color: #2563eb;
+}
+
+/* Last step: the Next button doubles as the Done button. Tint it violet to
+   match the Templates accent and signal completion. */
+.driver-popover.megane-tour:has(.driver-popover-progress-text:not(:empty))
+  .driver-popover-next-btn[disabled],
+.driver-popover.megane-tour .driver-popover-next-btn.driver-popover-btn-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.driver-popover.megane-tour .driver-popover-arrow-side-left.driver-popover-arrow {
+  border-left-color: #ffffff;
+}
+.driver-popover.megane-tour .driver-popover-arrow-side-right.driver-popover-arrow {
+  border-right-color: #ffffff;
+}
+.driver-popover.megane-tour .driver-popover-arrow-side-top.driver-popover-arrow {
+  border-top-color: #ffffff;
+}
+.driver-popover.megane-tour .driver-popover-arrow-side-bottom.driver-popover-arrow {
+  border-bottom-color: #ffffff;
+}
+
+/* "Don't show again" checkbox injected into the popover footer. */
+.megane-tour-dont-show {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11.5px;
+  color: #64748b;
+  cursor: pointer;
+  user-select: none;
+}
+.megane-tour-dont-show input {
+  margin: 0;
+  accent-color: #3b82f6;
+  cursor: pointer;
+}
+
+/* Mouse-controls step formatting. */
+.megane-tour-keys {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 6px;
+}
+.megane-tour-keys li {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  align-items: center;
+  gap: 10px;
+  font-size: 12.5px;
+  color: #334155;
+}
+.megane-tour-key {
+  display: inline-block;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  color: #1e293b;
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  border-radius: 5px;
+  padding: 2px 6px;
+  text-align: center;
+  white-space: nowrap;
+}
+
+/* Links step formatting. */
+.megane-tour-links {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 4px;
+}
+.megane-tour-link-row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.megane-tour-link-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #94a3b8;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.megane-tour-link {
+  font-size: 12.5px;
+  color: #3b82f6;
+  text-decoration: none;
+  word-break: break-all;
+}
+.megane-tour-link:hover {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+/* Highlight ring colour to match the primary accent. */
+.driver-overlay {
+  pointer-events: auto;
+}

--- a/src/tour/tour.css
+++ b/src/tour/tour.css
@@ -167,34 +167,102 @@
   white-space: nowrap;
 }
 
-/* Links step formatting. */
+/* Links step formatting — card layout with icons. */
+.megane-tour-links-intro {
+  margin: 0 0 10px;
+  font-size: 12.5px;
+  color: #475569;
+}
+
 .megane-tour-links {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  margin-top: 4px;
+  gap: 8px;
 }
-.megane-tour-link-row {
+
+.megane-tour-link-card {
+  display: grid;
+  grid-template-columns: 36px 1fr 18px;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  background: #ffffff;
+  text-decoration: none;
+  color: inherit;
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease,
+    box-shadow 140ms ease;
+}
+
+.megane-tour-link-card:hover {
+  border-color: rgba(59, 130, 246, 0.45);
+  background: rgba(59, 130, 246, 0.04);
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
+  transform: translateY(-1px);
+}
+
+.megane-tour-link-card-icon {
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.05);
+  color: #0f172a;
+  flex-shrink: 0;
+}
+
+.megane-tour-link-card:hover .megane-tour-link-card-icon {
+  background: rgba(59, 130, 246, 0.1);
+  color: #1d4ed8;
+}
+
+.megane-tour-link-card-body {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 1px;
+  min-width: 0;
 }
-.megane-tour-link-label {
-  font-size: 11px;
+
+.megane-tour-link-card-title {
+  font-size: 13px;
   font-weight: 600;
+  color: #0f172a;
+  line-height: 1.2;
+}
+
+.megane-tour-link-card-subtitle {
+  font-size: 11.5px;
+  color: #64748b;
+  line-height: 1.3;
+}
+
+.megane-tour-link-card-host {
+  margin-top: 2px;
+  font-size: 10.5px;
+  font-weight: 500;
   color: #94a3b8;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.02em;
 }
-.megane-tour-link {
-  font-size: 12.5px;
+
+.megane-tour-link-card-arrow {
+  color: #94a3b8;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    color 140ms ease,
+    transform 140ms ease;
+}
+
+.megane-tour-link-card:hover .megane-tour-link-card-arrow {
   color: #3b82f6;
-  text-decoration: none;
-  word-break: break-all;
-}
-.megane-tour-link:hover {
-  color: #2563eb;
-  text-decoration: underline;
+  transform: translateX(2px);
 }
 
 /* Highlight ring colour to match the primary accent. */

--- a/src/tour/tourSteps.ts
+++ b/src/tour/tourSteps.ts
@@ -13,9 +13,14 @@
  * them centred so they work on every host even when no anchor is present.
  */
 import type { DriveStep } from "driver.js";
+import packageJson from "../../package.json";
+
+const APP_VERSION = (packageJson as { version: string }).version;
 
 const REPO_URL = "https://github.com/hodakamori/megane";
-const DOCS_URL = "https://github.com/hodakamori/megane#readme";
+const DOCS_URL = "https://hodakamori.github.io/megane/";
+const AUTHOR_GITHUB_URL = "https://github.com/hodakamori";
+const AUTHOR_LINKEDIN_URL = "https://www.linkedin.com/in/hodaka-mori-146b61ba/";
 
 const ICON_GITHUB = `
   <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true">
@@ -28,6 +33,11 @@ const ICON_DOCS = `
     <path d="M4 18.5A2.5 2.5 0 0 1 6.5 16H20"/>
     <path d="M8 7h8"/>
     <path d="M8 11h6"/>
+  </svg>`;
+
+const ICON_LINKEDIN = `
+  <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+    <path fill="currentColor" d="M20.45 20.45h-3.55v-5.57c0-1.33-.02-3.04-1.85-3.04-1.85 0-2.13 1.45-2.13 2.94v5.67H9.37V9h3.41v1.56h.05c.47-.9 1.63-1.85 3.36-1.85 3.6 0 4.26 2.37 4.26 5.45v6.29ZM5.34 7.43a2.06 2.06 0 1 1 0-4.12 2.06 2.06 0 0 1 0 4.12ZM7.12 20.45H3.56V9h3.56v11.45ZM22.22 0H1.77C.79 0 0 .77 0 1.72v20.55C0 23.23.79 24 1.77 24h20.45c.98 0 1.78-.77 1.78-1.72V1.72C24 .77 23.2 0 22.22 0Z"/>
   </svg>`;
 
 const ICON_ARROW = `
@@ -64,8 +74,38 @@ function linkCard(opts: {
     </a>`;
 }
 
+function welcomeDescription(): string {
+  return `
+    <div class="megane-tour-welcome">
+      <div class="megane-tour-welcome-header">
+        <span class="megane-tour-welcome-name">megane</span>
+        <span class="megane-tour-welcome-version">v${escapeHtml(APP_VERSION)}</span>
+      </div>
+      <p class="megane-tour-welcome-tagline">Spectacles for atomistic data.</p>
+      <p class="megane-tour-welcome-blurb">
+        A fast, beautiful molecular viewer — render millions of atoms at 60fps,
+        build visual pipelines, and embed it in Jupyter, the browser, React, or VSCode.
+      </p>
+      <div class="megane-tour-welcome-author">
+        <span class="megane-tour-welcome-author-label">Built by hodakamori</span>
+        <span class="megane-tour-welcome-author-icons">
+          <a class="megane-tour-icon-link" href="${escapeHtml(AUTHOR_GITHUB_URL)}" target="_blank" rel="noopener noreferrer" aria-label="Author on GitHub" title="GitHub">${ICON_GITHUB}</a>
+          <a class="megane-tour-icon-link" href="${escapeHtml(AUTHOR_LINKEDIN_URL)}" target="_blank" rel="noopener noreferrer" aria-label="Author on LinkedIn" title="LinkedIn">${ICON_LINKEDIN}</a>
+        </span>
+      </div>
+    </div>`;
+}
+
 export function buildTourSteps(): DriveStep[] {
   return [
+    {
+      popover: {
+        title: "Welcome",
+        description: welcomeDescription(),
+        side: "over",
+        align: "center",
+      },
+    },
     {
       element: '[data-tour-anchor="viewport"]',
       popover: {

--- a/src/tour/tourSteps.ts
+++ b/src/tour/tourSteps.ts
@@ -1,0 +1,94 @@
+/**
+ * Step definitions for the megane first-time user tour.
+ *
+ * Targets reference DOM nodes that already exist in the shared MeganeViewer:
+ *  - viewer-root      (Viewport.tsx)
+ *  - panel-pipeline   (CollapsiblePanel for PipelineEditor)
+ *  - pipeline-editor-templates (Templates button in PipelineEditor headerExtra)
+ *
+ * The final two steps are unattached modals (no `element`); driver.js renders
+ * them centred so they work on every host even when no anchor is present.
+ */
+import type { DriveStep } from "driver.js";
+
+const REPO_URL = "https://github.com/hodakamori/megane";
+const DOCS_URL = "https://github.com/hodakamori/megane#readme";
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function linkRow(label: string, url: string): string {
+  const safeUrl = escapeHtml(url);
+  const safeLabel = escapeHtml(label);
+  return `
+    <div class="megane-tour-link-row">
+      <div class="megane-tour-link-label">${safeLabel}</div>
+      <a class="megane-tour-link" href="${safeUrl}" target="_blank" rel="noopener noreferrer">${safeUrl}</a>
+    </div>`;
+}
+
+export function buildTourSteps(): DriveStep[] {
+  return [
+    {
+      element: '[data-testid="viewer-root"]',
+      popover: {
+        title: "3D Viewport",
+        description:
+          "This is where structures are rendered. Atoms, bonds, cells and trajectories all draw here.",
+        side: "right",
+        align: "center",
+      },
+    },
+    {
+      element: '[data-testid="panel-pipeline"]',
+      popover: {
+        title: "Pipeline",
+        description:
+          "Build a rendering pipeline by connecting nodes: load files, apply bonds, attach trajectories, and choose a visual style.",
+        side: "left",
+        align: "start",
+      },
+    },
+    {
+      element: '[data-testid="pipeline-editor-templates"]',
+      popover: {
+        title: "Templates",
+        description:
+          "Pick a starter pipeline (molecule, solid, streaming) to see a working setup in one click.",
+        side: "bottom",
+        align: "end",
+      },
+    },
+    {
+      popover: {
+        title: "Mouse Controls",
+        description: `
+          <ul class="megane-tour-keys">
+            <li><span class="megane-tour-key">Left&nbsp;drag</span> Rotate the camera</li>
+            <li><span class="megane-tour-key">Right&nbsp;drag</span> Pan</li>
+            <li><span class="megane-tour-key">Wheel</span> Zoom</li>
+            <li><span class="megane-tour-key">Right&nbsp;click</span> Pick an atom for measurement</li>
+          </ul>`,
+        side: "over",
+        align: "center",
+      },
+    },
+    {
+      popover: {
+        title: "Learn More",
+        description: `
+          <div class="megane-tour-links">
+            ${linkRow("GitHub repository", REPO_URL)}
+            ${linkRow("Documentation", DOCS_URL)}
+          </div>`,
+        side: "over",
+        align: "center",
+      },
+    },
+  ];
+}

--- a/src/tour/tourSteps.ts
+++ b/src/tour/tourSteps.ts
@@ -2,9 +2,12 @@
  * Step definitions for the megane first-time user tour.
  *
  * Targets reference DOM nodes that already exist in the shared MeganeViewer:
- *  - viewer-root      (Viewport.tsx)
- *  - panel-pipeline   (CollapsiblePanel for PipelineEditor)
- *  - pipeline-editor-templates (Templates button in PipelineEditor headerExtra)
+ *  - [data-tour-anchor="viewport"]   — invisible region inside Viewport.tsx
+ *                                      so we highlight just the canvas area,
+ *                                      not the whole view (which would also
+ *                                      include the Pipeline panel)
+ *  - [data-testid="panel-pipeline"]  — CollapsiblePanel for PipelineEditor
+ *  - [data-testid="pipeline-editor-templates"] — Templates button
  *
  * The final two steps are unattached modals (no `element`); driver.js renders
  * them centred so they work on every host even when no anchor is present.
@@ -14,6 +17,25 @@ import type { DriveStep } from "driver.js";
 const REPO_URL = "https://github.com/hodakamori/megane";
 const DOCS_URL = "https://github.com/hodakamori/megane#readme";
 
+const ICON_GITHUB = `
+  <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true">
+    <path fill="currentColor" d="M12 .5C5.73.5.5 5.74.5 12.02c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56 0-.27-.01-1.17-.02-2.13-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.35.96.1-.74.4-1.25.73-1.54-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.45.11-3.02 0 0 .96-.31 3.16 1.17a10.99 10.99 0 0 1 5.76 0c2.2-1.48 3.16-1.17 3.16-1.17.62 1.57.23 2.73.11 3.02.74.8 1.18 1.82 1.18 3.07 0 4.4-2.7 5.36-5.27 5.65.41.36.78 1.06.78 2.14 0 1.55-.01 2.79-.01 3.17 0 .31.21.67.8.55C20.71 21.4 24 17.1 24 12.02 24 5.74 18.77.5 12.5.5h-.5Z"/>
+  </svg>`;
+
+const ICON_DOCS = `
+  <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M4 4.5A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v17a1 1 0 0 1-1 1H6.5A2.5 2.5 0 0 1 4 18.5v-14Z"/>
+    <path d="M4 18.5A2.5 2.5 0 0 1 6.5 16H20"/>
+    <path d="M8 7h8"/>
+    <path d="M8 11h6"/>
+  </svg>`;
+
+const ICON_ARROW = `
+  <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <line x1="5" y1="12" x2="19" y2="12"/>
+    <polyline points="13 6 19 12 13 18"/>
+  </svg>`;
+
 function escapeHtml(value: string): string {
   return value
     .replace(/&/g, "&amp;")
@@ -22,24 +44,34 @@ function escapeHtml(value: string): string {
     .replace(/"/g, "&quot;");
 }
 
-function linkRow(label: string, url: string): string {
-  const safeUrl = escapeHtml(url);
-  const safeLabel = escapeHtml(label);
+function linkCard(opts: {
+  href: string;
+  icon: string;
+  title: string;
+  subtitle: string;
+  hostLabel: string;
+}): string {
+  const safeHref = escapeHtml(opts.href);
   return `
-    <div class="megane-tour-link-row">
-      <div class="megane-tour-link-label">${safeLabel}</div>
-      <a class="megane-tour-link" href="${safeUrl}" target="_blank" rel="noopener noreferrer">${safeUrl}</a>
-    </div>`;
+    <a class="megane-tour-link-card" href="${safeHref}" target="_blank" rel="noopener noreferrer">
+      <span class="megane-tour-link-card-icon">${opts.icon}</span>
+      <span class="megane-tour-link-card-body">
+        <span class="megane-tour-link-card-title">${escapeHtml(opts.title)}</span>
+        <span class="megane-tour-link-card-subtitle">${escapeHtml(opts.subtitle)}</span>
+        <span class="megane-tour-link-card-host">${escapeHtml(opts.hostLabel)}</span>
+      </span>
+      <span class="megane-tour-link-card-arrow">${ICON_ARROW}</span>
+    </a>`;
 }
 
 export function buildTourSteps(): DriveStep[] {
   return [
     {
-      element: '[data-testid="viewer-root"]',
+      element: '[data-tour-anchor="viewport"]',
       popover: {
         title: "3D Viewport",
         description:
-          "This is where structures are rendered. Atoms, bonds, cells and trajectories all draw here.",
+          "Atoms, bonds, cells and trajectories all draw here. Use the mouse to orbit, pan, and zoom around your structure.",
         side: "right",
         align: "center",
       },
@@ -82,9 +114,22 @@ export function buildTourSteps(): DriveStep[] {
       popover: {
         title: "Learn More",
         description: `
+          <p class="megane-tour-links-intro">Explore the source code or read the full documentation.</p>
           <div class="megane-tour-links">
-            ${linkRow("GitHub repository", REPO_URL)}
-            ${linkRow("Documentation", DOCS_URL)}
+            ${linkCard({
+              href: REPO_URL,
+              icon: ICON_GITHUB,
+              title: "GitHub repository",
+              subtitle: "Source, issues and releases",
+              hostLabel: "github.com",
+            })}
+            ${linkCard({
+              href: DOCS_URL,
+              icon: ICON_DOCS,
+              title: "Documentation",
+              subtitle: "Guides, examples and API reference",
+              hostLabel: "github.com",
+            })}
           </div>`,
         side: "over",
         align: "center",

--- a/src/tour/tourStore.ts
+++ b/src/tour/tourStore.ts
@@ -1,0 +1,98 @@
+/**
+ * Tour state for the first-time user guide.
+ *
+ * Persisted state lives in localStorage under STORAGE_KEY and is JSON-encoded.
+ * The store keeps host metadata (which platform we're embedded in) so callers
+ * can decide the per-host default behaviour and skip auto-start where the host
+ * defaults to off (ipywidget).
+ */
+import { create } from "zustand";
+
+export type TourHost = "webapp" | "vscode" | "jupyterlab" | "ipywidget";
+
+const STORAGE_KEY = "megane-tour-prefs";
+
+const HOST_DEFAULT_AUTO_START: Record<TourHost, boolean> = {
+  webapp: true,
+  vscode: true,
+  jupyterlab: true,
+  ipywidget: false,
+};
+
+interface PersistedPrefs {
+  dontShowAgain: boolean;
+}
+
+function loadPrefs(): PersistedPrefs {
+  if (typeof localStorage === "undefined") return { dontShowAgain: false };
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { dontShowAgain: false };
+    const parsed = JSON.parse(raw) as Partial<PersistedPrefs>;
+    return { dontShowAgain: Boolean(parsed.dontShowAgain) };
+  } catch {
+    return { dontShowAgain: false };
+  }
+}
+
+function savePrefs(prefs: PersistedPrefs): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+  } catch {
+    // ignore quota / privacy-mode failures
+  }
+}
+
+interface TourState {
+  host: TourHost;
+  isActive: boolean;
+  dontShowAgain: boolean;
+  /** Becomes true once auto-start has run for this session, regardless of outcome. */
+  autoStartHandled: boolean;
+  setHost: (host: TourHost) => void;
+  setActive: (active: boolean) => void;
+  setDontShowAgain: (value: boolean) => void;
+  markAutoStartHandled: () => void;
+}
+
+export const useTourStore = create<TourState>((set) => ({
+  host: "webapp",
+  isActive: false,
+  dontShowAgain: loadPrefs().dontShowAgain,
+  autoStartHandled: false,
+  setHost: (host) => set({ host }),
+  setActive: (active) => set({ isActive: active }),
+  setDontShowAgain: (value) => {
+    savePrefs({ dontShowAgain: value });
+    set({ dontShowAgain: value });
+  },
+  markAutoStartHandled: () => set({ autoStartHandled: true }),
+}));
+
+/**
+ * URL query override for the webapp launcher: `?guide=on` forces the tour to
+ * start, `?guide=off` suppresses it for this session. Returns null on other
+ * hosts or when no recognised flag is present.
+ */
+function readWebappUrlOverride(): "on" | "off" | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const value = new URLSearchParams(window.location.search).get("guide");
+    if (value === "on" || value === "1" || value === "true") return "on";
+    if (value === "off" || value === "0" || value === "false") return "off";
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+export function shouldAutoStart(host: TourHost, dontShowAgain: boolean): boolean {
+  if (host === "webapp") {
+    const override = readWebappUrlOverride();
+    if (override === "on") return true;
+    if (override === "off") return false;
+  }
+  if (!HOST_DEFAULT_AUTO_START[host]) return false;
+  return !dontShowAgain;
+}

--- a/src/tour/useTour.ts
+++ b/src/tour/useTour.ts
@@ -1,0 +1,52 @@
+/**
+ * React hook that wires the tour into a host. It runs the auto-start gate once
+ * per session (per host) and exposes `startTour` for manual triggers like the
+ * Pipeline header Guide button.
+ */
+import { useCallback, useEffect } from "react";
+import { startTour, stopTour } from "./MeganeTour";
+import { shouldAutoStart, useTourStore, type TourHost } from "./tourStore";
+
+interface UseTourOptions {
+  host: TourHost;
+  /** Delay before auto-start so the highlighted DOM has settled. */
+  autoStartDelayMs?: number;
+}
+
+export function useTour({ host, autoStartDelayMs = 600 }: UseTourOptions) {
+  const setHost = useTourStore((s) => s.setHost);
+  const autoStartHandled = useTourStore((s) => s.autoStartHandled);
+  const markAutoStartHandled = useTourStore((s) => s.markAutoStartHandled);
+
+  useEffect(() => {
+    setHost(host);
+  }, [host, setHost]);
+
+  useEffect(() => {
+    if (autoStartHandled) return;
+    const { dontShowAgain } = useTourStore.getState();
+    if (!shouldAutoStart(host, dontShowAgain)) {
+      markAutoStartHandled();
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      markAutoStartHandled();
+      startTour();
+    }, autoStartDelayMs);
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [host, autoStartHandled, markAutoStartHandled, autoStartDelayMs]);
+
+  useEffect(() => {
+    return () => {
+      stopTour();
+    };
+  }, []);
+
+  const start = useCallback(() => {
+    startTour();
+  }, []);
+
+  return { startTour: start };
+}

--- a/vscode-megane/webview/main.tsx
+++ b/vscode-megane/webview/main.tsx
@@ -18,6 +18,7 @@ import { MeganeViewer } from "../../src/components/MeganeViewer";
 import { useMeganeLocal } from "../../src/hooks/useMeganeLocal";
 import { usePipelineStore } from "../../src/pipeline/store";
 import type { SerializedPipeline } from "../../src/pipeline/types";
+import { useTour } from "../../src/tour/useTour";
 import "../../src/styles/megane.css";
 
 // Acquire VS Code API
@@ -31,6 +32,7 @@ function setWasmUrlFromBytes(wasmBytes: number[] | undefined): void {
 
 function App() {
   const local = useMeganeLocal();
+  useTour({ host: "vscode" });
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
 


### PR DESCRIPTION
## Summary

Adds an in-app onboarding tour powered by [driver.js](https://driverjs.com/) that introduces new users to the megane viewer. The tour walks through five steps in order:

1. **Viewport** — highlights the 3D viewer canvas
2. **Pipeline** — highlights the pipeline editor panel
3. **Templates** — highlights the Templates button (starter pipelines)
4. **Mouse controls** — modal explaining left-drag rotate / right-drag pan / wheel zoom / right-click pick
5. **Links** — GitHub repository + documentation

### Behaviour per host

| Host | Auto-start on launch |
|---|---|
| Webapp | ON (overridable via `?guide=on` / `?guide=off`) |
| VSCode extension | ON |
| JupyterLab DocWidget / PipelineDocWidget | ON |
| ipywidget (anywidget) | OFF (no tour code bundled either) |

A "Don't show this again" checkbox in the popover footer is persisted to `localStorage` (`megane-tour-prefs`). Once checked, future sessions skip the tour automatically.

A new **Guide** button in the `PipelineEditor` header lets users re-trigger the tour at any time. Hosts that don't render the pipeline panel (ipywidget) simply don't get this button.

### Design

The popover styling overrides driver.js defaults to match the existing app palette: Inter font, slate text, blue (`#3b82f6`) primary action, violet/slate accents for secondary chrome, and a soft 12px box-shadow consistent with other panels.

### Files

- `src/tour/` — new module: `tourStore.ts` (Zustand + localStorage), `tourSteps.ts`, `MeganeTour.ts` (driver.js wrapper that injects the checkbox), `useTour.ts` (host hook), `tour.css` (theme overrides).
- `src/components/PipelineEditor.tsx` — adds Guide button + `data-testid="pipeline-editor-templates"` for the tour anchor.
- `src/index.tsx`, `vscode-megane/webview/main.tsx`, `jupyterlab-megane/src/Megane{Doc,PipelineDoc}Widget.tsx` — call `useTour({ host })`.
- `package.json` — adds `driver.js@^1.4.0`.

The widget bundle was verified to **not** include driver.js (saved bundle size for ipywidget users).

## Test plan

- [x] `npm test` — all 330 unit tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — no new warnings/errors
- [x] `npx vite build` (webapp) — succeeds, driver.js present in bundle
- [x] `npx vite build --config vite.widget.config.ts` — succeeds, driver.js absent from widget bundle
- [ ] Manual: load the webapp, confirm tour auto-starts, walk through all 5 steps, check the "Don't show again" checkbox, reload, confirm tour does not appear; click the Guide button to re-trigger.
- [ ] Manual: append `?guide=off` and confirm tour does not start; append `?guide=on` after dismissing and confirm it does.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J3fYBzRwVFW3K3NbUBfkLw)_