### PR TITLE
test: cover tour, stream, ai (roadmap Phases 0-3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           files: coverage/ts/lcov.info
-          flags: typescript,vscode,jupyterlab
+          flags: typescript
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_on_error: false
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -19,16 +19,6 @@ coverage:
         threshold: 1%
         flags:
           - rust
-      vscode:
-        target: auto
-        threshold: 1%
-        flags:
-          - vscode
-      jupyterlab:
-        target: auto
-        threshold: 1%
-        flags:
-          - jupyterlab
     patch:
       default:
         target: auto
@@ -50,18 +40,12 @@ flag_management:
     - name: typescript
       paths:
         - src/
+        - vscode-megane/src/
+        - jupyterlab-megane/src/
       carryforward: true
     - name: rust
       paths:
         - crates/
-      carryforward: true
-    - name: vscode
-      paths:
-        - vscode-megane/src/
-      carryforward: true
-    - name: jupyterlab
-      paths:
-        - jupyterlab-megane/src/
       carryforward: true
 
 ignore:

--- a/docs/plans/test-coverage-roadmap.md
+++ b/docs/plans/test-coverage-roadmap.md
@@ -1,5 +1,19 @@
 # Test Coverage Roadmap (Refactoring Re-plan)
 
+## Progress (updated)
+
+- ✅ Phase 0 — codecov flag/upload alignment (option A): commit `c17462a`
+- ✅ Phase 1 — `src/tour/` unit tests (3 files, 277 LOC): commit `b03bf04`
+- ✅ Phase 2 — `src/stream/` unit tests (2 files, 361 LOC): commit `61ada6e`
+- ✅ Phase 3 — `src/ai/` unit tests (4 files, 539 LOC) + `parseFrontmatter` export: commit `db0b679`
+- ⬜ Phase 4 — `src/renderer/` pure helpers (Selection, Picking, CameraManager, shaders)
+- ⬜ Phase 5 — `src/components/nodes/` UI tests (split: NodeShell + 4, then remaining 8)
+- ⬜ Phase 6 — `jupyterlab-megane/src/` (filetypes, wasmLoader, factory)
+- ⬜ Phase 7 — `vscode-megane/src/extension.ts` with vscode mock
+- ⬜ Phase 8 — codecov threshold tightening (`1% → 2%`) + `fail_ci_on_error: true`
+
+Total new tests added in Phases 0–3: **100** tests across 9 files (1,177 LOC test source).
+
 ## Context
 
 main を取り込んだ直後のリポジトリでは、すでに以下が main 側で完了しています:
@@ -23,7 +37,11 @@ main を取り込んだ直後のリポジトリでは、すでに以下が main 
 - **既存パターンに乗る**: `tests/ts/setup.ts` (`@testing-library/jest-dom/vitest`)、`tests/ts/stores/usePlaybackStore.test.ts`、`tests/ts/components/*.test.tsx` を参照テンプレに。
 - **vitest 設定はそのまま**: `vitest.config.ts:12` の `include: ["tests/ts/**/*.test.{ts,tsx}"]` に従い、新規テストは `tests/ts/<area>/` に追加。
 
-## Phase 0 — codecov 信号の整合性修正 (前提・ブロッキング)
+## Phase 0 — codecov 信号の整合性修正 (前提・ブロッキング) ✅ DONE (`c17462a`)
+
+**実施内容**: 推奨案 A (フラグ統合) を採用。`codecov.yml` から `vscode` / `jupyterlab` の status と `individual_flags` エントリを削除し、`typescript` フラグの paths に `vscode-megane/src/` と `jupyterlab-megane/src/` を追加。`.github/workflows/ci.yml:79` の `flags: typescript,vscode,jupyterlab` を `flags: typescript` に縮約。`fail_ci_on_error: true` への昇格は Phase 8 に持ち越し。
+
+
 
 このフェーズなしに以降のテストを足してもフラグ別ステータスが正しく光らない。
 
@@ -37,7 +55,15 @@ main を取り込んだ直後のリポジトリでは、すでに以下が main 
 - **対象ファイル**: `.github/workflows/ci.yml`, `codecov.yml`
 - **検証**: PR で codecov コメントを確認し、`typescript` (または `typescript` / `vscode` / `jupyterlab`) ステータスが PR チェックに分離して現れること。
 
-## Phase 1 — `src/tour/` (小さく・純粋・即効性高)
+## Phase 1 — `src/tour/` (小さく・純粋・即効性高) ✅ DONE (`b03bf04`)
+
+**実施内容**: 以下 3 ファイル / 35 テストを追加。`MeganeTour.ts` 本体は driver.js DOM 結合のため `useTour` 経由で間接的にカバー。
+
+- `tests/ts/tour/tourStore.test.ts` (131 LOC, 20 tests): `setHost` / `setActive` / `markAutoStartHandled` / `setDontShowAgain` (localStorage 永続化 + 不正 JSON 耐性 + 再 import パス) と `shouldAutoStart` の 4 ホスト × `dontShowAgain` 行列、`?guide=on/off/1/0/true/false` URL オーバーライド
+- `tests/ts/tour/tourSteps.test.ts` (62 LOC, 8 tests): ステップ数 / Welcome 構造 / `package.json` 由来バージョン / 全ステップタイトル非空 / アンカーセレクタ非空・重複なし
+- `tests/ts/tour/useTour.test.tsx` (84 LOC, 7 tests): `vi.mock("@/tour/MeganeTour")` で driver.js を回避、`renderHook` で host 同期 / 自動開始ゲート / unmount での `stopTour` / 手動 `startTour` 経路を検証
+
+
 
 `useTour.ts` (52), `tourStore.ts` (98), `tourSteps.ts` (179), `MeganeTour.ts` (80)。zustand ベース + 純データのみ。
 
@@ -49,7 +75,14 @@ main を取り込んだ直後のリポジトリでは、すでに以下が main 
 - **既存利用**: `@testing-library/react` は既に `tests/ts/components/*` で使用中
 - **規模**: S
 
-## Phase 2 — `src/stream/` (WebSocket / フレーム供給)
+## Phase 2 — `src/stream/` (WebSocket / フレーム供給) ✅ DONE (`61ada6e`)
+
+**実施内容**: 以下 2 ファイル / 23 テストを追加。`globalThis.WebSocket` を `MockWebSocket` クラスでスタブ化するパターンを `tests/ts/` に新規導入。
+
+- `tests/ts/stream/WebSocketClient.test.ts` (243 LOC, 15 tests): connect / 自動再接続の指数バックオフ (1s→2s→4s→8s→16s→30s 上限) / 成功 open でのバックオフリセット / disconnect での timer キャンセル / `send()` の readyState ガード / `connected` getter / `onerror` 非例外
+- `tests/ts/stream/StreamFrameProvider.test.ts` (118 LOC, 8 tests): cache miss → `request_frame` 送信 / `receiveFrame` の `onFrameReady` 発火 / `maxCacheSize` 越えでの LRU 退避 / 既存 frameId 再 receive での MRU 移動 / `clear()` / `setOnFrameReady` 上書き
+
+
 
 `WebSocketClient.ts` (93), `StreamFrameProvider.ts` (82)。
 
@@ -59,7 +92,16 @@ main を取り込んだ直後のリポジトリでは、すでに以下が main 
 - **既存契約参照**: `src/stores/usePlaybackStore.ts` の `setProvider` / `currentFrameData` 経路 (`MeganeViewer.tsx:122,140` で利用)
 - **規模**: S
 
-## Phase 3 — `src/ai/` (純粋ロジック先行、ネットワークは後回し)
+## Phase 3 — `src/ai/` (純粋ロジック先行、ネットワークは後回し) ✅ DONE (`db0b679`)
+
+**実施内容**: 以下 4 ファイル / 42 テストを追加。`fetch` を `vi.stubGlobal` でモックし、SSE は `ReadableStream` を Response 本体に渡す `makeSSEResponse` ヘルパで合成。`src/ai/skillLoader.ts` の `parseFrontmatter` を 1 行だけ `export` に昇格 (ロードマップが許容する「テスト + 必要最小の export 追加」枠)。
+
+- `tests/ts/ai/config.test.ts` (93 LOC, 8 tests): zustand store の localStorage 読み書き / `apiKey` を絶対に永続化しない不変条件 / 不正 JSON 耐性 / `setProvider` でのデフォルトモデル切替 / `PROVIDER_MODELS` 構造
+- `tests/ts/ai/prompt.test.ts` (45 LOC, 6 tests): 全ノードタイプ・スキーマ version 3 マーカー・JSON コードフェンス・`Connection Rules` 節の存在 / 決定性
+- `tests/ts/ai/skillLoader.test.ts` (121 LOC, 13 tests): `parseFrontmatter` のフロントマターあり/なし、コロンなし行、値中コロン、空ボディ / `buildToolDefinitions` の kebab→snake / `executeSkill` のマッチ・null / `loadSkills` (空ディレクトリ) / `getSkills` キャッシュ
+- `tests/ts/ai/client.test.ts` (280 LOC, 15 tests): `extractPipelineJSON` の fenced/raw/malformed/version 不一致/配列欠落分岐 / Anthropic SSE フローの text-only / tool_use → tool_result 往復 / ヘッダ・ボディ検証 / non-OK status 例外 / OpenAI SSE フローの delta / `[DONE]` / 不正 JSON 行スキップ / non-OK status 例外
+
+
 
 `config.ts` (80), `prompt.ts` (196), `skillLoader.ts` (128), `client.ts` (354)。
 
@@ -128,19 +170,19 @@ main を取り込んだ直後のリポジトリでは、すでに以下が main 
 ## 推奨実行順 / 並列性
 
 ```
-Phase 0 (codecov flag fix)        ← 必ず最初
+Phase 0 (codecov flag fix)        ✅ DONE (c17462a)
    │
-   ├─ Phase 1 (tour)              ← 小・即効性、並列可
-   ├─ Phase 2 (stream)            ← 並列可
-   └─ Phase 3 (ai)                ← 並列可
+   ├─ Phase 1 (tour)              ✅ DONE (b03bf04)
+   ├─ Phase 2 (stream)            ✅ DONE (61ada6e)
+   └─ Phase 3 (ai)                ✅ DONE (db0b679)
         │
-        ├─ Phase 4 (renderer pure helpers)
-        └─ Phase 5 (nodes UI)     ← 2 PR に分割
+        ├─ Phase 4 (renderer pure helpers)   ⬜ TODO
+        └─ Phase 5 (nodes UI)                 ⬜ TODO  ← 2 PR に分割
              │
-             ├─ Phase 6 (jupyterlab small files)
-             └─ Phase 7 (vscode extension)
+             ├─ Phase 6 (jupyterlab small files)  ⬜ TODO
+             └─ Phase 7 (vscode extension)        ⬜ TODO
                   │
-                  └─ Phase 8 (threshold tighten)
+                  └─ Phase 8 (threshold tighten)  ⬜ TODO
 ```
 
 各フェーズは独立 PR。1, 2, 3 は依存無しで並列着手可。

--- a/src/ai/skillLoader.ts
+++ b/src/ai/skillLoader.ts
@@ -43,7 +43,7 @@ const skillModules: Record<string, { default: string }> = import.meta.glob("./sk
  * Parse YAML frontmatter from a markdown string.
  * Returns the frontmatter key-value pairs and the remaining content.
  */
-function parseFrontmatter(raw: string): {
+export function parseFrontmatter(raw: string): {
   attrs: Record<string, string>;
   content: string;
 } {

--- a/tests/ts/ai/client.test.ts
+++ b/tests/ts/ai/client.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("@/ai/skillLoader", () => ({
+  getSkills: vi.fn(() => []),
+  buildToolDefinitions: vi.fn(() => []),
+  executeSkill: vi.fn((_skills: unknown, name: string) =>
+    name === "known_skill" ? "skill content" : null,
+  ),
+}));
+
+import { extractPipelineJSON, generatePipeline } from "@/ai/client";
+import type { AIConfig } from "@/ai/config";
+
+type SSEEvent = { event: string; data: unknown };
+
+function makeSSEResponse(events: SSEEvent[], status = 200): Response {
+  const encoder = new TextEncoder();
+  const text = events
+    .map((e) => {
+      const data = typeof e.data === "string" ? e.data : JSON.stringify(e.data);
+      return `event: ${e.event}\ndata: ${data}\n\n`;
+    })
+    .join("");
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+  return new Response(stream, { status });
+}
+
+function makeJSONResponse(body: unknown, status = 200): Response {
+  const encoder = new TextEncoder();
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+  return new Response(stream, { status });
+}
+
+const ANTHROPIC_CONFIG: AIConfig = {
+  provider: "anthropic",
+  model: "claude-sonnet-4-20250514",
+  apiKey: "sk-test",
+};
+
+const OPENAI_CONFIG: AIConfig = {
+  provider: "openai",
+  model: "gpt-4o",
+  apiKey: "sk-test",
+};
+
+const MINIMAL_PIPELINE_JSON = JSON.stringify({
+  version: 3,
+  nodes: [{ id: "v1", type: "viewport", position: { x: 0, y: 0 } }],
+  edges: [],
+});
+
+describe("extractPipelineJSON", () => {
+  it("parses a fenced ```json block", () => {
+    const result = extractPipelineJSON(`Here you go:\n\`\`\`json\n${MINIMAL_PIPELINE_JSON}\n\`\`\``);
+    expect(result.version).toBe(3);
+    expect(result.nodes).toHaveLength(1);
+  });
+
+  it("parses a fenced ``` block with no language tag", () => {
+    const result = extractPipelineJSON(`\`\`\`\n${MINIMAL_PIPELINE_JSON}\n\`\`\``);
+    expect(result.version).toBe(3);
+  });
+
+  it("parses raw JSON between the first { and last } when no fence is present", () => {
+    const result = extractPipelineJSON(`prefix ${MINIMAL_PIPELINE_JSON} suffix`);
+    expect(result.version).toBe(3);
+  });
+
+  it("throws when no JSON-like content is found", () => {
+    expect(() => extractPipelineJSON("no json here")).toThrow(/No JSON found/);
+  });
+
+  it("throws when the JSON is malformed", () => {
+    expect(() => extractPipelineJSON("```json\n{ not json }\n```")).toThrow(
+      /Failed to parse JSON/,
+    );
+  });
+
+  it("throws when version is not 3", () => {
+    const wrong = JSON.stringify({ version: 2, nodes: [], edges: [] });
+    expect(() => extractPipelineJSON(`\`\`\`json\n${wrong}\n\`\`\``)).toThrow(
+      /Unexpected pipeline version/,
+    );
+  });
+
+  it("throws when nodes or edges are missing", () => {
+    const noNodes = JSON.stringify({ version: 3, edges: [] });
+    expect(() => extractPipelineJSON(`\`\`\`json\n${noNodes}\n\`\`\``)).toThrow(
+      /Invalid pipeline/,
+    );
+
+    const noEdges = JSON.stringify({ version: 3, nodes: [] });
+    expect(() => extractPipelineJSON(`\`\`\`json\n${noEdges}\n\`\`\``)).toThrow(
+      /Invalid pipeline/,
+    );
+  });
+});
+
+describe("generatePipeline (Anthropic)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("streams text deltas via onChunk and returns the concatenated text", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeSSEResponse([
+        { event: "content_block_delta", data: { delta: { type: "text_delta", text: "hello " } } },
+        { event: "content_block_delta", data: { delta: { type: "text_delta", text: "world" } } },
+        { event: "message_delta", data: { delta: { stop_reason: "end_turn" } } },
+      ]),
+    );
+
+    const chunks: string[] = [];
+    const result = await generatePipeline(ANTHROPIC_CONFIG, "user msg", (c) => chunks.push(c));
+
+    expect(chunks).toEqual(["hello ", "world"]);
+    expect(result).toBe("hello world");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe("https://api.anthropic.com/v1/messages");
+  });
+
+  it("sets the required Anthropic headers", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeSSEResponse([
+        { event: "message_delta", data: { delta: { stop_reason: "end_turn" } } },
+      ]),
+    );
+
+    await generatePipeline(ANTHROPIC_CONFIG, "msg", () => {});
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["x-api-key"]).toBe("sk-test");
+    expect(headers["anthropic-version"]).toBe("2023-06-01");
+    expect(headers["content-type"]).toBe("application/json");
+    const body = JSON.parse(init.body as string);
+    expect(body.model).toBe("claude-sonnet-4-20250514");
+    expect(body.stream).toBe(true);
+    expect(body.system).toContain("Megane");
+  });
+
+  it("performs a tool-use round trip when stop_reason is tool_use", async () => {
+    const { buildToolDefinitions } = await import("@/ai/skillLoader");
+    (buildToolDefinitions as ReturnType<typeof vi.fn>).mockReturnValueOnce([
+      { name: "known_skill", description: "x", input_schema: { type: "object", properties: {} } },
+    ]);
+
+    // First response: tool_use
+    fetchMock.mockResolvedValueOnce(
+      makeSSEResponse([
+        {
+          event: "content_block_start",
+          data: { content_block: { type: "tool_use", id: "tu_1", name: "known_skill" } },
+        },
+        {
+          event: "content_block_delta",
+          data: { delta: { type: "input_json_delta", partial_json: "" } },
+        },
+        { event: "content_block_stop", data: {} },
+        { event: "message_delta", data: { delta: { stop_reason: "tool_use" } } },
+      ]),
+    );
+    // Second response: end_turn with text
+    fetchMock.mockResolvedValueOnce(
+      makeSSEResponse([
+        { event: "content_block_delta", data: { delta: { type: "text_delta", text: "done" } } },
+        { event: "message_delta", data: { delta: { stop_reason: "end_turn" } } },
+      ]),
+    );
+
+    const result = await generatePipeline(ANTHROPIC_CONFIG, "msg", () => {});
+    expect(result).toBe("done");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // The second request body should include the assistant tool_use and a user tool_result.
+    const secondBody = JSON.parse(
+      (fetchMock.mock.calls[1][1] as RequestInit).body as string,
+    );
+    expect(Array.isArray(secondBody.messages)).toBe(true);
+    const lastTwo = secondBody.messages.slice(-2);
+    expect(lastTwo[0].role).toBe("assistant");
+    expect(
+      (lastTwo[0].content as { type: string }[]).some((c) => c.type === "tool_use"),
+    ).toBe(true);
+    expect(lastTwo[1].role).toBe("user");
+    const toolResult = (lastTwo[1].content as { type: string; content: string }[])[0];
+    expect(toolResult.type).toBe("tool_result");
+    expect(toolResult.content).toBe("skill content");
+  });
+
+  it("throws when the API returns a non-OK status", async () => {
+    fetchMock.mockResolvedValueOnce(makeJSONResponse("rate limited", 429));
+    await expect(
+      generatePipeline(ANTHROPIC_CONFIG, "msg", () => {}),
+    ).rejects.toThrow(/Anthropic API error \(429\)/);
+  });
+});
+
+describe("generatePipeline (OpenAI)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("streams content deltas and returns concatenated text", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeSSEResponse([
+        { event: "", data: { choices: [{ delta: { content: "hi " } }] } },
+        { event: "", data: { choices: [{ delta: { content: "there" } }] } },
+        { event: "", data: "[DONE]" },
+      ]),
+    );
+
+    const chunks: string[] = [];
+    const result = await generatePipeline(OPENAI_CONFIG, "msg", (c) => chunks.push(c));
+    expect(chunks).toEqual(["hi ", "there"]);
+    expect(result).toBe("hi there");
+    expect(fetchMock.mock.calls[0][0]).toBe("https://api.openai.com/v1/chat/completions");
+  });
+
+  it("sets the OpenAI Authorization header and body", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeSSEResponse([{ event: "", data: "[DONE]" }]),
+    );
+    await generatePipeline(OPENAI_CONFIG, "msg", () => {});
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer sk-test");
+    const body = JSON.parse(init.body as string);
+    expect(body.model).toBe("gpt-4o");
+    expect(body.stream).toBe(true);
+    expect(body.messages[0].role).toBe("system");
+    expect(body.messages[1].role).toBe("user");
+    expect(body.messages[1].content).toBe("msg");
+  });
+
+  it("ignores unparseable SSE data lines", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeSSEResponse([
+        { event: "", data: "not json" },
+        { event: "", data: { choices: [{ delta: { content: "ok" } }] } },
+        { event: "", data: "[DONE]" },
+      ]),
+    );
+    const result = await generatePipeline(OPENAI_CONFIG, "msg", () => {});
+    expect(result).toBe("ok");
+  });
+
+  it("throws when OpenAI returns a non-OK status", async () => {
+    fetchMock.mockResolvedValueOnce(makeJSONResponse("bad request", 400));
+    await expect(generatePipeline(OPENAI_CONFIG, "msg", () => {})).rejects.toThrow(
+      /OpenAI API error \(400\)/,
+    );
+  });
+});

