### PR TITLE
ci: expand Codecov scope to TypeScript and Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test -p megane-core
+        with:
+          components: llvm-tools-preview
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - run: cargo llvm-cov --package megane-core --lcov --output-path lcov.info
+      - uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          flags: rust
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_on_error: false
 
   test-ts:
     name: TypeScript tests
@@ -63,7 +72,13 @@ jobs:
       - run: npm run build:wasm
       - run: npm run format:check
       - run: npm run lint
-      - run: npm test
+      - run: npm test -- --coverage
+      - uses: codecov/codecov-action@v5
+        with:
+          files: coverage/ts/lcov.info
+          flags: typescript
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_on_error: false
 
   test-python:
     name: Python tests
@@ -97,6 +112,7 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
+          flags: python
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_on_error: false
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,21 @@ coverage:
       default:
         target: auto
         threshold: 1%
+      python:
+        target: auto
+        threshold: 1%
+        flags:
+          - python
+      typescript:
+        target: auto
+        threshold: 1%
+        flags:
+          - typescript
+      rust:
+        target: auto
+        threshold: 1%
+        flags:
+          - rust
     patch:
       default:
         target: auto
@@ -14,7 +29,26 @@ comment:
   behavior: default
   require_changes: true
 
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: python
+      paths:
+        - python/megane/
+      carryforward: true
+    - name: typescript
+      paths:
+        - src/
+      carryforward: true
+    - name: rust
+      paths:
+        - crates/
+      carryforward: true
+
 ignore:
   - "python/megane/static/**"
   - "tests/**"
   - "docs/**"
+  - "**/*.d.ts"
+  - "src/vite-env.d.ts"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     setupFiles: ["tests/ts/setup.ts"],
     coverage: {
       provider: "v8",
-      reporter: ["text", "text-summary", "json", "html"],
+      reporter: ["text", "text-summary", "json", "html", "lcov"],
       reportsDirectory: "coverage/ts",
       include: ["src/**/*.{ts,tsx}"],
       exclude: ["src/vite-env.d.ts", "src/**/*.d.ts"],


### PR DESCRIPTION
## Summary

Codecov currently shows `python/megane/` as if it were the entire repository, because only the `test-python` CI job uploads coverage. This PR extends Codecov uploads to the TypeScript and Rust test jobs so the dashboard reflects the whole repo.

- **TypeScript** (`test-ts`): run `npm test -- --coverage` (vitest v8) and upload `coverage/ts/lcov.info` with flag `typescript`.
- **Rust** (`test-rust`): replace `cargo test` with `cargo llvm-cov --package megane-core --lcov` (via `taiki-e/install-action@cargo-llvm-cov`) and upload `lcov.info` with flag `rust`.
- **Python** (`test-python`): unchanged except for `flags: python` on the existing upload.
- **`codecov.yml`**: add per-flag project status checks and `flag_management` paths (`src/`, `crates/`, `python/megane/`) so each language is scoped to the right source tree.
- **`vitest.config.ts`**: add the `lcov` reporter to v8 coverage output.

## Test plan

- [ ] CI passes on this branch (`test-rust`, `test-ts`, `test-python` all green and uploading)
- [ ] Codecov PR comment shows three flags (python, typescript, rust) with non-empty file lists
- [ ] After merge, Codecov tree view at the repo root shows `src/`, `crates/`, and `python/megane/` rather than only `python/megane/`

https://claude.ai/code/session_01WGxMQqG8B3DJfaUpBq3acV

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGxMQqG8B3DJfaUpBq3acV)_