### PR TITLE
fix(pipeline): align toolbar buttons across category rows

### DIFF
--- a/src/components/PipelineEditor.tsx
+++ b/src/components/PipelineEditor.tsx
@@ -393,7 +393,7 @@ const toolbarCategoryLabelStyle: React.CSSProperties = {
   textTransform: "uppercase",
   letterSpacing: "0.08em",
   marginRight: 2,
-  minWidth: 38,
+  width: 64,
   flexShrink: 0,
 };
 


### PR DESCRIPTION
## Summary

The Pipeline toolbar is laid out as three rows ("Pipeline", "I/O", "Others"), each with a small uppercase category label followed by buttons. The category label used `minWidth: 38`, which is narrower than the natural width of the longest label (`PIPELINE` at fontSize 9, fontWeight 700, uppercase with 0.08em letter-spacing renders at ~56–60px). Each row therefore expanded the label to fit its own text, and the buttons started at different x positions per row.

Switch the label to a fixed `width: 64` so every category cell reserves the same horizontal slot, and the first button of each row lines up vertically.

- File: `src/components/PipelineEditor.tsx` (`toolbarCategoryLabelStyle`)
- Change: `minWidth: 38` → `width: 64`

## Test plan

- [ ] Open the viewer, expand the Pipeline panel, and confirm the first button of the `Pipeline`, `I/O`, and `Others` rows starts at the same x position.
- [ ] Verify the longest label (`PIPELINE`) is not truncated.
- [ ] Run `npm run test:e2e:webapp` and re-baseline if the toolbar snapshot drifts (`MEGANE_E2E_UPDATE=1`).


---
_Generated by [Claude Code](https://claude.ai/code/session_018h6GA4NTKSv6sAEM15sJyq)_