--- a/tests/ts/ai/config.test.ts
+++ b/tests/ts/ai/config.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const STORAGE_KEY = "megane-ai-config";
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.resetModules();
+});
+
+describe("useAIConfigStore", () => {
+  it("uses anthropic defaults when no localStorage entry exists", async () => {
+    const { useAIConfigStore } = await import("@/ai/config");
+    const state = useAIConfigStore.getState();
+    expect(state.provider).toBe("anthropic");
+    expect(state.model).toBe("claude-sonnet-4-20250514");
+    expect(state.apiKey).toBe("");
+  });
+
+  it("loads persisted provider and model from localStorage", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ provider: "openai", model: "gpt-4o" }),
+    );
+    const { useAIConfigStore } = await import("@/ai/config");
+    const state = useAIConfigStore.getState();
+    expect(state.provider).toBe("openai");
+    expect(state.model).toBe("gpt-4o");
+  });
+
+  it("never loads apiKey from localStorage even when present", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ provider: "openai", model: "gpt-4o", apiKey: "sk-leak" }),
+    );
+    const { useAIConfigStore } = await import("@/ai/config");
+    expect(useAIConfigStore.getState().apiKey).toBe("");
+  });
+
+  it("falls back to defaults when persisted JSON is malformed", async () => {
+    localStorage.setItem(STORAGE_KEY, "{not json");
+    const { useAIConfigStore } = await import("@/ai/config");
+    const state = useAIConfigStore.getState();
+    expect(state.provider).toBe("anthropic");
+    expect(state.model).toBe("claude-sonnet-4-20250514");
+  });
+
+  it("setProvider switches to that provider's first model and persists", async () => {
+    const { useAIConfigStore } = await import("@/ai/config");
+    useAIConfigStore.getState().setProvider("openai");
+
+    const state = useAIConfigStore.getState();
+    expect(state.provider).toBe("openai");
+    expect(state.model).toBe("gpt-4o");
+
+    const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) as string);
+    expect(persisted.provider).toBe("openai");
+    expect(persisted.model).toBe("gpt-4o");
+  });
+
+  it("setModel updates and persists the new model", async () => {
+    const { useAIConfigStore } = await import("@/ai/config");
+    useAIConfigStore.getState().setModel("claude-haiku-4-20250514");
+
+    expect(useAIConfigStore.getState().model).toBe("claude-haiku-4-20250514");
+    const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) as string);
+    expect(persisted.model).toBe("claude-haiku-4-20250514");
+  });
+
+  it("setApiKey updates state but does NOT persist the apiKey", async () => {
+    const { useAIConfigStore } = await import("@/ai/config");
+    useAIConfigStore.getState().setApiKey("sk-secret");
+
+    expect(useAIConfigStore.getState().apiKey).toBe("sk-secret");
+    const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) as string);
+    expect(persisted.apiKey).toBeUndefined();
+  });
+});
+
+describe("PROVIDER_MODELS", () => {
+  it("declares both anthropic and openai with non-empty model lists", async () => {
+    const { PROVIDER_MODELS } = await import("@/ai/config");
+    expect(PROVIDER_MODELS.anthropic.length).toBeGreaterThan(0);
+    expect(PROVIDER_MODELS.openai.length).toBeGreaterThan(0);
+    for (const model of PROVIDER_MODELS.anthropic) {
+      expect(model.value).toBeTruthy();
+      expect(model.label).toBeTruthy();
+    }
+    for (const model of PROVIDER_MODELS.openai) {
+      expect(model.value).toBeTruthy();
+      expect(model.label).toBeTruthy();
+    }
+  });
+});

