### PR TITLE
fix(pipeline): apply AddBond Source default in single-file viewers

### DIFF
--- a/src/hooks/useMeganeLocal.ts
+++ b/src/hooks/useMeganeLocal.ts
@@ -14,6 +14,7 @@ import { useLabelSource } from "./useLabelSource";
 import { useVectorSource } from "./useVectorSource";
 import { usePipelineStore } from "../pipeline/store";
 import { createMinimalStructurePipeline } from "../pipeline/defaults";
+import { syncAddBondSourceForLoader } from "../pipeline/openFile";
 import { getLayoutedElements } from "../pipeline/layout";
 import type {
   Snapshot,
@@ -211,6 +212,12 @@ export function useMeganeLocal(): MeganeLocalState {
             hasTrajectory: result.frames.length > 0,
             hasCell: !!result.snapshot.box,
           });
+          // Mirror the openFile path: pick AddBond's Source by file format
+          // ("structure" for PDB/MOL/SDF/LAMMPS, "distance" / VDW otherwise)
+          // so VSCode and JupyterLab single-file viewers — which feed files
+          // through this hook instead of usePipelineStore.openFile — also
+          // start with a sensible default for formats that lack bond info.
+          syncAddBondSourceForLoader(usePipelineStore.getState(), loaderNode.id, filename);
         }
         if (result.frames.length > 0) {
           // Multi-frame structure files (.traj, multi-MODEL PDB,

--- a/src/pipeline/openFile.ts
+++ b/src/pipeline/openFile.ts
@@ -74,9 +74,36 @@ const PIPELINE_SUFFIX = ".megane.json";
 // information, so VDW distance inference is the more useful default.
 const FILE_BOND_EXTS = [".pdb", ".ent", ".pdbx", ".mol", ".sdf", ".data", ".lammps"];
 
-function defaultBondSourceForFile(filename: string): "structure" | "distance" {
+export function defaultBondSourceForFile(filename: string): "structure" | "distance" {
   const lower = filename.toLowerCase();
   return FILE_BOND_EXTS.some((ext) => lower.endsWith(ext)) ? "structure" : "distance";
+}
+
+/**
+ * Switch the AddBond node(s) consuming `loaderId`'s `particle` output to a
+ * bondSource that matches the file format: `"structure"` for formats that
+ * embed bonds (PDB/MOL/SDF/LAMMPS data), `"distance"` (VDW inference) for
+ * formats that don't (XYZ/GRO/CIF/traj). Only nodes wired to the targeted
+ * loader are touched; user-customised AddBond nodes wired elsewhere are
+ * left alone.
+ */
+export function syncAddBondSourceForLoader(
+  state: PipelineStore,
+  loaderId: string,
+  filename: string,
+): void {
+  const desired = defaultBondSourceForFile(filename);
+  const targets = new Set<string>();
+  for (const edge of state.edges) {
+    if (edge.source !== loaderId) continue;
+    if (edge.sourceHandle && edge.sourceHandle !== "particle") continue;
+    if (edge.targetHandle && edge.targetHandle !== "particle") continue;
+    const targetNode = state.nodes.find((n) => n.id === edge.target);
+    if (targetNode?.type === "add_bond") targets.add(targetNode.id);
+  }
+  for (const id of targets) {
+    state.updateNodeParams(id, { bondSource: desired });
+  }
 }
 
 function classify(filename: string): FileKind {
@@ -166,25 +193,7 @@ async function openStructure(
     hasCell: !!result.snapshot.box,
   });
 
-  // Switch the AddBond node(s) consuming this loader to a bondSource that
-  // matches the file format: "structure" for formats that embed bonds
-  // (PDB/MOL/SDF/LAMMPS data), "distance" (VDW inference) for formats that
-  // don't (XYZ/GRO/CIF/traj). Only nodes whose `particle` input comes from
-  // the targeted loader are touched; user-customised AddBond nodes wired
-  // elsewhere are left alone.
-  const desiredBondSource = defaultBondSourceForFile(file.name);
-  const stateAfterLoader = api.getState();
-  const addBondTargets = new Set<string>();
-  for (const edge of stateAfterLoader.edges) {
-    if (edge.source !== loaderId) continue;
-    if (edge.sourceHandle && edge.sourceHandle !== "particle") continue;
-    if (edge.targetHandle && edge.targetHandle !== "particle") continue;
-    const targetNode = stateAfterLoader.nodes.find((n) => n.id === edge.target);
-    if (targetNode?.type === "add_bond") addBondTargets.add(targetNode.id);
-  }
-  for (const id of addBondTargets) {
-    state.updateNodeParams(id, { bondSource: desiredBondSource });
-  }
+  syncAddBondSourceForLoader(api.getState(), loaderId, file.name);
 
   if (result.vectorChannels && result.vectorChannels.length > 0) {
     state.setFileVectors(result.vectorChannels[0].frames);


### PR DESCRIPTION
## Summary

When opening a structure file directly in the **VSCode custom editor** or the **JupyterLab `MeganeDocWidget`**, the AddBond node's `Source` was always stuck at `"structure"` (File), even for formats that don't embed bond information (XYZ, GRO, CIF, ASE `.traj`). Only the canonical `usePipelineStore.openFile` path was applying `defaultBondSourceForFile` — these single-file hosts feed files through `useMeganeLocal.loadFile` and bypassed that step.

This PR extracts the per-loader bondSource sync into `syncAddBondSourceForLoader` in `src/pipeline/openFile.ts` and calls it from `useMeganeLocal.applyResult` after the `load_structure` node's `fileName` is updated.

After this change, both extensions match the webapp behavior:

| Format | Before (extensions) | After (extensions) |
|---|---|---|
| `.pdb` / `.mol` / `.sdf` / LAMMPS data | `structure` | `structure` (unchanged) |
| `.xyz` / `.gro` / `.cif` / `.traj` | `structure` | `distance` (VDW) |

User-customised AddBond nodes wired to a different loader are left alone — only nodes consuming the targeted loader's `particle` output are touched, identical to the existing `openFile` rule.

## Test plan

- [x] `npx vitest run` — 344 passed (29 files)
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run lint` — 0 errors (warnings unchanged)
- [ ] Manual: open `.xyz` in VSCode custom editor → AddBond Source = VDW
- [ ] Manual: open `.xyz` in JupyterLab DocWidget → AddBond Source = VDW
- [ ] Manual: open `.pdb` in either host → AddBond Source = File (unchanged)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FNyFmjfEqT8aLo597kNSRx)_