### PR TITLE
feat(pipeline): pick AddBond default by file format on open

### DIFF
--- a/src/pipeline/openFile.ts
+++ b/src/pipeline/openFile.ts
@@ -68,6 +68,17 @@ const TRAJECTORY_EXTS = [".xtc", ".lammpstrj", ".dump"];
 
 const PIPELINE_SUFFIX = ".megane.json";
 
+// Structure formats that embed bond information directly in the file
+// (PDB CONECT records, MOL/SDF bond block, LAMMPS data Bonds section).
+// Other supported structure formats (xyz, gro, cif, traj) carry no bond
+// information, so VDW distance inference is the more useful default.
+const FILE_BOND_EXTS = [".pdb", ".ent", ".pdbx", ".mol", ".sdf", ".data", ".lammps"];
+
+function defaultBondSourceForFile(filename: string): "structure" | "distance" {
+  const lower = filename.toLowerCase();
+  return FILE_BOND_EXTS.some((ext) => lower.endsWith(ext)) ? "structure" : "distance";
+}
+
 function classify(filename: string): FileKind {
   const lower = filename.toLowerCase();
   if (lower.endsWith(PIPELINE_SUFFIX)) return "pipeline";
@@ -154,6 +165,26 @@ async function openStructure(
     hasTrajectory: result.frames.length > 0,
     hasCell: !!result.snapshot.box,
   });
+
+  // Switch the AddBond node(s) consuming this loader to a bondSource that
+  // matches the file format: "structure" for formats that embed bonds
+  // (PDB/MOL/SDF/LAMMPS data), "distance" (VDW inference) for formats that
+  // don't (XYZ/GRO/CIF/traj). Only nodes whose `particle` input comes from
+  // the targeted loader are touched; user-customised AddBond nodes wired
+  // elsewhere are left alone.
+  const desiredBondSource = defaultBondSourceForFile(file.name);
+  const stateAfterLoader = api.getState();
+  const addBondTargets = new Set<string>();
+  for (const edge of stateAfterLoader.edges) {
+    if (edge.source !== loaderId) continue;
+    if (edge.sourceHandle && edge.sourceHandle !== "particle") continue;
+    if (edge.targetHandle && edge.targetHandle !== "particle") continue;
+    const targetNode = stateAfterLoader.nodes.find((n) => n.id === edge.target);
+    if (targetNode?.type === "add_bond") addBondTargets.add(targetNode.id);
+  }
+  for (const id of addBondTargets) {
+    state.updateNodeParams(id, { bondSource: desiredBondSource });
+  }
 
   if (result.vectorChannels && result.vectorChannels.length > 0) {
     state.setFileVectors(result.vectorChannels[0].frames);

--- a/tests/ts/pipeline/openFile.test.ts
+++ b/tests/ts/pipeline/openFile.test.ts
@@ -133,6 +133,81 @@ describe("usePipelineStore.openFile — single structure file", () => {
   });
 });
 
+describe("usePipelineStore.openFile — AddBond default by file format", () => {
+  function bondSourceFor(loaderId: string): string | undefined {
+    const state = usePipelineStore.getState();
+    const addBondId = state.edges.find(
+      (e) => e.source === loaderId && (e.sourceHandle ?? "particle") === "particle",
+    )?.target;
+    if (!addBondId) return undefined;
+    const node = state.nodes.find((n) => n.id === addBondId && n.type === "add_bond");
+    return node ? (node.data.params as { bondSource: string }).bondSource : undefined;
+  }
+
+  const formatsWithBonds: Array<[string, string]> = [
+    ["water.pdb", "structure"],
+    ["entry.ent", "structure"],
+    ["model.pdbx", "structure"],
+    ["caffeine.mol", "structure"],
+    ["library.sdf", "structure"],
+    ["system.data", "structure"],
+    ["system.lammps", "structure"],
+  ];
+  const formatsWithoutBonds: Array<[string, string]> = [
+    ["water.gro", "distance"],
+    ["coords.xyz", "distance"],
+    ["entry.cif", "distance"],
+    ["frames.traj", "distance"],
+  ];
+
+  for (const [filename, expected] of [...formatsWithBonds, ...formatsWithoutBonds]) {
+    it(`sets AddBond.bondSource="${expected}" for ${filename}`, async () => {
+      mockParseStructureFile.mockResolvedValueOnce({
+        snapshot: makeSnapshot(3),
+        frames: [],
+        meta: null,
+        labels: null,
+        vectorChannels: [],
+      });
+
+      const file = new File(["<data>"], filename);
+      await usePipelineStore.getState().openFile(file, { mode: "replace" });
+
+      const loader = usePipelineStore.getState().nodes.find((n) => n.type === "load_structure")!;
+      expect(bondSourceFor(loader.id)).toBe(expected);
+    });
+  }
+
+  it("updates AddBond.bondSource in merge mode too (re-opening a different format)", async () => {
+    // First load a .pdb so the seed AddBond is "structure" (matches file).
+    mockParseStructureFile.mockResolvedValueOnce({
+      snapshot: makeSnapshot(3),
+      frames: [],
+      meta: null,
+      labels: null,
+      vectorChannels: [],
+    });
+    await usePipelineStore.getState().openFile(new File(["<pdb>"], "first.pdb"), {
+      mode: "replace",
+    });
+
+    // Then merge in a .gro — AddBond should switch to VDW inference.
+    mockParseStructureFile.mockResolvedValueOnce({
+      snapshot: makeSnapshot(3),
+      frames: [],
+      meta: null,
+      labels: null,
+      vectorChannels: [],
+    });
+    await usePipelineStore.getState().openFile(new File(["<gro>"], "second.gro"), {
+      mode: "merge",
+    });
+
+    const loader = usePipelineStore.getState().nodes.find((n) => n.type === "load_structure")!;
+    expect(bondSourceFor(loader.id)).toBe("distance");
+  });
+});
+
 describe("usePipelineStore.openFile — trajectory files", () => {
   it("rejects when no load_structure snapshot has been loaded yet", async () => {
     // Reset clears nodeSnapshots, so even though the default graph has a


### PR DESCRIPTION
## Summary

When a structure file is opened via the shared `openFile` ingestion path (used by VSCode, JupyterLab, anywidget, and the webapp), the downstream AddBond node's `bondSource` is now chosen based on whether the file format embeds bond information:

- **`bondSource: "structure"` (UI label "File")** for formats that carry bonds: `.pdb`, `.ent`, `.pdbx`, `.mol`, `.sdf`, `.data`, `.lammps`. CONECT records / Bonds sections are used directly — same as today.
- **`bondSource: "distance"` (UI label "VDW")** for formats that don't: `.xyz`, `.gro`, `.cif`, `.traj`. VDW distance inference is the more useful default for these.

Only AddBond nodes wired to the `particle` output of the loader being populated are touched, so user-customised pipelines elsewhere in the graph are left alone. Pipeline (`.megane.json`) opens are unaffected — serialized bondSource is preserved.

## Test plan

- [x] `npm test` — 342 tests pass across 29 files (12 new cases in `tests/ts/pipeline/openFile.test.ts` cover all formats and the merge-mode re-open case)
- [x] `npm run lint` — no new warnings
- [x] `npm run format:check` — clean
- [ ] Manual VSCode: open `.pdb` → AddBond shows "File"; open `.gro` → AddBond shows "VDW"
- [ ] Manual JupyterLab DocWidget: same as above


---
_Generated by [Claude Code](https://claude.ai/code/session_0189Bf3cGaBr22RGvru8KM8X)_