--- a/tests/ts/ai/prompt.test.ts
+++ b/tests/ts/ai/prompt.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { buildSystemPrompt } from "@/ai/prompt";
+
+describe("buildSystemPrompt", () => {
+  const prompt = buildSystemPrompt();
+
+  it("returns a non-empty string", () => {
+    expect(typeof prompt).toBe("string");
+    expect(prompt.length).toBeGreaterThan(0);
+  });
+
+  it("documents every supported node type", () => {
+    const nodeTypes = [
+      "load_structure",
+      "load_trajectory",
+      "load_vector",
+      "add_bond",
+      "filter",
+      "modify",
+      "label_generator",
+      "polyhedron_generator",
+      "vector_overlay",
+      "viewport",
+    ];
+    for (const t of nodeTypes) {
+      expect(prompt).toContain(t);
+    }
+  });
+
+  it("includes the schema version 3 marker", () => {
+    expect(prompt).toContain('"version": 3');
+  });
+
+  it("includes a json fenced code block example", () => {
+    expect(prompt).toContain("```json");
+  });
+
+  it("documents the connection rules section", () => {
+    expect(prompt).toContain("Connection Rules");
+  });
+
+  it("is deterministic — two calls return identical strings", () => {
+    expect(buildSystemPrompt()).toBe(buildSystemPrompt());
+  });
+});

