### PR TITLE
ci: include vscode-megane and jupyterlab-megane in Codecov scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           files: coverage/ts/lcov.info
-          flags: typescript
+          flags: typescript,vscode,jupyterlab
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_on_error: false
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -19,6 +19,16 @@ coverage:
         threshold: 1%
         flags:
           - rust
+      vscode:
+        target: auto
+        threshold: 1%
+        flags:
+          - vscode
+      jupyterlab:
+        target: auto
+        threshold: 1%
+        flags:
+          - jupyterlab
     patch:
       default:
         target: auto
@@ -44,6 +54,14 @@ flag_management:
     - name: rust
       paths:
         - crates/
+      carryforward: true
+    - name: vscode
+      paths:
+        - vscode-megane/src/
+      carryforward: true
+    - name: jupyterlab
+      paths:
+        - jupyterlab-megane/src/
       carryforward: true
 
 ignore:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,8 +15,17 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "text-summary", "json", "html", "lcov"],
       reportsDirectory: "coverage/ts",
-      include: ["src/**/*.{ts,tsx}"],
-      exclude: ["src/vite-env.d.ts", "src/**/*.d.ts"],
+      include: [
+        "src/**/*.{ts,tsx}",
+        "vscode-megane/src/**/*.ts",
+        "jupyterlab-megane/src/**/*.{ts,tsx}",
+      ],
+      exclude: [
+        "src/vite-env.d.ts",
+        "src/**/*.d.ts",
+        "vscode-megane/src/**/*.d.ts",
+        "jupyterlab-megane/src/**/*.d.ts",
+      ],
     },
   },
 });


### PR DESCRIPTION
## Summary

The Codecov reports were missing the VSCode extension (`vscode-megane/src/`) and JupyterLab labextension (`jupyterlab-megane/src/`) sources. This PR brings them under coverage tracking.

- `vitest.config.ts`: extend `coverage.include` to also pick up `vscode-megane/src/**/*.ts` and `jupyterlab-megane/src/**/*.{ts,tsx}` (with matching `.d.ts` excludes).
- `codecov.yml`: register `vscode` and `jupyterlab` flags in `flag_management.individual_flags` (with the corresponding paths) and add matching `coverage.status.project` entries.
- `.github/workflows/ci.yml`: upload the existing `coverage/ts/lcov.info` with flags `typescript,vscode,jupyterlab` so Codecov attributes each file to the correct flag using the path filters.

These extensions currently have no Vitest tests, so they will initially report 0% — the goal here is visibility, so the gap is now tracked and any future tests will start lifting the numbers.

## Test plan

- [x] `npm run build:wasm`
- [x] `npm test -- --coverage` locally — coverage table shows `vscode-megane/src/extension.ts` and lcov contains `SF:` entries for all 7 `jupyterlab-megane/src/*` source files plus `vscode-megane/src/extension.ts`.
- [ ] CI passes on this branch and Codecov picks up the new flags.

https://claude.ai/code/session_01DWAaoF7SeggUQL9FRZLgF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWAaoF7SeggUQL9FRZLgF5)_