### PR TITLE
chore(deploy): add GitHub OIDC role for CI deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write # required for OIDC role assumption
 
 env:
   AWS_REGION: ap-northeast-1
@@ -48,8 +49,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - uses: hashicorp/setup-terraform@v3

--- a/deploy/terraform/iam.tf
+++ b/deploy/terraform/iam.tf
@@ -1,0 +1,211 @@
+# ---------------------------------------------------------------------------
+# GitHub Actions OIDC provider + CI deploy role
+#
+# Lets the workflow assume a least-privilege role via OIDC instead of using
+# long-lived static AWS access keys.
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
+  ]
+
+  tags = local.common_tags
+}
+
+data "aws_iam_policy_document" "ci_deploy_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github_actions.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    # Scope assumption to this repo. Loosen / tighten as needed:
+    #   "repo:owner/name:ref:refs/heads/main"   -> only main
+    #   "repo:owner/name:pull_request"          -> only PR runs
+    #   "repo:owner/name:*"                     -> any ref / event
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${var.github_repo}:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ci_deploy" {
+  name               = "${var.app_name}-ci-deploy"
+  assume_role_policy = data.aws_iam_policy_document.ci_deploy_assume_role.json
+
+  tags = local.common_tags
+}
+
+data "aws_iam_policy_document" "ci_deploy" {
+  # --- Terraform S3 backend (read/write tfstate) ---
+  statement {
+    sid     = "TfStateBucketRead"
+    effect  = "Allow"
+    actions = ["s3:ListBucket", "s3:GetBucketLocation"]
+    resources = [
+      "arn:aws:s3:::${var.app_name}-terraform-state",
+    ]
+  }
+
+  statement {
+    sid    = "TfStateObjectRW"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = [
+      "arn:aws:s3:::${var.app_name}-terraform-state/*",
+    ]
+  }
+
+  # --- Demo S3 bucket (full lifecycle: terraform create + workflow sync) ---
+  statement {
+    sid    = "DemoBucketManage"
+    effect = "Allow"
+    actions = [
+      "s3:CreateBucket",
+      "s3:DeleteBucket",
+      "s3:ListBucket",
+      "s3:GetBucket*",
+      "s3:PutBucket*",
+      "s3:DeleteBucketPolicy",
+      "s3:GetEncryptionConfiguration",
+      "s3:PutEncryptionConfiguration",
+    ]
+    resources = [
+      "arn:aws:s3:::${local.bucket_name}",
+    ]
+  }
+
+  statement {
+    sid    = "DemoBucketObjects"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:GetObjectTagging",
+      "s3:PutObjectTagging",
+    ]
+    resources = [
+      "arn:aws:s3:::${local.bucket_name}/*",
+    ]
+  }
+
+  # --- CloudFront (resource-level ARNs not supported on most actions) ---
+  statement {
+    sid    = "CloudFrontManage"
+    effect = "Allow"
+    actions = [
+      "cloudfront:CreateDistribution",
+      "cloudfront:GetDistribution",
+      "cloudfront:GetDistributionConfig",
+      "cloudfront:UpdateDistribution",
+      "cloudfront:DeleteDistribution",
+      "cloudfront:TagResource",
+      "cloudfront:UntagResource",
+      "cloudfront:ListTagsForResource",
+      "cloudfront:CreateOriginAccessControl",
+      "cloudfront:GetOriginAccessControl",
+      "cloudfront:GetOriginAccessControlConfig",
+      "cloudfront:UpdateOriginAccessControl",
+      "cloudfront:DeleteOriginAccessControl",
+      "cloudfront:ListOriginAccessControls",
+      "cloudfront:CreateInvalidation",
+      "cloudfront:GetInvalidation",
+      "cloudfront:ListInvalidations",
+      "cloudfront:ListDistributions",
+    ]
+    resources = ["*"]
+  }
+
+  # --- ACM (us-east-1 cert for CloudFront) ---
+  statement {
+    sid    = "AcmManage"
+    effect = "Allow"
+    actions = [
+      "acm:RequestCertificate",
+      "acm:DescribeCertificate",
+      "acm:GetCertificate",
+      "acm:ListCertificates",
+      "acm:DeleteCertificate",
+      "acm:AddTagsToCertificate",
+      "acm:RemoveTagsFromCertificate",
+      "acm:ListTagsForCertificate",
+    ]
+    resources = ["*"]
+  }
+
+  # --- Route53 (DNS records in the existing zone) ---
+  statement {
+    sid    = "Route53Read"
+    effect = "Allow"
+    actions = [
+      "route53:GetHostedZone",
+      "route53:ListHostedZones",
+      "route53:ListHostedZonesByName",
+      "route53:ListResourceRecordSets",
+      "route53:GetChange",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Route53Write"
+    effect = "Allow"
+    actions = [
+      "route53:ChangeResourceRecordSets",
+    ]
+    resources = [
+      "arn:aws:route53:::hostedzone/${data.aws_route53_zone.main.zone_id}",
+    ]
+  }
+
+  # --- IAM read-only on the role + OIDC provider (terraform refresh) ---
+  statement {
+    sid    = "IamSelfRead"
+    effect = "Allow"
+    actions = [
+      "iam:GetRole",
+      "iam:GetRolePolicy",
+      "iam:ListRolePolicies",
+      "iam:ListAttachedRolePolicies",
+      "iam:GetOpenIDConnectProvider",
+    ]
+    resources = [
+      aws_iam_role.ci_deploy.arn,
+      aws_iam_openid_connect_provider.github_actions.arn,
+    ]
+  }
+
+  # --- Caller identity ---
+  statement {
+    sid       = "StsCallerIdentity"
+    effect    = "Allow"
+    actions   = ["sts:GetCallerIdentity"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "ci_deploy" {
+  name   = "${var.app_name}-ci-deploy"
+  role   = aws_iam_role.ci_deploy.id
+  policy = data.aws_iam_policy_document.ci_deploy.json
+}

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -17,3 +17,13 @@ output "service_url" {
   description = "Public URL of the application"
   value       = "https://${var.domain_name}"
 }
+
+output "ci_deploy_role_arn" {
+  description = "ARN of the IAM role assumed by GitHub Actions via OIDC"
+  value       = aws_iam_role.ci_deploy.arn
+}
+
+output "github_oidc_provider_arn" {
+  description = "ARN of the GitHub Actions OIDC provider"
+  value       = aws_iam_openid_connect_provider.github_actions.arn
+}

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -15,3 +15,9 @@ variable "domain_name" {
   type        = string
   default     = "megane.tech-office-mori.com"
 }
+
+variable "github_repo" {
+  description = "GitHub repository (owner/name) allowed to assume the CI deploy role via OIDC"
+  type        = string
+  default     = "hodakamori/megane"
+}


### PR DESCRIPTION
Closing without merge.

Decision: stay with the existing IAM user `megane` + static access keys for CI auth instead of migrating to OIDC. The OIDC role would be the more secure long-term setup, but Option A (attach policies to the existing user) is simpler and acceptable for the current scope. PR #319 already shipped the S3+CloudFront migration; CI on main continues to use `secrets.AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` against that user.

If we want to revisit OIDC later, this PR's diff (a single self-contained `iam.tf` + 4-line workflow change) can be cherry-picked from `claude/oidc-deploy-role` at any time.

https://claude.ai/code/session_018kYV5DSUdcvVQM4bCe8ZbJ