--- a/tests/ts/ai/skillLoader.test.ts
+++ b/tests/ts/ai/skillLoader.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildToolDefinitions,
+  executeSkill,
+  getSkills,
+  loadSkills,
+  parseFrontmatter,
+  type PipelineSkill,
+} from "@/ai/skillLoader";
+
+describe("parseFrontmatter", () => {
+  it("parses well-formed frontmatter into key-value attrs and trimmed body", () => {
+    const raw = `---
+name: load-molecule
+description: Load a molecule file
+---
+This is the body content.`;
+    const { attrs, content } = parseFrontmatter(raw);
+    expect(attrs.name).toBe("load-molecule");
+    expect(attrs.description).toBe("Load a molecule file");
+    expect(content).toBe("This is the body content.");
+  });
+
+  it("returns empty attrs and the raw string when no frontmatter is present", () => {
+    const raw = "Just markdown without frontmatter.";
+    const { attrs, content } = parseFrontmatter(raw);
+    expect(attrs).toEqual({});
+    expect(content).toBe(raw);
+  });
+
+  it("splits each frontmatter line on the first colon only", () => {
+    const raw = `---
+description: A title: with: colons
+---
+body`;
+    const { attrs } = parseFrontmatter(raw);
+    expect(attrs.description).toBe("A title: with: colons");
+  });
+
+  it("ignores frontmatter lines without a colon", () => {
+    const raw = `---
+name: tool
+no-colon-here
+description: ok
+---
+body`;
+    const { attrs } = parseFrontmatter(raw);
+    expect(attrs.name).toBe("tool");
+    expect(attrs.description).toBe("ok");
+    expect(attrs["no-colon-here"]).toBeUndefined();
+  });
+
+  it("handles an empty body", () => {
+    const raw = `---
+name: x
+description: y
+---
+`;
+    const { attrs, content } = parseFrontmatter(raw);
+    expect(attrs.name).toBe("x");
+    expect(content).toBe("");
+  });
+});
+
+describe("buildToolDefinitions", () => {
+  it("converts kebab-case skill names to snake_case tool names", () => {
+    const skills: PipelineSkill[] = [
+      { name: "load-molecule", description: "x", content: "" },
+      { name: "add-bond-distance", description: "y", content: "" },
+    ];
+    const tools = buildToolDefinitions(skills);
+    expect(tools).toHaveLength(2);
+    expect(tools[0].name).toBe("load_molecule");
+    expect(tools[1].name).toBe("add_bond_distance");
+  });
+
+  it("each tool has the empty-input schema shape", () => {
+    const tools = buildToolDefinitions([
+      { name: "x", description: "d", content: "" },
+    ]);
+    expect(tools[0].input_schema).toEqual({ type: "object", properties: {} });
+    expect(tools[0].description).toBe("d");
+  });
+
+  it("returns an empty array for no skills", () => {
+    expect(buildToolDefinitions([])).toEqual([]);
+  });
+});
+
+describe("executeSkill", () => {
+  const skills: PipelineSkill[] = [
+    { name: "load-molecule", description: "", content: "molecule body" },
+    { name: "add-bond", description: "", content: "bond body" },
+  ];
+
+  it("returns the skill content when a tool name matches", () => {
+    expect(executeSkill(skills, "load_molecule")).toBe("molecule body");
+    expect(executeSkill(skills, "add_bond")).toBe("bond body");
+  });
+
+  it("returns null for an unknown tool name", () => {
+    expect(executeSkill(skills, "missing_tool")).toBeNull();
+  });
+
+  it("returns null for an empty skills array", () => {
+    expect(executeSkill([], "anything")).toBeNull();
+  });
+});
+
+describe("loadSkills / getSkills", () => {
+  it("loadSkills returns an array (currently empty since src/ai/skills/ has no .md files)", () => {
+    const skills = loadSkills();
+    expect(Array.isArray(skills)).toBe(true);
+  });
+
+  it("getSkills caches the result across calls", () => {
+    const a = getSkills();
+    const b = getSkills();
+    expect(a).toBe(b);
+  });
+});

