### PR TITLE
test(nodes): add unit tests for NodeShell + 4 nodes (Phase 5 part 1)

### DIFF
--- a/tests/ts/components/nodes/AddBondNode.test.tsx
+++ b/tests/ts/components/nodes/AddBondNode.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { usePipelineStore } from "@/pipeline/store";
+import { AddBondNode } from "@/components/nodes/AddBondNode";
+import type { AddBondParams } from "@/pipeline/types";
+import { seedPipelineStore } from "./_helpers";
+
+vi.mock("@xyflow/react", () => import("./_xyflowMock"));
+vi.mock("@/parsers/structure", () => ({
+  parseTopBonds: vi.fn(async () => new Uint32Array([0, 1, 2, 3])),
+}));
+
+import { parseTopBonds } from "@/parsers/structure";
+
+const mockedParseTopBonds = vi.mocked(parseTopBonds);
+
+/**
+ * Build a File whose `.text()` resolves to the given string. jsdom's File
+ * does not implement `text()` in the version bundled with vitest, and the
+ * production code awaits it.
+ */
+function makeFileWithText(name: string, text: string): File {
+  const file = new File([text], name, { type: "text/plain" });
+  Object.defineProperty(file, "text", {
+    value: () => Promise.resolve(text),
+    configurable: true,
+  });
+  return file;
+}
+
+function nodeProps(id: string, params: AddBondParams, enabled = true) {
+  return {
+    id,
+    type: "add_bond" as const,
+    data: { params, enabled },
+    selected: false,
+    isConnectable: true,
+    xPos: 0,
+    yPos: 0,
+    zIndex: 0,
+    dragging: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe("AddBondNode", () => {
+  beforeEach(() => {
+    cleanup();
+    mockedParseTopBonds.mockClear();
+    mockedParseTopBonds.mockResolvedValue(new Uint32Array([0, 1, 2, 3]));
+  });
+
+  it("renders three tab buttons: File / VDW / Topology", () => {
+    const seeded = seedPipelineStore("add_bond", { id: "ab1" });
+    render(<AddBondNode {...nodeProps("ab1", seeded.data.params as AddBondParams)} />);
+
+    expect(screen.getByRole("button", { name: "File" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "VDW" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Topology" })).toBeInTheDocument();
+  });
+
+  it("clicking a tab calls updateNodeParams with the new bondSource", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("add_bond", {
+      id: "ab1",
+      params: { bondSource: "distance" },
+    });
+    usePipelineStore.setState({ updateNodeParams });
+    render(<AddBondNode {...nodeProps("ab1", seeded.data.params as AddBondParams)} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "File" }));
+    expect(updateNodeParams).toHaveBeenCalledWith("ab1", { bondSource: "structure" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Topology" }));
+    expect(updateNodeParams).toHaveBeenCalledWith("ab1", { bondSource: "file" });
+  });
+
+  it("hides the topology upload UI when bondSource !== 'file'", () => {
+    const seeded = seedPipelineStore("add_bond", {
+      id: "ab1",
+      params: { bondSource: "distance" },
+    });
+    render(<AddBondNode {...nodeProps("ab1", seeded.data.params as AddBondParams)} />);
+
+    expect(screen.queryByText("Load .top...")).toBeNull();
+    expect(screen.queryByText("No topology loaded")).toBeNull();
+  });
+
+  it("shows 'No topology loaded' placeholder when bondSource='file' and no file selected", () => {
+    const seeded = seedPipelineStore("add_bond", {
+      id: "ab1",
+      params: { bondSource: "file" },
+    });
+    render(<AddBondNode {...nodeProps("ab1", seeded.data.params as AddBondParams)} />);
+
+    expect(screen.getByText("No topology loaded")).toBeInTheDocument();
+    expect(screen.getByText("Load .top...")).toBeInTheDocument();
+  });
+
+  it("shows the topology filename when bondSource='file' and bondFileName is set", () => {
+    const seeded = seedPipelineStore("add_bond", {
+      id: "ab1",
+      params: { bondSource: "file", bondFileName: "system.top" },
+    });
+    render(<AddBondNode {...nodeProps("ab1", seeded.data.params as AddBondParams)} />);
+
+    expect(screen.getByText("system.top")).toBeInTheDocument();
+    expect(screen.queryByText("No topology loaded")).toBeNull();
+  });
+
+  it("uploading a .top file parses it and dispatches the parsed bonds to the store", async () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("add_bond", {
+      id: "ab1",
+      params: { bondSource: "file" },
+    });
+    usePipelineStore.setState({ updateNodeParams });
+
+    render(<AddBondNode {...nodeProps("ab1", seeded.data.params as AddBondParams)} />);
+
+    const fileText = "[ bonds ]\n1 2";
+    const file = makeFileWithText("system.top", fileText);
+    const input = screen.getByText("Load .top...").parentElement!.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    Object.defineProperty(input, "files", {
+      value: [file],
+      writable: false,
+      configurable: true,
+    });
+    fireEvent.change(input);
+
+    await waitFor(() => {
+      expect(mockedParseTopBonds).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedParseTopBonds).toHaveBeenCalledWith(fileText, 0xffffffff);
+    expect(updateNodeParams).toHaveBeenCalledWith("ab1", {
+      bondSource: "file",
+      bondFileName: "system.top",
+      bondFileData: expect.any(Uint32Array),
+    });
+    const dispatchedData = updateNodeParams.mock.calls[0][1].bondFileData as Uint32Array;
+    expect(Array.from(dispatchedData)).toEqual([0, 1, 2, 3]);
+  });
+
+  it("uploading a non-.top file does not call the parser or dispatch", async () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("add_bond", {
+      id: "ab1",
+      params: { bondSource: "file" },
+    });
+    usePipelineStore.setState({ updateNodeParams });
+
+    render(<AddBondNode {...nodeProps("ab1", seeded.data.params as AddBondParams)} />);
+
+    const file = new File(["junk"], "system.json", { type: "application/json" });
+    const input = screen.getByText("Load .top...").parentElement!.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    Object.defineProperty(input, "files", {
+      value: [file],
+      writable: false,
+      configurable: true,
+    });
+    fireEvent.change(input);
+
+    // Allow any pending async work to flush.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockedParseTopBonds).not.toHaveBeenCalled();
+    expect(updateNodeParams).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ts/components/nodes/FilterNode.test.tsx
+++ b/tests/ts/components/nodes/FilterNode.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { usePipelineStore } from "@/pipeline/store";
+import { FilterNode } from "@/components/nodes/FilterNode";
+import type { FilterParams } from "@/pipeline/types";
+import { seedPipelineStore } from "./_helpers";
+
+vi.mock("@xyflow/react", () => import("./_xyflowMock"));
+vi.mock("@/pipeline/selection", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/pipeline/selection")>();
+  return {
+    ...actual,
+    validateQuery: vi.fn(() => ({ valid: true })),
+    validateBondQuery: vi.fn(() => ({ valid: true })),
+  };
+});
+
+import { validateQuery, validateBondQuery } from "@/pipeline/selection";
+
+const mockedValidateQuery = vi.mocked(validateQuery);
+const mockedValidateBondQuery = vi.mocked(validateBondQuery);
+
+function nodeProps(id: string, params: FilterParams, enabled = true) {
+  return {
+    id,
+    type: "filter" as const,
+    data: { params, enabled },
+    selected: false,
+    isConnectable: true,
+    xPos: 0,
+    yPos: 0,
+    zIndex: 0,
+    dragging: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe("FilterNode", () => {
+  beforeEach(() => {
+    cleanup();
+    mockedValidateQuery.mockReset();
+    mockedValidateQuery.mockReturnValue({ valid: true });
+    mockedValidateBondQuery.mockReset();
+    mockedValidateBondQuery.mockReturnValue({ valid: true });
+  });
+
+  it("renders the particle and bond query inputs with values from params", () => {
+    const seeded = seedPipelineStore("filter", {
+      id: "f1",
+      params: { query: 'element == "C"', bond_query: "both atom_index >= 1" },
+    });
+    render(<FilterNode {...nodeProps("f1", seeded.data.params as FilterParams)} />);
+
+    const particleInput = screen.getByPlaceholderText('element == "C"') as HTMLInputElement;
+    const bondInput = screen.getByPlaceholderText("both atom_index >= 24") as HTMLInputElement;
+    expect(particleInput.value).toBe('element == "C"');
+    expect(bondInput.value).toBe("both atom_index >= 1");
+  });
+
+  it("typing in the input updates local state but does not call updateNodeParams", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("filter", { id: "f1" });
+    usePipelineStore.setState({ updateNodeParams });
+    render(<FilterNode {...nodeProps("f1", seeded.data.params as FilterParams)} />);
+
+    const particleInput = screen.getByPlaceholderText('element == "C"') as HTMLInputElement;
+    fireEvent.change(particleInput, { target: { value: "name == 'O'" } });
+
+    expect(particleInput.value).toBe("name == 'O'");
+    expect(updateNodeParams).not.toHaveBeenCalled();
+  });
+
+  it("blur with a valid particle query commits to the store with no error", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("filter", { id: "f1" });
+    usePipelineStore.setState({ updateNodeParams });
+    mockedValidateQuery.mockReturnValue({ valid: true });
+
+    render(<FilterNode {...nodeProps("f1", seeded.data.params as FilterParams)} />);
+    const particleInput = screen.getByPlaceholderText('element == "C"');
+    fireEvent.change(particleInput, { target: { value: "element == 'O'" } });
+    fireEvent.blur(particleInput);
+
+    expect(mockedValidateQuery).toHaveBeenCalledWith("element == 'O'");
+    expect(updateNodeParams).toHaveBeenCalledWith("f1", { query: "element == 'O'" });
+  });
+
+  it("blur with an invalid particle query renders the error message", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("filter", { id: "f1" });
+    usePipelineStore.setState({ updateNodeParams });
+    mockedValidateQuery.mockReturnValue({ valid: false, error: "bad token" });
+
+    render(<FilterNode {...nodeProps("f1", seeded.data.params as FilterParams)} />);
+    const particleInput = screen.getByPlaceholderText('element == "C"');
+    fireEvent.change(particleInput, { target: { value: "garbage" } });
+    fireEvent.blur(particleInput);
+
+    expect(screen.getByText("bad token")).toBeInTheDocument();
+    // Component still commits the value (current behavior)
+    expect(updateNodeParams).toHaveBeenCalledWith("f1", { query: "garbage" });
+  });
+
+  it("Enter key triggers a commit identical to blur", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("filter", { id: "f1" });
+    usePipelineStore.setState({ updateNodeParams });
+
+    render(<FilterNode {...nodeProps("f1", seeded.data.params as FilterParams)} />);
+    const particleInput = screen.getByPlaceholderText('element == "C"');
+    fireEvent.change(particleInput, { target: { value: "element == 'N'" } });
+    fireEvent.keyDown(particleInput, { key: "Enter" });
+
+    expect(updateNodeParams).toHaveBeenCalledWith("f1", { query: "element == 'N'" });
+  });
+
+  it("bond query input runs through validateBondQuery on commit", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("filter", { id: "f1" });
+    usePipelineStore.setState({ updateNodeParams });
+    mockedValidateBondQuery.mockReturnValue({ valid: false, error: "bond syntax" });
+
+    render(<FilterNode {...nodeProps("f1", seeded.data.params as FilterParams)} />);
+    const bondInput = screen.getByPlaceholderText("both atom_index >= 24");
+    fireEvent.change(bondInput, { target: { value: "garbage bond" } });
+    fireEvent.blur(bondInput);
+
+    expect(mockedValidateBondQuery).toHaveBeenCalledWith("garbage bond");
+    expect(screen.getByText("bond syntax")).toBeInTheDocument();
+    expect(updateNodeParams).toHaveBeenCalledWith("f1", { bond_query: "garbage bond" });
+  });
+
+  it("when params.query changes externally, the input re-syncs via useEffect", () => {
+    const seeded = seedPipelineStore("filter", {
+      id: "f1",
+      params: { query: "element == 'C'", bond_query: "" },
+    });
+    const { rerender } = render(
+      <FilterNode {...nodeProps("f1", seeded.data.params as FilterParams)} />,
+    );
+    const particleInput = screen.getByPlaceholderText('element == "C"') as HTMLInputElement;
+    expect(particleInput.value).toBe("element == 'C'");
+
+    // Simulate an external param change (e.g. AI agent sets a new query).
+    const updatedParams = {
+      type: "filter",
+      query: "element == 'O'",
+      bond_query: "",
+    } as FilterParams;
+    rerender(<FilterNode {...nodeProps("f1", updatedParams)} />);
+    expect(particleInput.value).toBe("element == 'O'");
+  });
+
+  it("hint text shows when query is empty and there is no error", () => {
+    const seeded = seedPipelineStore("filter", {
+      id: "f1",
+      params: { query: "", bond_query: "" },
+    });
+    render(<FilterNode {...nodeProps("f1", seeded.data.params as FilterParams)} />);
+    expect(screen.getByText("element, index, x, y, z, resname, mass")).toBeInTheDocument();
+    expect(
+      screen.getByText('bond_index, atom_index, element · "both" for AND'),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/ts/components/nodes/LoadStructureNode.test.tsx
+++ b/tests/ts/components/nodes/LoadStructureNode.test.tsx
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { usePipelineStore } from "@/pipeline/store";
+import {
+  LoadStructureNode,
+  setStructureLoadHandler,
+} from "@/components/nodes/LoadStructureNode";
+import type { LoadStructureParams } from "@/pipeline/types";
+import { seedPipelineStore } from "./_helpers";
+
+vi.mock("@xyflow/react", () => import("./_xyflowMock"));
+
+function nodeProps(id: string, params: LoadStructureParams, enabled = true) {
+  return {
+    id,
+    type: "load_structure" as const,
+    data: { params, enabled },
+    selected: false,
+    isConnectable: true,
+    xPos: 0,
+    yPos: 0,
+    zIndex: 0,
+    dragging: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+/**
+ * Helper to simulate a `change` event on the hidden file input. jsdom does
+ * not let us set `e.target.files` via `fireEvent.change` directly; instead
+ * we redefine the property on the input element.
+ */
+function fireFileInputChange(input: HTMLInputElement, files: File[]) {
+  Object.defineProperty(input, "files", {
+    value: files,
+    writable: false,
+    configurable: true,
+  });
+  fireEvent.change(input);
+}
+
+describe("LoadStructureNode", () => {
+  beforeEach(() => {
+    cleanup();
+    setStructureLoadHandler(null);
+  });
+
+  afterEach(() => {
+    setStructureLoadHandler(null);
+  });
+
+  it("renders the placeholder when fileName is null", () => {
+    const seeded = seedPipelineStore("load_structure", { id: "ls1" });
+    render(
+      <LoadStructureNode {...nodeProps("ls1", seeded.data.params as LoadStructureParams)} />,
+    );
+    expect(screen.getByTestId("load-structure-filename")).toHaveTextContent(
+      "No structure loaded",
+    );
+  });
+
+  it("renders the filename when params.fileName is set", () => {
+    const seeded = seedPipelineStore("load_structure", {
+      id: "ls1",
+      params: { fileName: "water.pdb", hasTrajectory: false, hasCell: true },
+    });
+    render(
+      <LoadStructureNode {...nodeProps("ls1", seeded.data.params as LoadStructureParams)} />,
+    );
+    expect(screen.getByTestId("load-structure-filename")).toHaveTextContent("water.pdb");
+  });
+
+  it("file input change with a supported extension updates params and fires the load handler", () => {
+    const updateNodeParams = vi.fn();
+    const handler = vi.fn();
+    const seeded = seedPipelineStore("load_structure", { id: "ls1" });
+    usePipelineStore.setState({ updateNodeParams });
+    setStructureLoadHandler(handler);
+
+    render(
+      <LoadStructureNode {...nodeProps("ls1", seeded.data.params as LoadStructureParams)} />,
+    );
+
+    const file = new File(["dummy"], "system.pdb", { type: "chemical/x-pdb" });
+    const input = screen.getByTestId("load-structure-input") as HTMLInputElement;
+    fireFileInputChange(input, [file]);
+
+    expect(updateNodeParams).toHaveBeenCalledWith("ls1", { fileName: "system.pdb" });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith("ls1", file);
+  });
+
+  it("file input change with an unsupported extension is a no-op", () => {
+    const updateNodeParams = vi.fn();
+    const handler = vi.fn();
+    const seeded = seedPipelineStore("load_structure", { id: "ls1" });
+    usePipelineStore.setState({ updateNodeParams });
+    setStructureLoadHandler(handler);
+
+    render(
+      <LoadStructureNode {...nodeProps("ls1", seeded.data.params as LoadStructureParams)} />,
+    );
+
+    const file = new File(["dummy"], "garbage.bad", { type: "text/plain" });
+    const input = screen.getByTestId("load-structure-input") as HTMLInputElement;
+    fireFileInputChange(input, [file]);
+
+    expect(updateNodeParams).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("clearing the load handler with setStructureLoadHandler(null) prevents subsequent dispatch", () => {
+    const updateNodeParams = vi.fn();
+    const handler = vi.fn();
+    const seeded = seedPipelineStore("load_structure", { id: "ls1" });
+    usePipelineStore.setState({ updateNodeParams });
+
+    setStructureLoadHandler(handler);
+    setStructureLoadHandler(null);
+
+    render(
+      <LoadStructureNode {...nodeProps("ls1", seeded.data.params as LoadStructureParams)} />,
+    );
+
+    const file = new File(["dummy"], "system.gro", { type: "text/plain" });
+    const input = screen.getByTestId("load-structure-input") as HTMLInputElement;
+    fireFileInputChange(input, [file]);
+
+    expect(updateNodeParams).toHaveBeenCalledWith("ls1", { fileName: "system.gro" });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("drag-and-drop of a supported file calls updateNodeParams and the load handler", () => {
+    const updateNodeParams = vi.fn();
+    const handler = vi.fn();
+    const seeded = seedPipelineStore("load_structure", { id: "ls1" });
+    usePipelineStore.setState({ updateNodeParams });
+    setStructureLoadHandler(handler);
+
+    render(
+      <LoadStructureNode {...nodeProps("ls1", seeded.data.params as LoadStructureParams)} />,
+    );
+
+    const file = new File(["dummy"], "trajectory.xyz", { type: "text/plain" });
+    const dropZone = screen.getByTestId("load-structure-filename").parentElement!;
+    fireEvent.drop(dropZone, {
+      dataTransfer: { files: [file] },
+    });
+
+    expect(updateNodeParams).toHaveBeenCalledWith("ls1", { fileName: "trajectory.xyz" });
+    expect(handler).toHaveBeenCalledWith("ls1", file);
+  });
+
+  it("drag-and-drop ignores files with unsupported extensions", () => {
+    const updateNodeParams = vi.fn();
+    const handler = vi.fn();
+    const seeded = seedPipelineStore("load_structure", { id: "ls1" });
+    usePipelineStore.setState({ updateNodeParams });
+    setStructureLoadHandler(handler);
+
+    render(
+      <LoadStructureNode {...nodeProps("ls1", seeded.data.params as LoadStructureParams)} />,
+    );
+
+    const file = new File(["dummy"], "readme.txt", { type: "text/plain" });
+    const dropZone = screen.getByTestId("load-structure-filename").parentElement!;
+    fireEvent.drop(dropZone, {
+      dataTransfer: { files: [file] },
+    });
+
+    expect(updateNodeParams).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("disables trajectory and cell handles when params indicate they are absent", () => {
+    const seeded = seedPipelineStore("load_structure", {
+      id: "ls1",
+      params: { fileName: "water.pdb", hasTrajectory: false, hasCell: false },
+    });
+    render(
+      <LoadStructureNode {...nodeProps("ls1", seeded.data.params as LoadStructureParams)} />,
+    );
+
+    const trajectoryHandle = screen.getByTestId("handle-source-trajectory");
+    const cellHandle = screen.getByTestId("handle-source-cell");
+    const particleHandle = screen.getByTestId("handle-source-particle");
+
+    // Disabled handles use the slate-300 gray (#cbd5e1 → rgb(203, 213, 225))
+    expect(trajectoryHandle.style.background).toBe("rgb(203, 213, 225)");
+    expect(cellHandle.style.background).toBe("rgb(203, 213, 225)");
+    // Particle handle remains its data-type color
+    expect(particleHandle.style.background).not.toBe("rgb(203, 213, 225)");
+  });
+
+  it("enables trajectory handle when hasTrajectory is true", () => {
+    const seeded = seedPipelineStore("load_structure", {
+      id: "ls1",
+      params: { fileName: "system.gro", hasTrajectory: true, hasCell: true },
+    });
+    render(
+      <LoadStructureNode {...nodeProps("ls1", seeded.data.params as LoadStructureParams)} />,
+    );
+    const trajectoryHandle = screen.getByTestId("handle-source-trajectory");
+    expect(trajectoryHandle.style.background).not.toBe("rgb(203, 213, 225)");
+  });
+});

--- a/tests/ts/components/nodes/NodeShell.test.tsx
+++ b/tests/ts/components/nodes/NodeShell.test.tsx
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { usePipelineStore } from "@/pipeline/store";
+import { NodeShell } from "@/components/nodes/NodeShell";
+import { NODE_TYPE_LABELS, NODE_PORTS, DATA_TYPE_COLORS } from "@/pipeline/types";
+import { seedPipelineStore } from "./_helpers";
+
+vi.mock("@xyflow/react", () => import("./_xyflowMock"));
+
+describe("NodeShell", () => {
+  beforeEach(() => {
+    cleanup();
+    seedPipelineStore("filter", { id: "n1" });
+  });
+
+  it("renders the human-readable title for the node type", () => {
+    render(
+      <NodeShell id="n1" nodeType="filter" enabled>
+        <div>body</div>
+      </NodeShell>,
+    );
+    expect(screen.getByText(NODE_TYPE_LABELS.filter)).toBeInTheDocument();
+  });
+
+  it("forwards children into the body", () => {
+    render(
+      <NodeShell id="n1" nodeType="filter" enabled>
+        <div data-testid="child-content">hello</div>
+      </NodeShell>,
+    );
+    expect(screen.getByTestId("child-content")).toHaveTextContent("hello");
+  });
+
+  it("sets data-testid, data-node-id, data-enabled attributes", () => {
+    render(
+      <NodeShell id="n1" nodeType="filter" enabled>
+        <div />
+      </NodeShell>,
+    );
+    const root = screen.getByTestId("pipeline-node-filter");
+    expect(root).toHaveAttribute("data-node-id", "n1");
+    expect(root).toHaveAttribute("data-enabled", "true");
+  });
+
+  it("reflects disabled state in data-enabled", () => {
+    render(
+      <NodeShell id="n1" nodeType="filter" enabled={false}>
+        <div />
+      </NodeShell>,
+    );
+    expect(screen.getByTestId("pipeline-node-filter")).toHaveAttribute("data-enabled", "false");
+  });
+
+  it("renders one Handle per input and output port from NODE_PORTS", () => {
+    seedPipelineStore("viewport", { id: "v1" });
+    render(
+      <NodeShell id="v1" nodeType="viewport" enabled>
+        <div />
+      </NodeShell>,
+    );
+    const ports = NODE_PORTS.viewport;
+    for (const port of ports.inputs) {
+      expect(screen.getByTestId(`handle-target-${port.name}`)).toBeInTheDocument();
+    }
+    expect(ports.outputs).toHaveLength(0);
+    expect(screen.queryAllByTestId(/^handle-source-/)).toHaveLength(0);
+  });
+
+  it("renders source/target handles correctly for filter (1 in, 1 out)", () => {
+    render(
+      <NodeShell id="n1" nodeType="filter" enabled>
+        <div />
+      </NodeShell>,
+    );
+    expect(screen.getByTestId("handle-target-in")).toBeInTheDocument();
+    expect(screen.getByTestId("handle-source-out")).toBeInTheDocument();
+  });
+
+  it("colors handles by their port dataType", () => {
+    render(
+      <NodeShell id="n1" nodeType="filter" enabled>
+        <div />
+      </NodeShell>,
+    );
+    const inHandle = screen.getByTestId("handle-target-in");
+    expect(inHandle.style.background).toBe(toRgb(DATA_TYPE_COLORS.particle));
+  });
+
+  it("grays out handles listed in disabledPorts", () => {
+    seedPipelineStore("load_structure", {
+      id: "ls1",
+      params: { fileName: null, hasTrajectory: false, hasCell: false },
+    });
+    render(
+      <NodeShell
+        id="ls1"
+        nodeType="load_structure"
+        enabled
+        disabledPorts={new Set(["trajectory", "cell"])}
+      >
+        <div />
+      </NodeShell>,
+    );
+    const trajectoryHandle = screen.getByTestId("handle-source-trajectory");
+    const particleHandle = screen.getByTestId("handle-source-particle");
+    expect(trajectoryHandle.style.background).toBe(toRgb("#cbd5e1"));
+    expect(particleHandle.style.background).toBe(toRgb(DATA_TYPE_COLORS.particle));
+  });
+
+  it("clicking the enable toggle invokes toggleNode(id)", () => {
+    const toggleNode = vi.fn();
+    usePipelineStore.setState({ toggleNode });
+    render(
+      <NodeShell id="n1" nodeType="filter" enabled>
+        <div />
+      </NodeShell>,
+    );
+    const toggle = screen.getByTitle("Disable node");
+    fireEvent.click(toggle);
+    expect(toggleNode).toHaveBeenCalledTimes(1);
+    expect(toggleNode).toHaveBeenCalledWith("n1");
+  });
+
+  it("toggle title flips between Disable and Enable based on enabled flag", () => {
+    const { rerender } = render(
+      <NodeShell id="n1" nodeType="filter" enabled>
+        <div />
+      </NodeShell>,
+    );
+    expect(screen.getByTitle("Disable node")).toBeInTheDocument();
+    rerender(
+      <NodeShell id="n1" nodeType="filter" enabled={false}>
+        <div />
+      </NodeShell>,
+    );
+    expect(screen.getByTitle("Enable node")).toBeInTheDocument();
+  });
+
+  it("renders a delete button that calls removeNode(id)", () => {
+    const removeNode = vi.fn();
+    usePipelineStore.setState({ removeNode });
+    render(
+      <NodeShell id="n1" nodeType="filter" enabled>
+        <div />
+      </NodeShell>,
+    );
+    const deleteBtn = screen.getByTitle("Remove node");
+    fireEvent.click(deleteBtn);
+    expect(removeNode).toHaveBeenCalledWith("n1");
+  });
+
+  it("hides the delete button for the viewport node type", () => {
+    seedPipelineStore("viewport", { id: "v1" });
+    render(
+      <NodeShell id="v1" nodeType="viewport" enabled>
+        <div />
+      </NodeShell>,
+    );
+    expect(screen.queryByTitle("Remove node")).toBeNull();
+  });
+
+  it("shows no error indicator when nodeErrors is empty", () => {
+    render(
+      <NodeShell id="n1" nodeType="filter" enabled>
+        <div />
+      </NodeShell>,
+    );
+    // The error indicator renders a literal "!" character; absence asserted by text.
+    expect(screen.queryByText("!")).toBeNull();
+  });
+
+  it("shows error indicator when an error is registered for this node id", () => {
+    seedPipelineStore("filter", {
+      id: "n1",
+      errors: [{ severity: "error", message: "Invalid query" }],
+    });
+    render(
+      <NodeShell id="n1" nodeType="filter" enabled>
+        <div />
+      </NodeShell>,
+    );
+    expect(screen.getByText("!")).toBeInTheDocument();
+  });
+
+  it("error indicator tooltip toggles on hover", () => {
+    seedPipelineStore("filter", {
+      id: "n1",
+      errors: [{ severity: "error", message: "Invalid query" }],
+    });
+    render(
+      <NodeShell id="n1" nodeType="filter" enabled>
+        <div />
+      </NodeShell>,
+    );
+    expect(screen.queryByText("Invalid query")).toBeNull();
+    const indicator = screen.getByText("!");
+    fireEvent.mouseEnter(indicator);
+    expect(screen.getByText("Invalid query")).toBeInTheDocument();
+    fireEvent.mouseLeave(indicator);
+    expect(screen.queryByText("Invalid query")).toBeNull();
+  });
+
+  it("error indicator uses warning color when only warnings are present", () => {
+    seedPipelineStore("filter", {
+      id: "n1",
+      errors: [{ severity: "warning", message: "Just a warning" }],
+    });
+    render(
+      <NodeShell id="n1" nodeType="filter" enabled>
+        <div />
+      </NodeShell>,
+    );
+    const indicator = screen.getByText("!");
+    // Amber #f59e0b → rgb(245, 158, 11)
+    expect(indicator.style.color).toBe("rgb(245, 158, 11)");
+  });
+
+  it("error indicator uses error color when any severity is error", () => {
+    seedPipelineStore("filter", {
+      id: "n1",
+      errors: [
+        { severity: "warning", message: "warn" },
+        { severity: "error", message: "boom" },
+      ],
+    });
+    render(
+      <NodeShell id="n1" nodeType="filter" enabled>
+        <div />
+      </NodeShell>,
+    );
+    const indicator = screen.getByText("!");
+    // Red #ef4444 → rgb(239, 68, 68)
+    expect(indicator.style.color).toBe("rgb(239, 68, 68)");
+  });
+});
+
+/**
+ * Convert a hex color (`#rrggbb`) to the `rgb(r, g, b)` form that browsers
+ * (and jsdom) emit for `style.background` reads.
+ */
+function toRgb(hex: string): string {
+  const n = parseInt(hex.slice(1), 16);
+  const r = (n >> 16) & 0xff;
+  const g = (n >> 8) & 0xff;
+  const b = n & 0xff;
+  return `rgb(${r}, ${g}, ${b})`;
+}

--- a/tests/ts/components/nodes/ViewportNode.test.tsx
+++ b/tests/ts/components/nodes/ViewportNode.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { usePipelineStore } from "@/pipeline/store";
+import { ViewportNode } from "@/components/nodes/ViewportNode";
+import type { ViewportParams } from "@/pipeline/types";
+import { seedPipelineStore } from "./_helpers";
+
+vi.mock("@xyflow/react", () => import("./_xyflowMock"));
+
+function nodeProps(id: string, params: ViewportParams, enabled = true) {
+  return {
+    id,
+    type: "viewport" as const,
+    data: { params, enabled },
+    selected: false,
+    isConnectable: true,
+    xPos: 0,
+    yPos: 0,
+    zIndex: 0,
+    dragging: false,
+    // xyflow's NodeProps has many optional fields; these are the ones our
+    // node component actually reads.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe("ViewportNode", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it("renders the three display toggles with checked state from params", () => {
+    const seeded = seedPipelineStore("viewport", {
+      id: "v1",
+      params: { perspective: true, cellAxesVisible: false, pivotMarkerVisible: true },
+    });
+    render(<ViewportNode {...nodeProps("v1", seeded.data.params as ViewportParams)} />);
+
+    const perspective = screen.getByLabelText("Perspective") as HTMLInputElement;
+    const cellAxes = screen.getByLabelText("Cell axes") as HTMLInputElement;
+    const pivotMarker = screen.getByLabelText("Pivot marker") as HTMLInputElement;
+
+    expect(perspective.checked).toBe(true);
+    expect(cellAxes.checked).toBe(false);
+    expect(pivotMarker.checked).toBe(true);
+  });
+
+  it("toggling Perspective calls updateNodeParams with the new value", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("viewport", { id: "v1" });
+    usePipelineStore.setState({ updateNodeParams });
+
+    render(<ViewportNode {...nodeProps("v1", seeded.data.params as ViewportParams)} />);
+    fireEvent.click(screen.getByLabelText("Perspective"));
+
+    expect(updateNodeParams).toHaveBeenCalledWith("v1", { perspective: true });
+  });
+
+  it("toggling Cell axes calls updateNodeParams with the new value", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("viewport", {
+      id: "v1",
+      params: { cellAxesVisible: true },
+    });
+    usePipelineStore.setState({ updateNodeParams });
+
+    render(<ViewportNode {...nodeProps("v1", seeded.data.params as ViewportParams)} />);
+    fireEvent.click(screen.getByLabelText("Cell axes"));
+
+    expect(updateNodeParams).toHaveBeenCalledWith("v1", { cellAxesVisible: false });
+  });
+
+  it("toggling Pivot marker calls updateNodeParams with the new value", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("viewport", {
+      id: "v1",
+      params: { pivotMarkerVisible: true },
+    });
+    usePipelineStore.setState({ updateNodeParams });
+
+    render(<ViewportNode {...nodeProps("v1", seeded.data.params as ViewportParams)} />);
+    fireEvent.click(screen.getByLabelText("Pivot marker"));
+
+    expect(updateNodeParams).toHaveBeenCalledWith("v1", { pivotMarkerVisible: false });
+  });
+
+  it("renders inside a NodeShell with the Viewport title and no delete button", () => {
+    const seeded = seedPipelineStore("viewport", { id: "v1" });
+    render(<ViewportNode {...nodeProps("v1", seeded.data.params as ViewportParams)} />);
+
+    expect(screen.getByText("Viewport")).toBeInTheDocument();
+    expect(screen.queryByTitle("Remove node")).toBeNull();
+  });
+});

--- a/tests/ts/components/nodes/_helpers.tsx
+++ b/tests/ts/components/nodes/_helpers.tsx
@@ -1,0 +1,44 @@
+import type { Node, Edge } from "@xyflow/react";
+import { usePipelineStore } from "@/pipeline/store";
+import type { PipelineNodeData } from "@/pipeline/execute";
+import type { PipelineNodeType, PipelineNodeParams, NodeError } from "@/pipeline/types";
+import { defaultParams } from "@/pipeline/types";
+
+/**
+ * Reset `usePipelineStore` to a known seed containing the supplied node.
+ *
+ * Bypasses the store's `deserialize()` action (which re-runs the pipeline
+ * `execute()` side effect) by writing state directly. Tests inspect or
+ * mutate the resulting `{ nodes, edges, nodeErrors }` after user
+ * interactions.
+ */
+export function seedPipelineStore<T extends PipelineNodeType>(
+  nodeType: T,
+  options: {
+    id?: string;
+    enabled?: boolean;
+    params?: Record<string, unknown>;
+    errors?: NodeError[];
+  } = {},
+): { id: string; data: PipelineNodeData } {
+  const id = options.id ?? `${nodeType}-1`;
+  const enabled = options.enabled ?? true;
+  const params = { ...defaultParams(nodeType), ...options.params } as PipelineNodeParams;
+
+  const node: Node<PipelineNodeData> = {
+    id,
+    type: nodeType,
+    position: { x: 0, y: 0 },
+    data: { params, enabled },
+  };
+
+  const edges: Edge[] = [];
+
+  usePipelineStore.setState({
+    nodes: [node],
+    edges,
+    nodeErrors: options.errors ? { [id]: options.errors } : {},
+  });
+
+  return { id, data: { params, enabled } };
+}

--- a/tests/ts/components/nodes/_xyflowMock.tsx
+++ b/tests/ts/components/nodes/_xyflowMock.tsx
@@ -1,0 +1,51 @@
+/**
+ * Stub module used by node component tests in place of `@xyflow/react`.
+ * The real package needs a `<ReactFlowProvider>` wrapper for `<Handle>` to
+ * resolve its internal store, which is overkill for unit tests that only
+ * care about handle props. The stubs below cover everything imported at
+ * runtime by `src/pipeline/store.ts`, `src/components/nodes/NodeShell.tsx`,
+ * and `src/pipeline/serialize.ts`.
+ *
+ * Wire it up per test file with:
+ *   vi.mock("@xyflow/react", () => import("./_xyflowMock"));
+ */
+
+export const Handle = (props: {
+  id?: string;
+  type?: string;
+  position?: string;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+}) => {
+  const { id, type, position, style, children } = props;
+  return (
+    <div
+      data-testid={`handle-${type}-${id}`}
+      data-handleid={id}
+      data-handletype={type}
+      data-handleposition={position}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+};
+
+export const Position = {
+  Top: "top",
+  Bottom: "bottom",
+  Left: "left",
+  Right: "right",
+} as const;
+
+export function applyNodeChanges<T>(_changes: unknown, nodes: T): T {
+  return nodes;
+}
+
+export function applyEdgeChanges<T>(_changes: unknown, edges: T): T {
+  return edges;
+}
+
+export function addEdge<T>(edge: T, edges: T[]): T[] {
+  return [...edges, edge];
+}


### PR DESCRIPTION
## Summary

Phase 5 part 1 of the test-coverage roadmap (`docs/plans/test-coverage-roadmap.md`).
The roadmap explicitly splits Phase 5 into two PRs: **NodeShell + 4 nodes** (this PR)
and the remaining 7 nodes (follow-up).

Adds **46 tests across 5 files** under a new `tests/ts/components/nodes/` directory:

- `NodeShell.test.tsx` (17 tests) — title, port handles via `NODE_PORTS`, enable
  toggle, delete button (hidden for `viewport`), error indicator with hover tooltip,
  `disabledPorts` graying.
- `ViewportNode.test.tsx` (5 tests) — three checkbox toggles wired through
  `updateNodeParams`.
- `LoadStructureNode.test.tsx` (9 tests) — file input, drag-and-drop, extension
  filtering, `setStructureLoadHandler` event-bus dispatch, `disabledPorts` derivation
  from `hasTrajectory` / `hasCell`.
- `AddBondNode.test.tsx` (7 tests) — `TabSelector` for `bondSource`, conditional
  `.top` upload UI, `parseTopBonds` dispatch with mocked parser.
- `FilterNode.test.tsx` (8 tests) — local-state input with blur/Enter commit,
  `validateQuery` / `validateBondQuery` error rendering, `useEffect` re-sync from
  external param changes.

### Approach

`@xyflow/react` is replaced per-test-file with a small stub module
(`tests/ts/components/nodes/_xyflowMock.tsx`) so that `<Handle>` renders a `<div>`
carrying handle metadata as `data-*` attributes — no `<ReactFlowProvider>` needed.
The stub also provides `applyNodeChanges` / `applyEdgeChanges` / `addEdge` so
`src/pipeline/store.ts` keeps loading. The store is reset per test via `setState`
rather than `deserialize()` to avoid the executor side effect.

### Scope

- **No production-code changes.** Only new files under `tests/ts/components/nodes/`.
- The remaining 7 node components (`LoadTrajectoryNode`, `LoadVectorNode`,
  `StreamingNode`, `ModifyNode`, `LabelGeneratorNode`, `PolyhedronGeneratorNode`,
  `VectorOverlayNode`) ship in a follow-up PR.
- The roadmap progress section will be updated to mark Phase 5 done only after the
  follow-up PR lands.

## Test plan

- [x] `npm run build:wasm` (CRITICAL RULE 3)
- [x] `npm test` — 569 passed (523 existing + 46 new), 0 failures
- [x] `npx vitest run tests/ts/components/nodes` — 46 passed in all 5 files
- [x] `npm run lint` — 0 errors (23 pre-existing warnings outside this PR's scope)
- [x] `npm run format:check` — clean
- [ ] CI green on this PR
- [ ] Codecov comment shows positive `typescript` flag delta

https://claude.ai/code/sessions


---
_Generated by [Claude Code](https://claude.ai/code/session_017zvr63LpVPHNM8RfgA7U3Z)_