### PR TITLE
Add LICENSE file to vscode-megane extension

### DIFF
--- a/vscode-megane/LICENSE
+++ b/vscode-megane/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 hodakamori
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- Copy the root MIT `LICENSE` into `vscode-megane/` so `vsce package` no longer emits the `LICENSE, LICENSE.md, or LICENSE.txt not found` warning.
- `vscode-megane/package.json` already declares `"license": "MIT"`; this lands the actual file alongside that declaration so it ships inside the `.vsix` and is shown to Marketplace users.

## Test plan
- [ ] `cd vscode-megane && npx vsce package` no longer prompts about a missing LICENSE
- [ ] CI green via `gh run list`

https://claude.ai/code/session_019XVchRAvjm1qZZsL4toaTk

---
_Generated by [Claude Code](https://claude.ai/code/session_019XVchRAvjm1qZZsL4toaTk)_