### PR TITLE
fix(widget): atomically apply pipeline JSON and per-node snapshots

### DIFF
--- a/src/components/WidgetViewer.tsx
+++ b/src/components/WidgetViewer.tsx
@@ -89,39 +89,62 @@ export function WidgetViewer({
   const storeSnapshot = usePipelineStore((s) => s.snapshot);
   const setSnapshot = usePipelineStore((s) => s.setSnapshot);
 
-  // Push per-node snapshots from Python to the pipeline store
+  // Apply pipeline + per-node snapshots from Python.
+  //
+  // Order matters: `deserialize()` clears `nodeSnapshots` (so opening a new
+  // .megane.json doesn't bleed state across JupyterLab documents), so a
+  // separate effect that calls `setNodeSnapshot` followed by another that
+  // calls `deserialize` would race — the deserialize wins, leaves
+  // nodeSnapshots empty, and `executeLoadStructure` produces no particles
+  // (blank viewport). Using `loadPipeline` performs both updates in a
+  // single store transaction so the post-deserialize execute() sees the
+  // matching snapshots.
+  const prevPipelineJsonRef = useRef<string>("");
   useEffect(() => {
-    if (!nodeSnapshotsData || Object.keys(nodeSnapshotsData).length === 0) {
-      // Fall back to the global snapshot (legacy .load() path)
-      setSnapshot(snapshot);
-    } else {
-      // Decode each per-node snapshot and populate nodeSnapshots
-      const store = usePipelineStore.getState();
+    const store = usePipelineStore.getState();
+    const decodedSnapshots: Record<string, Parameters<typeof store.setNodeSnapshot>[1]> = {};
+    if (nodeSnapshotsData) {
       for (const [nodeId, data] of Object.entries(nodeSnapshotsData)) {
         const decoded = decodeNodeSnapshot(data);
         if (decoded) {
-          store.setNodeSnapshot(nodeId, {
+          decodedSnapshots[nodeId] = {
             snapshot: decoded,
             frames: null,
             meta: null,
             labels: null,
-          });
+          };
         }
       }
-      // Also set the first snapshot as the global one for the renderer
-      const firstData = Object.values(nodeSnapshotsData)[0];
-      if (firstData) {
-        const firstSnapshot = decodeNodeSnapshot(firstData);
-        setSnapshot(firstSnapshot);
-      }
     }
+
+    if (pipelineJson && pipelineJson !== prevPipelineJsonRef.current) {
+      prevPipelineJsonRef.current = pipelineJson;
+      try {
+        const config = JSON.parse(pipelineJson);
+        store.loadPipeline(config, decodedSnapshots);
+      } catch {
+        // Ignore invalid JSON
+      }
+    } else if (Object.keys(decodedSnapshots).length > 0) {
+      // Pipeline JSON is unchanged but the per-node snapshots may have
+      // refreshed (e.g. trajectory tick or a follow-up `.load()` call).
+      for (const [nodeId, data] of Object.entries(decodedSnapshots)) {
+        store.setNodeSnapshot(nodeId, data);
+      }
+      const sortedIds = Object.keys(decodedSnapshots).sort();
+      setSnapshot(decodedSnapshots[sortedIds[0]].snapshot);
+    } else {
+      // Legacy `.load()` path: no pipeline JSON, no per-node snapshots.
+      setSnapshot(snapshot);
+    }
+
     const renderer = rendererRef.current;
     if (renderer) {
       const vs = usePipelineStore.getState().viewportState;
       applyViewportState(renderer, vs, null);
       prevViewportStateRef.current = vs;
     }
-  }, [snapshot, nodeSnapshotsData, setSnapshot]);
+  }, [snapshot, nodeSnapshotsData, pipelineJson, setSnapshot]);
 
   // Apply viewportState changes to the renderer
   useEffect(() => {
@@ -178,19 +201,6 @@ export function WidgetViewer({
     const total = viewportState.bonds.reduce((sum, b) => sum + b.bondIndices.length / 2, 0);
     setBondCount(total);
   }, [viewportState.bonds]);
-
-  // Apply pipeline JSON from Python
-  const prevPipelineJsonRef = useRef<string>("");
-  useEffect(() => {
-    if (!pipelineJson || pipelineJson === prevPipelineJsonRef.current) return;
-    prevPipelineJsonRef.current = pipelineJson;
-    try {
-      const config = JSON.parse(pipelineJson);
-      usePipelineStore.getState().deserialize(config);
-    } catch {
-      // Ignore invalid JSON
-    }
-  }, [pipelineJson]);
 
   const handleRendererReady = useCallback(
     (renderer: MoleculeRenderer) => {

--- a/src/pipeline/store.ts
+++ b/src/pipeline/store.ts
@@ -89,6 +89,19 @@ export interface PipelineStore {
   serialize: () => SerializedPipeline;
   deserialize: (json: SerializedPipeline) => void;
 
+  // Atomically replace the graph and per-node snapshots. Used by anywidget
+  // hosts (Jupyter widget, VSCode webview) when Python pushes a new pipeline
+  // alongside the per-node binary snapshot blobs. `deserialize` alone wipes
+  // `nodeSnapshots` (so that opening a new .megane.json doesn't bleed state
+  // across documents in JupyterLab); calling `setNodeSnapshot` *before*
+  // `deserialize` therefore loses the snapshot. `loadPipeline` performs both
+  // updates inside a single store transaction so the post-deserialize
+  // execute() sees the matching per-node snapshots.
+  loadPipeline: (
+    json: SerializedPipeline,
+    nodeSnapshots: Record<string, NodeSnapshotData>,
+  ) => void;
+
   // Templates
   pendingTemplateId: string | null;
   applyTemplate: (templateId: string) => void;
@@ -465,6 +478,24 @@ export const usePipelineStore = create<PipelineStore>((set, get, api) => ({
       edges,
       viewportState: { ...DEFAULT_VIEWPORT_STATE },
       ...CLEARED_EXECUTION_CONTEXT,
+    });
+    get().execute();
+  },
+
+  loadPipeline: (json, nodeSnapshots) => {
+    const { nodes, edges } = deserializePipeline(json);
+    // Pick a primary snapshot for the legacy `snapshot` field so the
+    // Viewport's loadSnapshot path still has data to render. Iterate in
+    // node-id order to be deterministic across hosts.
+    const sortedIds = Object.keys(nodeSnapshots).sort();
+    const primarySnapshot = sortedIds.length > 0 ? nodeSnapshots[sortedIds[0]].snapshot : null;
+    set({
+      nodes,
+      edges,
+      viewportState: { ...DEFAULT_VIEWPORT_STATE },
+      ...CLEARED_EXECUTION_CONTEXT,
+      nodeSnapshots: { ...nodeSnapshots },
+      snapshot: primarySnapshot,
     });
     get().execute();
   },

--- a/src/pipeline/store.ts
+++ b/src/pipeline/store.ts
@@ -97,10 +97,7 @@ export interface PipelineStore {
   // `deserialize` therefore loses the snapshot. `loadPipeline` performs both
   // updates inside a single store transaction so the post-deserialize
   // execute() sees the matching per-node snapshots.
-  loadPipeline: (
-    json: SerializedPipeline,
-    nodeSnapshots: Record<string, NodeSnapshotData>,
-  ) => void;
+  loadPipeline: (json: SerializedPipeline, nodeSnapshots: Record<string, NodeSnapshotData>) => void;
 
   // Templates
   pendingTemplateId: string | null;

--- a/tests/ts/components/WidgetViewer.test.tsx
+++ b/tests/ts/components/WidgetViewer.test.tsx
@@ -248,6 +248,140 @@ describe("WidgetViewer — per-frame bond recalc", () => {
     expect(updateBondsExt).toHaveBeenCalled();
   });
 
+  /**
+   * Encode a Snapshot into the binary protocol that `decodeNodeSnapshot`
+   * expects. Mirrors python/megane/protocol.py write_snapshot but only
+   * supports the no-bond-orders / no-box subset we need here.
+   */
+  function encodeSnapshot(snap: Snapshot): DataView {
+    const HEADER = 8;
+    const positionsBytes = snap.nAtoms * 3 * 4;
+    let elementsBytes = snap.nAtoms;
+    elementsBytes += (4 - (elementsBytes % 4)) % 4; // pad to 4
+    const bondsBytes = snap.nBonds * 2 * 4;
+    const total = HEADER + 4 + 4 + positionsBytes + elementsBytes + bondsBytes;
+
+    const buffer = new ArrayBuffer(total);
+    const view = new DataView(buffer);
+    view.setUint32(0, 0x4e47454d, true); // "MEGN"
+    view.setUint8(4, 0); // MSG_SNAPSHOT
+    view.setUint8(5, 0); // flags: no bond orders, no box
+    let offset = HEADER;
+    view.setUint32(offset, snap.nAtoms, true);
+    offset += 4;
+    view.setUint32(offset, snap.nBonds, true);
+    offset += 4;
+    new Float32Array(buffer, offset, snap.nAtoms * 3).set(snap.positions);
+    offset += positionsBytes;
+    new Uint8Array(buffer, offset, snap.nAtoms).set(snap.elements);
+    offset += elementsBytes;
+    if (snap.nBonds > 0) {
+      new Uint32Array(buffer, offset, snap.nBonds * 2).set(snap.bonds);
+    }
+    return new DataView(buffer);
+  }
+
+  it("renders particles when AddLabels + AddPolyhedra pipeline + nodeSnapshotsData arrive together (blank-ipywidget regression)", () => {
+    // Repro of the user's bug: set_pipeline pushes both _pipeline_json and
+    // _node_snapshots_data; the WidgetViewer must populate per-node
+    // snapshots in the same store transaction as the deserialize, otherwise
+    // executeLoadStructure runs with a null snapshot and the canvas stays
+    // blank (only the pivot crosshair shows).
+    usePipelineStore.getState().reset();
+
+    const snapshot = makeSnapshot();
+    const pipelineJson = JSON.stringify({
+      version: 3,
+      nodes: [
+        {
+          type: "load_structure",
+          id: "loader-w",
+          position: { x: 0, y: 0 },
+          fileName: null,
+          hasTrajectory: false,
+          hasCell: false,
+          enabled: true,
+        },
+        {
+          type: "label_generator",
+          id: "labels-w",
+          position: { x: 200, y: 0 },
+          source: "element",
+          enabled: true,
+        },
+        {
+          type: "polyhedron_generator",
+          id: "poly-w",
+          position: { x: 200, y: 200 },
+          centerElements: [8],
+          ligandElements: [],
+          maxDistance: 3.0,
+          opacity: 0.6,
+          showEdges: true,
+          enabled: true,
+        },
+        {
+          type: "viewport",
+          id: "viewport-w",
+          position: { x: 400, y: 100 },
+          perspective: false,
+          cellAxesVisible: true,
+          enabled: true,
+        },
+      ],
+      edges: [
+        {
+          source: "loader-w",
+          target: "labels-w",
+          sourceHandle: "particle",
+          targetHandle: "particle",
+        },
+        {
+          source: "loader-w",
+          target: "poly-w",
+          sourceHandle: "particle",
+          targetHandle: "particle",
+        },
+        {
+          source: "loader-w",
+          target: "viewport-w",
+          sourceHandle: "particle",
+          targetHandle: "particle",
+        },
+        {
+          source: "labels-w",
+          target: "viewport-w",
+          sourceHandle: "label",
+          targetHandle: "label",
+        },
+        {
+          source: "poly-w",
+          target: "viewport-w",
+          sourceHandle: "mesh",
+          targetHandle: "mesh",
+        },
+      ],
+    });
+    const nodeSnapshotsData = { "loader-w": encodeSnapshot(snapshot) };
+
+    render(
+      <WidgetViewer
+        {...defaultProps}
+        snapshot={null}
+        pipelineJson={pipelineJson}
+        nodeSnapshotsData={nodeSnapshotsData}
+      />,
+    );
+
+    const state = usePipelineStore.getState();
+    expect(state.viewportState.particles.length).toBeGreaterThan(0);
+    expect(state.viewportState.particles[0].source.nAtoms).toBe(snapshot.nAtoms);
+    // The legacy global snapshot must also be set so Viewport.loadSnapshot
+    // has data to feed to the renderer.
+    expect(state.snapshot).not.toBeNull();
+    expect(state.snapshot?.nAtoms).toBe(snapshot.nAtoms);
+  });
+
   it("does not call inferBondsVdwJS when both prop and store snapshot are null", () => {
     // Guards must still work: no snapshot from either source → no bond recalc.
     seedDistanceBondPipeline(null);

--- a/tests/ts/pipeline/store.test.ts
+++ b/tests/ts/pipeline/store.test.ts
@@ -224,4 +224,122 @@ describe("usePipelineStore", () => {
       expect(usePipelineStore.getState().nodes.length).toBeGreaterThan(0);
     });
   });
+
+  describe("loadPipeline (anywidget set_pipeline path)", () => {
+    /**
+     * Build a minimal H2O snapshot the executors can consume.
+     */
+    function makeWaterSnapshot() {
+      return {
+        nAtoms: 3,
+        nBonds: 0,
+        nFileBonds: 0,
+        positions: new Float32Array([0, 0, 0, 0.96, 0, 0, -0.24, 0.93, 0]),
+        elements: new Uint8Array([8, 1, 1]),
+        bonds: new Uint32Array(0),
+        bondOrders: null,
+        box: null,
+      };
+    }
+
+    /**
+     * Mirrors the pipeline produced by the user's repro:
+     *   LoadStructure → AddLabels   (label edge to Viewport)
+     *   LoadStructure → AddPolyhedra (mesh edge to Viewport)
+     *   LoadStructure → Viewport    (particle edge — no AddBond)
+     */
+    function labelsAndPolyhedraPipeline() {
+      return {
+        version: 3,
+        nodes: [
+          {
+            type: "load_structure",
+            id: "loader-1",
+            position: { x: 0, y: 0 },
+            fileName: null,
+            hasTrajectory: false,
+            hasCell: false,
+            enabled: true,
+          },
+          {
+            type: "label_generator",
+            id: "labels-1",
+            position: { x: 200, y: 0 },
+            source: "element",
+            enabled: true,
+          },
+          {
+            type: "polyhedron_generator",
+            id: "poly-1",
+            position: { x: 200, y: 200 },
+            centerElements: [8],
+            ligandElements: [],
+            maxDistance: 3.0,
+            opacity: 0.6,
+            showEdges: true,
+            enabled: true,
+          },
+          {
+            type: "viewport",
+            id: "viewport-1",
+            position: { x: 400, y: 100 },
+            perspective: false,
+            cellAxesVisible: true,
+            enabled: true,
+          },
+        ],
+        edges: [
+          { source: "loader-1", target: "labels-1", sourceHandle: "particle", targetHandle: "particle" },
+          { source: "loader-1", target: "poly-1", sourceHandle: "particle", targetHandle: "particle" },
+          { source: "loader-1", target: "viewport-1", sourceHandle: "particle", targetHandle: "particle" },
+          { source: "labels-1", target: "viewport-1", sourceHandle: "label", targetHandle: "label" },
+          { source: "poly-1", target: "viewport-1", sourceHandle: "mesh", targetHandle: "mesh" },
+        ],
+      };
+    }
+
+    it("renders particles for an AddLabels + AddPolyhedra pipeline (regression for blank ipywidget)", () => {
+      const snapshot = makeWaterSnapshot();
+      usePipelineStore.getState().loadPipeline(labelsAndPolyhedraPipeline(), {
+        "loader-1": { snapshot, frames: null, meta: null, labels: null },
+      });
+
+      const state = usePipelineStore.getState();
+      // The viewer was blank because executeLoadStructure ran with a null
+      // snapshot (deserialize had wiped nodeSnapshots). loadPipeline's
+      // single-transaction update keeps the snapshot, so particles flow
+      // into the viewport.
+      expect(state.viewportState.particles.length).toBeGreaterThan(0);
+      expect(state.viewportState.particles[0].source.nAtoms).toBe(3);
+      // Labels reach the viewport too.
+      expect(state.viewportState.labels.length).toBeGreaterThan(0);
+      expect(state.viewportState.labels[0].labels).toEqual(["O", "H", "H"]);
+    });
+
+    it("populates the legacy global snapshot from the first per-node entry", () => {
+      const snapshot = makeWaterSnapshot();
+      usePipelineStore.getState().loadPipeline(labelsAndPolyhedraPipeline(), {
+        "loader-1": { snapshot, frames: null, meta: null, labels: null },
+      });
+      // The Viewport component reads `effectiveSnapshot = storeSnapshot ?? snapshot`,
+      // so the store snapshot must be set for the renderer to call loadSnapshot.
+      expect(usePipelineStore.getState().snapshot).toBe(snapshot);
+    });
+
+    it("clears nodeSnapshots from a previous pipeline before loading the new one", () => {
+      // Seed an unrelated snapshot to ensure cross-document state cannot bleed.
+      usePipelineStore.getState().setNodeSnapshot("stale-loader", {
+        snapshot: makeWaterSnapshot(),
+        frames: null,
+        meta: null,
+        labels: null,
+      });
+      const snapshot = makeWaterSnapshot();
+      usePipelineStore.getState().loadPipeline(labelsAndPolyhedraPipeline(), {
+        "loader-1": { snapshot, frames: null, meta: null, labels: null },
+      });
+      const finalSnapshots = usePipelineStore.getState().nodeSnapshots;
+      expect(Object.keys(finalSnapshots).sort()).toEqual(["loader-1"]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the blank ipywidget reported when a pipeline built with `AddLabels` and `AddPolyhedra` is applied via `v2.set_pipeline(pipe)` in JupyterLab or VSCode notebooks. The canvas was running but no atoms rendered (only the pivot crosshair was visible).

## Root cause

`set_pipeline()` in Python sets `_node_snapshots_data` and then `_pipeline_json` in succession. anywidget batches both into the same React render, where two effects in `WidgetViewer` then run in declaration order:

1. **Effect A** (`[snapshot, nodeSnapshotsData, setSnapshot]`) decoded the per-node binary snapshots and called `setNodeSnapshot()`, populating `nodeSnapshots`.
2. **Effect B** (`[pipelineJson]`) ran next and called `usePipelineStore.deserialize()`, which by design clears `nodeSnapshots` and the global `snapshot` (so opening a new `.megane.json` doesn't bleed state across JupyterLab document tabs). It then re-ran `execute()` against the cleared map, so `executeLoadStructure` produced no particle output and the viewport stayed empty.

## Fix

- New atomic store action `usePipelineStore.loadPipeline(json, nodeSnapshots)` deserializes the graph and seeds `nodeSnapshots` plus the legacy `snapshot` field inside a single store transaction before running `execute()`.
- `WidgetViewer` collapses its two effects into one that calls `loadPipeline` whenever `pipelineJson` changes, falling back to the per-node-snapshot or legacy global-snapshot paths otherwise.
- `deserialize()` semantics are unchanged for `.megane.json` opens in JupyterLab DocWidget / VSCode custom editor.

## Tests

- `tests/ts/pipeline/store.test.ts` — three regressions covering the exact AddLabels + AddPolyhedra graph from the user's repro: particles reach the viewport, the legacy snapshot is populated, and stale per-node snapshots from a previous pipeline are dropped.
- `tests/ts/components/WidgetViewer.test.tsx` — end-to-end regression that mounts `WidgetViewer` with both `pipelineJson` and an encoded `nodeSnapshotsData`, asserting the store ends with non-empty `viewportState.particles` and a populated global snapshot. Verified to fail without the fix (4 new tests fail on revert, all pass with the fix).

## Test plan

- [x] `npm test` (353/353 pass)
- [x] `npx tsc --noEmit` (clean)
- [x] `npm run lint` (no new errors)
- [ ] Manual verification of the user's exact pipeline (LoadStructure → AddLabels + AddPolyhedra → Viewport with no AddBond) in JupyterLab and VSCode notebook hosts.

https://claude.ai/code/session_016Y7nX6aMN1W49vSHLhKiEA

---
_Generated by [Claude Code](https://claude.ai/code/session_016Y7nX6aMN1W49vSHLhKiEA)_