--- a/tests/ts/stream/StreamFrameProvider.test.ts
+++ b/tests/ts/stream/StreamFrameProvider.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { StreamFrameProvider } from "@/stream/StreamFrameProvider";
+import type { WebSocketClient } from "@/stream/WebSocketClient";
+import type { Frame, TrajectoryMeta } from "@/types";
+
+function fakeClient(): WebSocketClient {
+  return {
+    send: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    get connected() {
+      return true;
+    },
+  } as unknown as WebSocketClient;
+}
+
+function makeFrame(id: number, nAtoms = 2): Frame {
+  return {
+    frameId: id,
+    nAtoms,
+    positions: new Float32Array(nAtoms * 3),
+  };
+}
+
+const META: TrajectoryMeta = { nFrames: 100, timestepPs: 1, nAtoms: 2 };
+
+describe("StreamFrameProvider", () => {
+  let client: WebSocketClient;
+
+  beforeEach(() => {
+    client = fakeClient();
+  });
+
+  it("kind is 'stream' and meta matches the constructor argument", () => {
+    const provider = new StreamFrameProvider(client, META);
+    expect(provider.kind).toBe("stream");
+    expect(provider.meta).toEqual(META);
+  });
+
+  it("getFrame on empty cache returns null and requests via the client", () => {
+    const provider = new StreamFrameProvider(client, META);
+    const result = provider.getFrame(7);
+    expect(result).toBeNull();
+    expect(client.send).toHaveBeenCalledWith({ type: "request_frame", frame: 7 });
+  });
+
+  it("receiveFrame caches the frame and triggers onFrameReady", () => {
+    const provider = new StreamFrameProvider(client, META);
+    const onReady = vi.fn();
+    provider.setOnFrameReady(onReady);
+
+    const frame = makeFrame(3);
+    provider.receiveFrame(frame);
+    expect(onReady).toHaveBeenCalledWith(frame);
+  });
+
+  it("getFrame returns the cached frame without re-requesting", () => {
+    const provider = new StreamFrameProvider(client, META);
+    const frame = makeFrame(3);
+    provider.receiveFrame(frame);
+
+    const result = provider.getFrame(3);
+    expect(result).toBe(frame);
+    expect(client.send).not.toHaveBeenCalled();
+  });
+
+  it("evicts the oldest frame when cache exceeds maxCacheSize (LRU)", () => {
+    const provider = new StreamFrameProvider(client, META, 2);
+    provider.receiveFrame(makeFrame(0));
+    provider.receiveFrame(makeFrame(1));
+    provider.receiveFrame(makeFrame(2));
+
+    // Frame 0 should have been evicted; frames 1 and 2 stay.
+    (client.send as ReturnType<typeof vi.fn>).mockClear();
+    expect(provider.getFrame(0)).toBeNull();
+    expect(client.send).toHaveBeenCalledWith({ type: "request_frame", frame: 0 });
+
+    expect(provider.getFrame(1)?.frameId).toBe(1);
+    expect(provider.getFrame(2)?.frameId).toBe(2);
+  });
+
+  it("re-receiving an existing frameId moves it to MRU position", () => {
+    const provider = new StreamFrameProvider(client, META, 2);
+    provider.receiveFrame(makeFrame(0));
+    provider.receiveFrame(makeFrame(1));
+    // Touch frame 0 → it becomes MRU; frame 1 is now the candidate for eviction.
+    provider.receiveFrame(makeFrame(0));
+    provider.receiveFrame(makeFrame(2));
+
+    expect(provider.getFrame(0)?.frameId).toBe(0);
+    (client.send as ReturnType<typeof vi.fn>).mockClear();
+    expect(provider.getFrame(1)).toBeNull();
+    expect(client.send).toHaveBeenCalledWith({ type: "request_frame", frame: 1 });
+  });
+
+  it("clear empties the cache and order", () => {
+    const provider = new StreamFrameProvider(client, META);
+    provider.receiveFrame(makeFrame(0));
+    provider.receiveFrame(makeFrame(1));
+
+    provider.clear();
+    (client.send as ReturnType<typeof vi.fn>).mockClear();
+    expect(provider.getFrame(0)).toBeNull();
+    expect(provider.getFrame(1)).toBeNull();
+    expect(client.send).toHaveBeenCalledTimes(2);
+  });
+
+  it("setOnFrameReady can be replaced and the latest callback is used", () => {
+    const provider = new StreamFrameProvider(client, META);
+    const first = vi.fn();
+    const second = vi.fn();
+    provider.setOnFrameReady(first);
+    provider.setOnFrameReady(second);
+    provider.receiveFrame(makeFrame(5));
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/ts/stream/WebSocketClient.test.ts
+++ b/tests/ts/stream/WebSocketClient.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { WebSocketClient } from "@/stream/WebSocketClient";
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  static instances: MockWebSocket[] = [];
+
+  url: string;
+  binaryType = "blob";
+  readyState: number = MockWebSocket.CONNECTING;
+  onopen: ((this: MockWebSocket, ev: Event) => void) | null = null;
+  onmessage: ((this: MockWebSocket, ev: MessageEvent) => void) | null = null;
+  onerror: ((this: MockWebSocket, ev: Event) => void) | null = null;
+  onclose: ((this: MockWebSocket, ev: CloseEvent) => void) | null = null;
+
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.(new Event("close") as CloseEvent);
+  });
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  fireOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.(new Event("open"));
+  }
+
+  fireMessage(data: ArrayBuffer | string): void {
+    this.onmessage?.({ data } as MessageEvent);
+  }
+
+  fireClose(): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.(new Event("close") as CloseEvent);
+  }
+
+  fireError(): void {
+    this.onerror?.(new Event("error"));
+  }
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  vi.useFakeTimers();
+  vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("WebSocketClient", () => {
+  it("connect() opens a socket with arraybuffer binary type", () => {
+    const client = new WebSocketClient("ws://localhost:1234", () => {});
+    client.connect();
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    const ws = MockWebSocket.instances[0];
+    expect(ws.url).toBe("ws://localhost:1234");
+    expect(ws.binaryType).toBe("arraybuffer");
+  });
+
+  it("calls onStatus(true) when the socket opens", () => {
+    const onStatus = vi.fn();
+    const client = new WebSocketClient("ws://x", () => {}, onStatus);
+    client.connect();
+
+    MockWebSocket.instances[0].fireOpen();
+    expect(onStatus).toHaveBeenCalledWith(true);
+  });
+
+  it("delivers ArrayBuffer messages to onMessage", () => {
+    const onMessage = vi.fn();
+    const client = new WebSocketClient("ws://x", onMessage);
+    client.connect();
+    MockWebSocket.instances[0].fireOpen();
+
+    const buf = new ArrayBuffer(8);
+    MockWebSocket.instances[0].fireMessage(buf);
+    expect(onMessage).toHaveBeenCalledWith(buf);
+  });
+
+  it("ignores non-ArrayBuffer message payloads", () => {
+    const onMessage = vi.fn();
+    const client = new WebSocketClient("ws://x", onMessage);
+    client.connect();
+    MockWebSocket.instances[0].fireMessage("hello");
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it("calls onStatus(false) on close", () => {
+    const onStatus = vi.fn();
+    const client = new WebSocketClient("ws://x", () => {}, onStatus);
+    client.connect();
+    MockWebSocket.instances[0].fireOpen();
+    onStatus.mockClear();
+
+    MockWebSocket.instances[0].fireClose();
+    expect(onStatus).toHaveBeenCalledWith(false);
+  });
+
+  it("schedules a reconnect with 1s initial delay after close", () => {
+    const client = new WebSocketClient("ws://x", () => {});
+    client.connect();
+    MockWebSocket.instances[0].fireOpen();
+    MockWebSocket.instances[0].fireClose();
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    vi.advanceTimersByTime(999);
+    expect(MockWebSocket.instances).toHaveLength(1);
+    vi.advanceTimersByTime(1);
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it("uses exponential backoff for repeated reconnects", () => {
+    const client = new WebSocketClient("ws://x", () => {});
+    client.connect();
+
+    // First close → reconnect at 1000ms
+    MockWebSocket.instances[0].fireClose();
+    vi.advanceTimersByTime(1000);
+    expect(MockWebSocket.instances).toHaveLength(2);
+
+    // Second close before opening → reconnect at 2000ms
+    MockWebSocket.instances[1].fireClose();
+    vi.advanceTimersByTime(1999);
+    expect(MockWebSocket.instances).toHaveLength(2);
+    vi.advanceTimersByTime(1);
+    expect(MockWebSocket.instances).toHaveLength(3);
+
+    // Third close → reconnect at 4000ms
+    MockWebSocket.instances[2].fireClose();
+    vi.advanceTimersByTime(4000);
+    expect(MockWebSocket.instances).toHaveLength(4);
+  });
+
+  it("resets backoff after a successful open", () => {
+    const client = new WebSocketClient("ws://x", () => {});
+    client.connect();
+
+    // Cycle close → reconnect → close to grow backoff
+    MockWebSocket.instances[0].fireClose();
+    vi.advanceTimersByTime(1000);
+    MockWebSocket.instances[1].fireClose();
+    vi.advanceTimersByTime(2000);
+    expect(MockWebSocket.instances).toHaveLength(3);
+
+    // Successful open should reset the delay back to 1s
+    MockWebSocket.instances[2].fireOpen();
+    MockWebSocket.instances[2].fireClose();
+    vi.advanceTimersByTime(1000);
+    expect(MockWebSocket.instances).toHaveLength(4);
+  });
+
+  it("caps backoff at 30s", () => {
+    const client = new WebSocketClient("ws://x", () => {});
+    client.connect();
+
+    // Drive backoff up: 1s → 2s → 4s → 8s → 16s → 30s (cap)
+    const delays = [1000, 2000, 4000, 8000, 16000, 30000, 30000];
+    let expectedSockets = 1;
+    for (const delay of delays) {
+      MockWebSocket.instances[expectedSockets - 1].fireClose();
+      vi.advanceTimersByTime(delay);
+      expectedSockets++;
+      expect(MockWebSocket.instances).toHaveLength(expectedSockets);
+    }
+  });
+
+  it("disconnect() prevents further reconnects", () => {
+    const client = new WebSocketClient("ws://x", () => {});
+    client.connect();
+    MockWebSocket.instances[0].fireOpen();
+
+    client.disconnect();
+    vi.advanceTimersByTime(60000);
+    // Initial socket plus no reconnects.
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("disconnect() also clears a pending reconnect timer", () => {
+    const client = new WebSocketClient("ws://x", () => {});
+    client.connect();
+    MockWebSocket.instances[0].fireClose();
+
+    // Reconnect is queued for 1000ms.
+    client.disconnect();
+    vi.advanceTimersByTime(60000);
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("send() is a no-op when readyState is not OPEN", () => {
+    const client = new WebSocketClient("ws://x", () => {});
+    client.connect();
+    // Socket is in CONNECTING state.
+    client.send({ type: "ping" });
+    expect(MockWebSocket.instances[0].send).not.toHaveBeenCalled();
+  });
+
+  it("send() serializes JSON when the socket is open", () => {
+    const client = new WebSocketClient("ws://x", () => {});
+    client.connect();
+    MockWebSocket.instances[0].fireOpen();
+
+    client.send({ type: "request_frame", frame: 7 });
+    expect(MockWebSocket.instances[0].send).toHaveBeenCalledTimes(1);
+    expect(MockWebSocket.instances[0].send).toHaveBeenCalledWith(
+      JSON.stringify({ type: "request_frame", frame: 7 }),
+    );
+  });
+
+  it("connected getter reflects the live readyState", () => {
+    const client = new WebSocketClient("ws://x", () => {});
+    expect(client.connected).toBe(false);
+
+    client.connect();
+    expect(client.connected).toBe(false); // still CONNECTING
+
+    MockWebSocket.instances[0].fireOpen();
+    expect(client.connected).toBe(true);
+
+    MockWebSocket.instances[0].fireClose();
+    expect(client.connected).toBe(false);
+  });
+
+  it("logs but does not throw on socket errors", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const client = new WebSocketClient("ws://x", () => {});
+    client.connect();
+    expect(() => MockWebSocket.instances[0].fireError()).not.toThrow();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});

--- a/tests/ts/tour/tourSteps.test.ts
+++ b/tests/ts/tour/tourSteps.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { buildTourSteps } from "@/tour/tourSteps";
+import packageJson from "../../../package.json";
+
+describe("buildTourSteps", () => {
+  const steps = buildTourSteps();
+
+  it("returns the expected number of steps", () => {
+    expect(steps).toHaveLength(6);
+  });
+
+  it("first step is the welcome screen with no anchor element", () => {
+    const first = steps[0];
+    expect(first.element).toBeUndefined();
+    expect(first.popover?.title).toBe("Welcome");
+    expect(typeof first.popover?.description).toBe("string");
+  });
+
+  it("welcome description embeds the current package version", () => {
+    const desc = steps[0].popover?.description as string;
+    expect(desc).toContain(`v${packageJson.version}`);
+  });
+
+  it("every step has a non-empty popover title", () => {
+    for (const step of steps) {
+      expect(step.popover?.title).toBeTruthy();
+      expect(typeof step.popover?.title).toBe("string");
+    }
+  });
+
+  it("every step has a description string", () => {
+    for (const step of steps) {
+      expect(step.popover?.description).toBeTruthy();
+      expect(typeof step.popover?.description).toBe("string");
+    }
+  });
+
+  it("anchored steps point at non-empty selectors", () => {
+    const anchored = steps.filter((s) => s.element !== undefined);
+    expect(anchored.length).toBeGreaterThan(0);
+    for (const step of anchored) {
+      expect(typeof step.element).toBe("string");
+      expect((step.element as string).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("anchored selectors are unique", () => {
+    const selectors = steps
+      .map((s) => s.element)
+      .filter((v): v is string => typeof v === "string");
+    expect(new Set(selectors).size).toBe(selectors.length);
+  });
+
+  it("expected anchors reference the documented data attributes", () => {
+    const selectors = steps
+      .map((s) => s.element)
+      .filter((v): v is string => typeof v === "string");
+    expect(selectors).toContain('[data-tour-anchor="viewport"]');
+    expect(selectors).toContain('[data-testid="panel-pipeline"]');
+    expect(selectors).toContain('[data-testid="pipeline-editor-templates"]');
+  });
+});

--- a/tests/ts/tour/tourStore.test.ts
+++ b/tests/ts/tour/tourStore.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { shouldAutoStart, useTourStore, type TourHost } from "@/tour/tourStore";
+
+const STORAGE_KEY = "megane-tour-prefs";
+
+function setLocation(search: string): void {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...window.location, search },
+  });
+}
+
+describe("useTourStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useTourStore.setState({
+      host: "webapp",
+      isActive: false,
+      dontShowAgain: false,
+      autoStartHandled: false,
+    });
+    setLocation("");
+  });
+
+  it("has expected initial state", () => {
+    const state = useTourStore.getState();
+    expect(state.host).toBe("webapp");
+    expect(state.isActive).toBe(false);
+    expect(state.dontShowAgain).toBe(false);
+    expect(state.autoStartHandled).toBe(false);
+  });
+
+  it("setHost updates host", () => {
+    useTourStore.getState().setHost("vscode");
+    expect(useTourStore.getState().host).toBe("vscode");
+  });
+
+  it("setActive toggles isActive", () => {
+    useTourStore.getState().setActive(true);
+    expect(useTourStore.getState().isActive).toBe(true);
+    useTourStore.getState().setActive(false);
+    expect(useTourStore.getState().isActive).toBe(false);
+  });
+
+  it("markAutoStartHandled flips autoStartHandled to true", () => {
+    useTourStore.getState().markAutoStartHandled();
+    expect(useTourStore.getState().autoStartHandled).toBe(true);
+  });
+
+  it("setDontShowAgain updates state and persists to localStorage", () => {
+    useTourStore.getState().setDontShowAgain(true);
+    expect(useTourStore.getState().dontShowAgain).toBe(true);
+
+    const stored = localStorage.getItem(STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored as string);
+    expect(parsed.dontShowAgain).toBe(true);
+  });
+
+  it("setDontShowAgain(false) is also persisted", () => {
+    useTourStore.getState().setDontShowAgain(true);
+    useTourStore.getState().setDontShowAgain(false);
+    const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY) as string);
+    expect(parsed.dontShowAgain).toBe(false);
+  });
+
+  it("loads persisted dontShowAgain on a fresh module import", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ dontShowAgain: true }));
+    // The store reads localStorage at module init, so reset modules and re-import.
+    vi.resetModules();
+    const fresh = await import("@/tour/tourStore");
+    expect(fresh.useTourStore.getState().dontShowAgain).toBe(true);
+  });
+
+  it("tolerates malformed persisted JSON", async () => {
+    localStorage.setItem(STORAGE_KEY, "{not json");
+    vi.resetModules();
+    const fresh = await import("@/tour/tourStore");
+    expect(fresh.useTourStore.getState().dontShowAgain).toBe(false);
+  });
+});
+
+describe("shouldAutoStart", () => {
+  beforeEach(() => {
+    setLocation("");
+  });
+
+  const cases: Array<{ host: TourHost; dontShow: boolean; expected: boolean }> = [
+    { host: "webapp", dontShow: false, expected: true },
+    { host: "webapp", dontShow: true, expected: false },
+    { host: "vscode", dontShow: false, expected: true },
+    { host: "vscode", dontShow: true, expected: false },
+    { host: "jupyterlab", dontShow: false, expected: true },
+    { host: "jupyterlab", dontShow: true, expected: false },
+    { host: "ipywidget", dontShow: false, expected: false },
+    { host: "ipywidget", dontShow: true, expected: false },
+  ];
+
+  it.each(cases)(
+    "host=$host dontShowAgain=$dontShow → $expected",
+    ({ host, dontShow, expected }) => {
+      expect(shouldAutoStart(host, dontShow)).toBe(expected);
+    },
+  );
+
+  it("URL override ?guide=on forces auto-start on webapp even when dontShowAgain=true", () => {
+    setLocation("?guide=on");
+    expect(shouldAutoStart("webapp", true)).toBe(true);
+  });
+
+  it("URL override ?guide=off suppresses auto-start on webapp even when dontShowAgain=false", () => {
+    setLocation("?guide=off");
+    expect(shouldAutoStart("webapp", false)).toBe(false);
+  });
+
+  it("URL override accepts numeric and boolean string variants", () => {
+    setLocation("?guide=1");
+    expect(shouldAutoStart("webapp", true)).toBe(true);
+    setLocation("?guide=true");
+    expect(shouldAutoStart("webapp", true)).toBe(true);
+    setLocation("?guide=0");
+    expect(shouldAutoStart("webapp", false)).toBe(false);
+    setLocation("?guide=false");
+    expect(shouldAutoStart("webapp", false)).toBe(false);
+  });
+
+  it("URL override is ignored on non-webapp hosts", () => {
+    setLocation("?guide=on");
+    expect(shouldAutoStart("ipywidget", false)).toBe(false);
+  });
+});

--- a/tests/ts/tour/useTour.test.tsx
+++ b/tests/ts/tour/useTour.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+// Mock the driver.js-backed tour controller so we don't pull driver into jsdom.
+vi.mock("@/tour/MeganeTour", () => ({
+  startTour: vi.fn(),
+  stopTour: vi.fn(),
+}));
+
+import { useTour } from "@/tour/useTour";
+import { startTour, stopTour } from "@/tour/MeganeTour";
+import { useTourStore } from "@/tour/tourStore";
+
+const mockStartTour = vi.mocked(startTour);
+const mockStopTour = vi.mocked(stopTour);
+
+describe("useTour", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockStartTour.mockReset();
+    mockStopTour.mockReset();
+    useTourStore.setState({
+      host: "webapp",
+      isActive: false,
+      dontShowAgain: false,
+      autoStartHandled: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("syncs the host into the store", () => {
+    renderHook(() => useTour({ host: "vscode" }));
+    expect(useTourStore.getState().host).toBe("vscode");
+  });
+
+  it("auto-starts on webapp when dontShowAgain=false", () => {
+    renderHook(() => useTour({ host: "webapp", autoStartDelayMs: 100 }));
+    expect(mockStartTour).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(100);
+    expect(mockStartTour).toHaveBeenCalledTimes(1);
+    expect(useTourStore.getState().autoStartHandled).toBe(true);
+  });
+
+  it("does not auto-start on ipywidget host", () => {
+    renderHook(() => useTour({ host: "ipywidget", autoStartDelayMs: 100 }));
+    vi.advanceTimersByTime(1000);
+    expect(mockStartTour).not.toHaveBeenCalled();
+    expect(useTourStore.getState().autoStartHandled).toBe(true);
+  });
+
+  it("does not auto-start when dontShowAgain is true", () => {
+    useTourStore.setState({ dontShowAgain: true });
+    renderHook(() => useTour({ host: "webapp", autoStartDelayMs: 100 }));
+    vi.advanceTimersByTime(1000);
+    expect(mockStartTour).not.toHaveBeenCalled();
+    expect(useTourStore.getState().autoStartHandled).toBe(true);
+  });
+
+  it("skips auto-start when autoStartHandled is already true (subsequent mount)", () => {
+    useTourStore.setState({ autoStartHandled: true });
+    renderHook(() => useTour({ host: "webapp", autoStartDelayMs: 100 }));
+    vi.advanceTimersByTime(1000);
+    expect(mockStartTour).not.toHaveBeenCalled();
+  });
+
+  it("stops the tour on unmount", () => {
+    const { unmount } = renderHook(() => useTour({ host: "webapp", autoStartDelayMs: 100 }));
+    unmount();
+    expect(mockStopTour).toHaveBeenCalled();
+  });
+
+  it("returns a startTour callback that triggers the controller immediately", () => {
+    useTourStore.setState({ dontShowAgain: true });
+    const { result } = renderHook(() => useTour({ host: "webapp", autoStartDelayMs: 100 }));
+    vi.advanceTimersByTime(100);
+    expect(mockStartTour).not.toHaveBeenCalled();
+
+    result.current.startTour();
+    expect(mockStartTour).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Executes Phases 0–3 of `docs/plans/test-coverage-roadmap.md` on a single branch (each phase is its own commit, so they can be cherry-picked into separate PRs if preferred).

- **Phase 0** (`c17462a`) — codecov flag/upload alignment. The TS coverage step uploaded one lcov tagged `flags: typescript,vscode,jupyterlab` while `codecov.yml` declared `vscode`/`jupyterlab` as independent flags with their own status checks, so per-flag status didn't fire correctly. Folded both flags' paths into `typescript` and reduced the upload's flag list to `typescript`.
- **Phase 1** (`b03bf04`) — `src/tour/` unit tests. 35 tests across `tourStore.test.ts` (zustand + localStorage + `shouldAutoStart` matrix + `?guide=on/off` URL override), `tourSteps.test.ts` (structural invariants of the 6 tour steps), `useTour.test.tsx` (auto-start gating + manual `startTour`, with `driver.js` mocked).
- **Phase 2** (`61ada6e`) — `src/stream/` unit tests. 23 tests across `WebSocketClient.test.ts` (full state machine: open/close/error, exponential reconnect backoff 1s→30s cap, backoff reset on open, disconnect timer cancellation, `send()` readyState gating, `connected` getter) and `StreamFrameProvider.test.ts` (LRU cache: miss → `request_frame`, eviction at maxCacheSize, MRU-touch on re-receive, `clear`).
- **Phase 3** (`db0b679`) — `src/ai/` unit tests. 42 tests across `config.test.ts` (zustand + localStorage; `apiKey` never persisted), `prompt.test.ts` (system prompt structural markers), `skillLoader.test.ts` (`parseFrontmatter` edge cases, kebab→snake, `executeSkill`, caching), `client.test.ts` (`extractPipelineJSON` parsing modes, full Anthropic SSE flow including tool_use→tool_result round trip, OpenAI SSE flow, error paths). One source change: `parseFrontmatter` is now exported from `skillLoader.ts` to enable direct unit testing — the only edit allowed by the roadmap's "tests + minimum needed export" rule.
- Roadmap doc (`a8746c2`) updated to reflect Phases 0–3 done with commit references and remaining Phases 4–8 still TODO.

**Coverage delta** (vitest --coverage):
- `src/tour/`: 0% → 76% (`MeganeTour.ts` deliberately deferred to E2E per roadmap)
- `src/stream/`: 0% → 100%
- `src/ai/`: 0% → 97%
- 100 new tests added; 454 total tests pass (was 354).

Out of scope (deferred to later PRs per roadmap): Phase 4 (`renderer` pure helpers), Phase 5 (`components/nodes/`), Phase 6 (`jupyterlab-megane/src/`), Phase 7 (`vscode-megane/src/extension.ts`), Phase 8 (codecov threshold tightening).

## Test plan

- [x] `npm run build:wasm`
- [x] `npm test -- --coverage` — 454/454 pass
- [x] `npm run lint` — only pre-existing warnings, 0 errors
- [x] `npm run format:check` — clean
- [ ] CI run on this PR is green
- [ ] Codecov PR comment shows only `typescript` / `rust` / `python` flags (no orphan `vscode` / `jupyterlab`) — validates Phase 0


---
_Generated by [Claude Code](https://claude.ai/code/session_0157vD2kVErHEAxFgsArX1Kq)_