### PR TITLE
test(nodes): add unit tests for the remaining 7 node components (Phase 5b)

### DIFF
--- a/docs/plans/test-coverage-roadmap.md
+++ b/docs/plans/test-coverage-roadmap.md
@@ -7,7 +7,8 @@
 - ✅ Phase 2 — `src/stream/` unit tests (2 files, 361 LOC): commit `61ada6e`
 - ✅ Phase 3 — `src/ai/` unit tests (4 files, 539 LOC) + `parseFrontmatter` export: commit `db0b679`
 - ✅ Phase 4 — `src/renderer/` pure helpers (Selection, Picking, CameraManager, shaders) — 4 files, 788 LOC, 69 tests
-- ⬜ Phase 5 — `src/components/nodes/` UI tests (split: NodeShell + 4, then remaining 8)
+- ✅ Phase 5a — `NodeShell` + 4 node components (commit `a9a0540`)
+- ✅ Phase 5b — remaining 7 node components (LabelGenerator, LoadTrajectory, LoadVector, Modify, PolyhedronGenerator, Streaming, VectorOverlay) — 7 files, 56 tests
 - ⬜ Phase 6 — `jupyterlab-megane/src/` (filetypes, wasmLoader, factory)
 - ⬜ Phase 7 — `vscode-megane/src/extension.ts` with vscode mock
 - ⬜ Phase 8 — codecov threshold tightening (`1% → 2%`) + `fail_ci_on_error: true`
@@ -140,16 +141,23 @@ main を取り込んだ直後のリポジトリでは、すでに以下が main 
 - **注意**: `three` の `WebGLRenderer` を import すると jsdom で死ぬため、テストは `Selection` / `Picking` / `CameraManager` を **個別 import** し、副作用 import を避ける
 - **規模**: M
 
-## Phase 5 — `src/components/nodes/` (xyflow ノード UI)
+## Phase 5 — `src/components/nodes/` (xyflow ノード UI) ✅ DONE
+
+**実施内容**: 2 PR に分割。`tests/ts/components/nodes/_xyflowMock.tsx` で `<Handle>` を `<div>` に差し替え (xyflow 内部 store 不要)、`tests/ts/components/nodes/_helpers.tsx` の `seedPipelineStore()` で `defaultParams()` ベースのノードを直接 `usePipelineStore.setState` に投入するスキャフォールドを共有。
+
+- **Phase 5a** (commit `a9a0540`, 5 ファイル / 46 tests): `NodeShell` (17), `LoadStructureNode` (9), `AddBondNode` (7), `FilterNode` (8), `ViewportNode` (5)。`setStructureLoadHandler(null)` で各テスト後に副作用クリーンアップ。`AddBondNode` は `parseTopBonds` を `vi.mock`、`FilterNode` は `validateQuery` / `validateBondQuery` を `vi.mock` してネットワーク・WASM 経路を回避
+- **Phase 5b** (本 PR, 7 ファイル / 56 tests): `LabelGeneratorNode` (5), `LoadTrajectoryNode` (9), `LoadVectorNode` (7), `ModifyNode` (7), `PolyhedronGeneratorNode` (14), `StreamingNode` (10), `VectorOverlayNode` (4)
+  - ファイルアップロード系 3 件 (`LoadTrajectory` / `LoadVector` / `LoadStructure` 同パターン): `Object.defineProperty(input, "files", { value: [file] })` → `fireEvent.change` で hidden `<input type="file">` をシム、`fireEvent.drop(dropZone, { dataTransfer: { files } })` で D&D 経路、サポート外拡張子・ハンドラ未設定・ハンドラ解除の 3 ガード、複数ファイルドロップ時の最初の一致選択を検証
+  - `ModifyNode` / `VectorOverlayNode`: スライダ `change` event での `parseFloat` 経路、`%` / 1-decimal フォーマット、`nodrag` クラス保持
+  - `PolyhedronGeneratorNode`: 12 中心 + 5 リガンド chip 列挙、選択トグルのセット差分 (`Set.add` / `Set.delete` → `[...set]` で配列再構築)、`showEdges=false` で edge color/width 非表示、`getAllByRole("slider")` の順序 (max distance → opacity → edge width) で個別検証、color picker 経路
+  - `StreamingNode`: `params.connected` から status 文言・色、`nodeStreamingData[id]` の snapshot / streamProvider から atom/bond/frame カウント文字列 (`"5 atoms, 4 bonds, 123 frames"`)、bond/trajectory/cell ハンドル disable ロジック (`hasBond` / `hasTrajectory` / `hasCell` ゲート)
+  - `LabelGeneratorNode`: `TabSelector<T>` の active/inactive 色 (`#3b82f6` vs `#94a3b8`)、active タブクリックの no-op ガード
 
 12 ファイル (合計 1,359 行)。`NodeShell.tsx` (308) と `PolyhedronGeneratorNode.tsx` (246) が大物。
 
-- **追加テスト** (`@testing-library/react` で props/render のスナップショット的検証):
-  - `tests/ts/components/nodes/NodeShell.test.tsx`: タイトル / ハンドル / 折りたたみトグル
-  - 各ノードタイプの最小レンダ (12 件 → 段階的に追加。最初は `LoadStructureNode`, `AddBondNode`, `FilterNode`, `ViewportNode` の 4 件)
 - **既存契約参照**: `src/pipeline/types.ts` の各 `*Params` 型 (props バリデーション)
 - **既存パターン**: `tests/ts/components/Tooltip.test.tsx` を参照
-- **規模**: M (UI が多いので分割 PR 推奨: `NodeShell + 4 件` → `残り 8 件` の 2 PR)
+- **規模**: M (2 PR 分割で実施)
 
 ## Phase 6 — `jupyterlab-megane/src/` (小ファイル中心)
 
@@ -190,7 +198,7 @@ Phase 0 (codecov flag fix)        ✅ DONE (c17462a)
    └─ Phase 3 (ai)                ✅ DONE (db0b679)
         │
         ├─ Phase 4 (renderer pure helpers)   ✅ DONE
-        └─ Phase 5 (nodes UI)                 ⬜ TODO  ← 2 PR に分割
+        └─ Phase 5 (nodes UI)                 ✅ DONE (2 PR: 5a + 5b)
              │
              ├─ Phase 6 (jupyterlab small files)  ⬜ TODO
              └─ Phase 7 (vscode extension)        ⬜ TODO

--- a/tests/ts/components/nodes/LabelGeneratorNode.test.tsx
+++ b/tests/ts/components/nodes/LabelGeneratorNode.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { usePipelineStore } from "@/pipeline/store";
+import { LabelGeneratorNode } from "@/components/nodes/LabelGeneratorNode";
+import type { LabelGeneratorParams } from "@/pipeline/types";
+import { seedPipelineStore } from "./_helpers";
+
+vi.mock("@xyflow/react", () => import("./_xyflowMock"));
+
+function nodeProps(id: string, params: LabelGeneratorParams, enabled = true) {
+  return {
+    id,
+    type: "label_generator" as const,
+    data: { params, enabled },
+    selected: false,
+    isConnectable: true,
+    xPos: 0,
+    yPos: 0,
+    zIndex: 0,
+    dragging: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe("LabelGeneratorNode", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it("renders the three source tabs: Element, Resname, Index", () => {
+    const seeded = seedPipelineStore("label_generator", { id: "lg1" });
+    render(
+      <LabelGeneratorNode {...nodeProps("lg1", seeded.data.params as LabelGeneratorParams)} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Element" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Resname" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Index" })).toBeInTheDocument();
+  });
+
+  it("renders inside a NodeShell with the Labels title", () => {
+    const seeded = seedPipelineStore("label_generator", { id: "lg1" });
+    render(
+      <LabelGeneratorNode {...nodeProps("lg1", seeded.data.params as LabelGeneratorParams)} />,
+    );
+    expect(screen.getByText("Labels")).toBeInTheDocument();
+  });
+
+  it("clicking a non-active tab dispatches updateNodeParams with the new source", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("label_generator", {
+      id: "lg1",
+      params: { source: "element" },
+    });
+    usePipelineStore.setState({ updateNodeParams });
+    render(
+      <LabelGeneratorNode {...nodeProps("lg1", seeded.data.params as LabelGeneratorParams)} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Resname" }));
+    expect(updateNodeParams).toHaveBeenCalledWith("lg1", { source: "resname" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Index" }));
+    expect(updateNodeParams).toHaveBeenCalledWith("lg1", { source: "index" });
+  });
+
+  it("clicking the already-active tab is a no-op", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("label_generator", {
+      id: "lg1",
+      params: { source: "element" },
+    });
+    usePipelineStore.setState({ updateNodeParams });
+    render(
+      <LabelGeneratorNode {...nodeProps("lg1", seeded.data.params as LabelGeneratorParams)} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Element" }));
+    expect(updateNodeParams).not.toHaveBeenCalled();
+  });
+
+  it("uses the active-tab color for the currently-selected source", () => {
+    const seeded = seedPipelineStore("label_generator", {
+      id: "lg1",
+      params: { source: "resname" },
+    });
+    render(
+      <LabelGeneratorNode {...nodeProps("lg1", seeded.data.params as LabelGeneratorParams)} />,
+    );
+
+    const active = screen.getByRole("button", { name: "Resname" });
+    const inactive = screen.getByRole("button", { name: "Element" });
+    // Active tab uses the project's blue (#3b82f6 → rgb(59, 130, 246))
+    expect(active.style.color).toBe("rgb(59, 130, 246)");
+    // Inactive tab uses slate-400 (#94a3b8 → rgb(148, 163, 184))
+    expect(inactive.style.color).toBe("rgb(148, 163, 184)");
+  });
+});

--- a/tests/ts/components/nodes/LoadTrajectoryNode.test.tsx
+++ b/tests/ts/components/nodes/LoadTrajectoryNode.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { usePipelineStore } from "@/pipeline/store";
+import {
+  LoadTrajectoryNode,
+  setTrajectoryLoadHandler,
+} from "@/components/nodes/LoadTrajectoryNode";
+import type { LoadTrajectoryParams } from "@/pipeline/types";
+import { seedPipelineStore } from "./_helpers";
+
+vi.mock("@xyflow/react", () => import("./_xyflowMock"));
+
+function nodeProps(id: string, params: LoadTrajectoryParams, enabled = true) {
+  return {
+    id,
+    type: "load_trajectory" as const,
+    data: { params, enabled },
+    selected: false,
+    isConnectable: true,
+    xPos: 0,
+    yPos: 0,
+    zIndex: 0,
+    dragging: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+function fireFileInputChange(input: HTMLInputElement, files: File[]) {
+  Object.defineProperty(input, "files", {
+    value: files,
+    writable: false,
+    configurable: true,
+  });
+  fireEvent.change(input);
+}
+
+describe("LoadTrajectoryNode", () => {
+  beforeEach(() => {
+    cleanup();
+    setTrajectoryLoadHandler(null);
+  });
+
+  afterEach(() => {
+    setTrajectoryLoadHandler(null);
+  });
+
+  it("renders the placeholder when fileName is null", () => {
+    const seeded = seedPipelineStore("load_trajectory", { id: "lt1" });
+    render(
+      <LoadTrajectoryNode {...nodeProps("lt1", seeded.data.params as LoadTrajectoryParams)} />,
+    );
+
+    expect(screen.getByTestId("load-trajectory-filename")).toHaveTextContent(
+      "No trajectory loaded",
+    );
+  });
+
+  it("renders the filename when params.fileName is set", () => {
+    const seeded = seedPipelineStore("load_trajectory", {
+      id: "lt1",
+      params: { fileName: "traj.xtc" },
+    });
+    render(
+      <LoadTrajectoryNode {...nodeProps("lt1", seeded.data.params as LoadTrajectoryParams)} />,
+    );
+
+    expect(screen.getByTestId("load-trajectory-filename")).toHaveTextContent("traj.xtc");
+  });
+
+  it("file input change with .xtc updates params and fires the load handler", () => {
+    const updateNodeParams = vi.fn();
+    const handler = vi.fn();
+    const seeded = seedPipelineStore("load_trajectory", { id: "lt1" });
+    usePipelineStore.setState({ updateNodeParams });
+    setTrajectoryLoadHandler(handler);
+
+    render(
+      <LoadTrajectoryNode {...nodeProps("lt1", seeded.data.params as LoadTrajectoryParams)} />,
+    );
+
+    const file = new File(["dummy"], "traj.xtc", { type: "application/octet-stream" });
+    const input = screen
+      .getByText("Load trajectory...")
+      .parentElement!.querySelector('input[type="file"]') as HTMLInputElement;
+    fireFileInputChange(input, [file]);
+
+    expect(updateNodeParams).toHaveBeenCalledWith("lt1", { fileName: "traj.xtc" });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(file);
+  });
+
+  it("file input change with .lammpstrj is accepted", () => {
+    const updateNodeParams = vi.fn();
+    const handler = vi.fn();
+    const seeded = seedPipelineStore("load_trajectory", { id: "lt1" });
+    usePipelineStore.setState({ updateNodeParams });
+    setTrajectoryLoadHandler(handler);
+
+    render(
+      <LoadTrajectoryNode {...nodeProps("lt1", seeded.data.params as LoadTrajectoryParams)} />,
+    );
+
+    const file = new File(["dummy"], "run.lammpstrj", { type: "text/plain" });
+    const input = screen
+      .getByText("Load trajectory...")
+      .parentElement!.querySelector('input[type="file"]') as HTMLInputElement;
+    fireFileInputChange(input, [file]);
+
+    expect(updateNodeParams).toHaveBeenCalledWith("lt1", { fileName: "run.lammpstrj" });
+    expect(handler).toHaveBeenCalledWith(file);
+  });
+
+  it("file input change with an unsupported extension is a no-op", () => {
+    const updateNodeParams = vi.fn();
+    const handler = vi.fn();
+    const seeded = seedPipelineStore("load_trajectory", { id: "lt1" });
+    usePipelineStore.setState({ updateNodeParams });
+    setTrajectoryLoadHandler(handler);
+
+    render(
+      <LoadTrajectoryNode {...nodeProps("lt1", seeded.data.params as LoadTrajectoryParams)} />,
+    );
+
+    const file = new File(["junk"], "garbage.bad", { type: "text/plain" });
+    const input = screen
+      .getByText("Load trajectory...")
+      .parentElement!.querySelector('input[type="file"]') as HTMLInputElement;
+    fireFileInputChange(input, [file]);
+
+    expect(updateNodeParams).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("clearing the load handler with setTrajectoryLoadHandler(null) prevents subsequent dispatch", () => {
+    const updateNodeParams = vi.fn();
+    const handler = vi.fn();
+    const seeded = seedPipelineStore("load_trajectory", { id: "lt1" });
+    usePipelineStore.setState({ updateNodeParams });
+
+    setTrajectoryLoadHandler(handler);
+    setTrajectoryLoadHandler(null);
+
+    render(
+      <LoadTrajectoryNode {...nodeProps("lt1", seeded.data.params as LoadTrajectoryParams)} />,
+    );
+
+    const file = new File(["dummy"], "traj.xtc", { type: "application/octet-stream" });
+    const input = screen
+      .getByText("Load trajectory...")
+      .parentElement!.querySelector('input[type="file"]') as HTMLInputElement;
+    fireFileInputChange(input, [file]);
+
+    expect(updateNodeParams).toHaveBeenCalledWith("lt1", { fileName: "traj.xtc" });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("drag-and-drop of a supported file calls updateNodeParams and the load handler", () => {
+    const updateNodeParams = vi.fn();
+    const handler = vi.fn();
+    const seeded = seedPipelineStore("load_trajectory", { id: "lt1" });
+    usePipelineStore.setState({ updateNodeParams });
+    setTrajectoryLoadHandler(handler);
+
+    render(
+      <LoadTrajectoryNode {...nodeProps("lt1", seeded.data.params as LoadTrajectoryParams)} />,
+    );
+
+    const file = new File(["dummy"], "run.dump", { type: "text/plain" });
+    const dropZone = screen.getByTestId("load-trajectory-filename").parentElement!;
+    fireEvent.drop(dropZone, { dataTransfer: { files: [file] } });
+
+    expect(updateNodeParams).toHaveBeenCalledWith("lt1", { fileName: "run.dump" });
+    expect(handler).toHaveBeenCalledWith(file);
+  });
+
+  it("drag-and-drop ignores files with unsupported extensions", () => {
+    const updateNodeParams = vi.fn();
+    const handler = vi.fn();
+    const seeded = seedPipelineStore("load_trajectory", { id: "lt1" });
+    usePipelineStore.setState({ updateNodeParams });
+    setTrajectoryLoadHandler(handler);
+
+    render(
+      <LoadTrajectoryNode {...nodeProps("lt1", seeded.data.params as LoadTrajectoryParams)} />,
+    );
+
+    const file = new File(["junk"], "readme.txt", { type: "text/plain" });
+    const dropZone = screen.getByTestId("load-trajectory-filename").parentElement!;
+    fireEvent.drop(dropZone, { dataTransfer: { files: [file] } });
+
+    expect(updateNodeParams).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("drag-and-drop picks the first matching file when multiple are dropped", () => {
+    const updateNodeParams = vi.fn();
+    const handler = vi.fn();
+    const seeded = seedPipelineStore("load_trajectory", { id: "lt1" });
+    usePipelineStore.setState({ updateNodeParams });
+    setTrajectoryLoadHandler(handler);
+
+    render(
+      <LoadTrajectoryNode {...nodeProps("lt1", seeded.data.params as LoadTrajectoryParams)} />,
+    );
+
+    const junk = new File(["x"], "ignored.txt", { type: "text/plain" });
+    const traj = new File(["x"], "good.xtc", { type: "application/octet-stream" });
+    const dropZone = screen.getByTestId("load-trajectory-filename").parentElement!;
+    fireEvent.drop(dropZone, { dataTransfer: { files: [junk, traj] } });
+
+    expect(updateNodeParams).toHaveBeenCalledWith("lt1", { fileName: "good.xtc" });
+    expect(handler).toHaveBeenCalledWith(traj);
+  });
+});

--- a/tests/ts/components/nodes/LoadVectorNode.test.tsx
+++ b/tests/ts/components/nodes/LoadVectorNode.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { usePipelineStore } from "@/pipeline/store";
+import { LoadVectorNode, setVectorLoadHandler } from "@/components/nodes/LoadVectorNode";
+import type { LoadVectorParams } from "@/pipeline/types";
+import { seedPipelineStore } from "./_helpers";
+
+vi.mock("@xyflow/react", () => import("./_xyflowMock"));
+
+function nodeProps(id: string, params: LoadVectorParams, enabled = true) {
+  return {
+    id,
+    type: "load_vector" as const,
+    data: { params, enabled },
+    selected: false,
+    isConnectable: true,
+    xPos: 0,
+    yPos: 0,
+    zIndex: 0,
+    dragging: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+function fireFileInputChange(input: HTMLInputElement, files: File[]) {
+  Object.defineProperty(input, "files", {
+    value: files,
+    writable: false,
+    configurable: true,
+  });
+  fireEvent.change(input);
+}
+
+describe("LoadVectorNode", () => {
+  beforeEach(() => {
+    cleanup();
+    setVectorLoadHandler(null);
+  });
+
+  afterEach(() => {
+    setVectorLoadHandler(null);
+  });
+
+  it("renders the placeholder when fileName is null", () => {
+    const seeded = seedPipelineStore("load_vector", { id: "lv1" });
+    render(<LoadVectorNode {...nodeProps("lv1", seeded.data.params as LoadVectorParams)} />);
+    expect(screen.getByText("No vector file loaded")).toBeInTheDocument();
+  });
+
+  it("renders the filename when params.fileName is set", () => {
+    const seeded = seedPipelineStore("load_vector", {
+      id: "lv1",
+      params: { fileName: "forces.vec" },
+    });
+    render(<LoadVectorNode {...nodeProps("lv1", seeded.data.params as LoadVectorParams)} />);
+    expect(screen.getByText("forces.vec")).toBeInTheDocument();
+    expect(screen.queryByText("No vector file loaded")).toBeNull();
+  });
+
+  it("file input change with .vec updates params and fires the load handler", () => {
+    const updateNodeParams = vi.fn();
+    const handler = vi.fn();
+    const seeded = seedPipelineStore("load_vector", { id: "lv1" });
+    usePipelineStore.setState({ updateNodeParams });
+    setVectorLoadHandler(handler);
+
+    render(<LoadVectorNode {...nodeProps("lv1", seeded.data.params as LoadVectorParams)} />);
+
+    const file = new File(["dummy"], "forces.vec", { type: "application/octet-stream" });
+    const input = screen
+      .getByText("Load vectors...")
+      .parentElement!.querySelector('input[type="file"]') as HTMLInputElement;
+    fireFileInputChange(input, [file]);
+
+    expect(updateNodeParams).toHaveBeenCalledWith("lv1", { fileName: "forces.vec" });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(file);
+  });
+
+  it("file input change with an unsupported extension is a no-op", () => {
+    const updateNodeParams = vi.fn();
+    const handler = vi.fn();
+    const seeded = seedPipelineStore("load_vector", { id: "lv1" });
+    usePipelineStore.setState({ updateNodeParams });
+    setVectorLoadHandler(handler);
+
+    render(<LoadVectorNode {...nodeProps("lv1", seeded.data.params as LoadVectorParams)} />);
+
+    const file = new File(["junk"], "garbage.json", { type: "application/json" });
+    const input = screen
+      .getByText("Load vectors...")
+      .parentElement!.querySelector('input[type="file"]') as HTMLInputElement;
+    fireFileInputChange(input, [file]);
+
+    expect(updateNodeParams).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("clearing the load handler with setVectorLoadHandler(null) prevents subsequent dispatch", () => {
+    const updateNodeParams = vi.fn();
+    const handler = vi.fn();
+    const seeded = seedPipelineStore("load_vector", { id: "lv1" });
+    usePipelineStore.setState({ updateNodeParams });
+
+    setVectorLoadHandler(handler);
+    setVectorLoadHandler(null);
+
+    render(<LoadVectorNode {...nodeProps("lv1", seeded.data.params as LoadVectorParams)} />);
+
+    const file = new File(["dummy"], "v.vec", { type: "application/octet-stream" });
+    const input = screen
+      .getByText("Load vectors...")
+      .parentElement!.querySelector('input[type="file"]') as HTMLInputElement;
+    fireFileInputChange(input, [file]);
+
+    expect(updateNodeParams).toHaveBeenCalledWith("lv1", { fileName: "v.vec" });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("drag-and-drop of a supported file calls updateNodeParams and the load handler", () => {
+    const updateNodeParams = vi.fn();
+    const handler = vi.fn();
+    const seeded = seedPipelineStore("load_vector", { id: "lv1" });
+    usePipelineStore.setState({ updateNodeParams });
+    setVectorLoadHandler(handler);
+
+    render(<LoadVectorNode {...nodeProps("lv1", seeded.data.params as LoadVectorParams)} />);
+
+    const file = new File(["dummy"], "fields.vec", { type: "application/octet-stream" });
+    // Drop target is the wrapper that owns the file input — first ascendant
+    // of the placeholder/filename text.
+    const dropZone = screen.getByText("No vector file loaded").parentElement!;
+    fireEvent.drop(dropZone, { dataTransfer: { files: [file] } });
+
+    expect(updateNodeParams).toHaveBeenCalledWith("lv1", { fileName: "fields.vec" });
+    expect(handler).toHaveBeenCalledWith(file);
+  });
+
+  it("drag-and-drop ignores files with unsupported extensions", () => {
+    const updateNodeParams = vi.fn();
+    const handler = vi.fn();
+    const seeded = seedPipelineStore("load_vector", { id: "lv1" });
+    usePipelineStore.setState({ updateNodeParams });
+    setVectorLoadHandler(handler);
+
+    render(<LoadVectorNode {...nodeProps("lv1", seeded.data.params as LoadVectorParams)} />);
+
+    const file = new File(["junk"], "readme.txt", { type: "text/plain" });
+    const dropZone = screen.getByText("No vector file loaded").parentElement!;
+    fireEvent.drop(dropZone, { dataTransfer: { files: [file] } });
+
+    expect(updateNodeParams).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ts/components/nodes/ModifyNode.test.tsx
+++ b/tests/ts/components/nodes/ModifyNode.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { usePipelineStore } from "@/pipeline/store";
+import { ModifyNode } from "@/components/nodes/ModifyNode";
+import type { ModifyParams } from "@/pipeline/types";
+import { seedPipelineStore } from "./_helpers";
+
+vi.mock("@xyflow/react", () => import("./_xyflowMock"));
+
+function nodeProps(id: string, params: ModifyParams, enabled = true) {
+  return {
+    id,
+    type: "modify" as const,
+    data: { params, enabled },
+    selected: false,
+    isConnectable: true,
+    xPos: 0,
+    yPos: 0,
+    zIndex: 0,
+    dragging: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe("ModifyNode", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it("renders the scale and opacity sliders with values from params", () => {
+    const seeded = seedPipelineStore("modify", {
+      id: "m1",
+      params: { scale: 1.25, opacity: 0.4 },
+    });
+    render(<ModifyNode {...nodeProps("m1", seeded.data.params as ModifyParams)} />);
+
+    const scale = screen.getByTestId("modify-node-scale") as HTMLInputElement;
+    const opacity = screen.getByTestId("modify-node-opacity") as HTMLInputElement;
+
+    expect(scale.value).toBe("1.25");
+    expect(opacity.value).toBe("0.4");
+  });
+
+  it("formats the scale value to two decimals", () => {
+    const seeded = seedPipelineStore("modify", {
+      id: "m1",
+      params: { scale: 1, opacity: 1 },
+    });
+    render(<ModifyNode {...nodeProps("m1", seeded.data.params as ModifyParams)} />);
+    expect(screen.getByText("1.00")).toBeInTheDocument();
+  });
+
+  it("formats the opacity value as a rounded percentage", () => {
+    const seeded = seedPipelineStore("modify", {
+      id: "m1",
+      params: { scale: 1, opacity: 0.337 },
+    });
+    render(<ModifyNode {...nodeProps("m1", seeded.data.params as ModifyParams)} />);
+    // 0.337 * 100 = 33.7 → Math.round → 34
+    expect(screen.getByText("34%")).toBeInTheDocument();
+  });
+
+  it("changing the scale slider dispatches updateNodeParams with parsed float", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("modify", { id: "m1" });
+    usePipelineStore.setState({ updateNodeParams });
+    render(<ModifyNode {...nodeProps("m1", seeded.data.params as ModifyParams)} />);
+
+    const scale = screen.getByTestId("modify-node-scale");
+    fireEvent.change(scale, { target: { value: "1.5" } });
+
+    expect(updateNodeParams).toHaveBeenCalledWith("m1", { scale: 1.5 });
+  });
+
+  it("changing the opacity slider dispatches updateNodeParams with parsed float", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("modify", { id: "m1" });
+    usePipelineStore.setState({ updateNodeParams });
+    render(<ModifyNode {...nodeProps("m1", seeded.data.params as ModifyParams)} />);
+
+    const opacity = screen.getByTestId("modify-node-opacity");
+    fireEvent.change(opacity, { target: { value: "0.25" } });
+
+    expect(updateNodeParams).toHaveBeenCalledWith("m1", { opacity: 0.25 });
+  });
+
+  it("renders inside a NodeShell with the Modify title", () => {
+    const seeded = seedPipelineStore("modify", { id: "m1" });
+    render(<ModifyNode {...nodeProps("m1", seeded.data.params as ModifyParams)} />);
+    expect(screen.getByText("Modify")).toBeInTheDocument();
+  });
+
+  it("sliders carry the 'nodrag' class so xyflow does not start a node drag", () => {
+    const seeded = seedPipelineStore("modify", { id: "m1" });
+    render(<ModifyNode {...nodeProps("m1", seeded.data.params as ModifyParams)} />);
+    expect(screen.getByTestId("modify-node-scale").className).toContain("nodrag");
+    expect(screen.getByTestId("modify-node-opacity").className).toContain("nodrag");
+  });
+});

--- a/tests/ts/components/nodes/PolyhedronGeneratorNode.test.tsx
+++ b/tests/ts/components/nodes/PolyhedronGeneratorNode.test.tsx
@@ -1,0 +1,336 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { usePipelineStore } from "@/pipeline/store";
+import { PolyhedronGeneratorNode } from "@/components/nodes/PolyhedronGeneratorNode";
+import type { PolyhedronGeneratorParams } from "@/pipeline/types";
+import { seedPipelineStore } from "./_helpers";
+
+vi.mock("@xyflow/react", () => import("./_xyflowMock"));
+
+function nodeProps(id: string, params: PolyhedronGeneratorParams, enabled = true) {
+  return {
+    id,
+    type: "polyhedron_generator" as const,
+    data: { params, enabled },
+    selected: false,
+    isConnectable: true,
+    xPos: 0,
+    yPos: 0,
+    zIndex: 0,
+    dragging: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+const ACTIVE_COLOR = "rgb(59, 130, 246)";
+const INACTIVE_COLOR = "rgb(148, 163, 184)";
+
+describe("PolyhedronGeneratorNode", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it("renders the Polyhedra title", () => {
+    const seeded = seedPipelineStore("polyhedron_generator", { id: "pg1" });
+    render(
+      <PolyhedronGeneratorNode
+        {...nodeProps("pg1", seeded.data.params as PolyhedronGeneratorParams)}
+      />,
+    );
+    expect(screen.getByText("Polyhedra")).toBeInTheDocument();
+  });
+
+  it("renders all 12 center element chips", () => {
+    const seeded = seedPipelineStore("polyhedron_generator", { id: "pg1" });
+    render(
+      <PolyhedronGeneratorNode
+        {...nodeProps("pg1", seeded.data.params as PolyhedronGeneratorParams)}
+      />,
+    );
+
+    for (const sym of ["Si", "Al", "Ti", "Fe", "Zr", "Mn", "Co", "Ni", "Cr", "Zn", "Mg", "Ca"]) {
+      expect(screen.getByRole("button", { name: sym })).toBeInTheDocument();
+    }
+  });
+
+  it("renders all 5 ligand element chips", () => {
+    const seeded = seedPipelineStore("polyhedron_generator", { id: "pg1" });
+    render(
+      <PolyhedronGeneratorNode
+        {...nodeProps("pg1", seeded.data.params as PolyhedronGeneratorParams)}
+      />,
+    );
+
+    for (const sym of ["O", "F", "Cl", "N", "S"]) {
+      expect(screen.getByRole("button", { name: sym })).toBeInTheDocument();
+    }
+  });
+
+  it("highlights chips whose atomic number is in the selected list", () => {
+    const seeded = seedPipelineStore("polyhedron_generator", {
+      id: "pg1",
+      params: {
+        centerElements: [14], // Si
+        ligandElements: [8], // O
+        maxDistance: 2.5,
+        opacity: 0.5,
+        showEdges: false,
+        edgeColor: "#dddddd",
+        edgeWidth: 3,
+      },
+    });
+    render(
+      <PolyhedronGeneratorNode
+        {...nodeProps("pg1", seeded.data.params as PolyhedronGeneratorParams)}
+      />,
+    );
+
+    expect((screen.getByRole("button", { name: "Si" }) as HTMLElement).style.color).toBe(
+      ACTIVE_COLOR,
+    );
+    expect((screen.getByRole("button", { name: "Al" }) as HTMLElement).style.color).toBe(
+      INACTIVE_COLOR,
+    );
+    expect((screen.getByRole("button", { name: "O" }) as HTMLElement).style.color).toBe(
+      ACTIVE_COLOR,
+    );
+    expect((screen.getByRole("button", { name: "F" }) as HTMLElement).style.color).toBe(
+      INACTIVE_COLOR,
+    );
+  });
+
+  it("clicking an unselected center chip adds its atomic number", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("polyhedron_generator", {
+      id: "pg1",
+      params: {
+        centerElements: [],
+        ligandElements: [8],
+        maxDistance: 2.5,
+        opacity: 0.5,
+        showEdges: false,
+        edgeColor: "#dddddd",
+        edgeWidth: 3,
+      },
+    });
+    usePipelineStore.setState({ updateNodeParams });
+    render(
+      <PolyhedronGeneratorNode
+        {...nodeProps("pg1", seeded.data.params as PolyhedronGeneratorParams)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Si" }));
+    expect(updateNodeParams).toHaveBeenCalledWith("pg1", { centerElements: [14] });
+  });
+
+  it("clicking a selected center chip removes it", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("polyhedron_generator", {
+      id: "pg1",
+      params: {
+        centerElements: [14, 22],
+        ligandElements: [8],
+        maxDistance: 2.5,
+        opacity: 0.5,
+        showEdges: false,
+        edgeColor: "#dddddd",
+        edgeWidth: 3,
+      },
+    });
+    usePipelineStore.setState({ updateNodeParams });
+    render(
+      <PolyhedronGeneratorNode
+        {...nodeProps("pg1", seeded.data.params as PolyhedronGeneratorParams)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Ti" }));
+    expect(updateNodeParams).toHaveBeenCalledWith("pg1", { centerElements: [14] });
+  });
+
+  it("clicking ligand chips updates the ligand list", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("polyhedron_generator", {
+      id: "pg1",
+      params: {
+        centerElements: [14],
+        ligandElements: [8],
+        maxDistance: 2.5,
+        opacity: 0.5,
+        showEdges: false,
+        edgeColor: "#dddddd",
+        edgeWidth: 3,
+      },
+    });
+    usePipelineStore.setState({ updateNodeParams });
+    render(
+      <PolyhedronGeneratorNode
+        {...nodeProps("pg1", seeded.data.params as PolyhedronGeneratorParams)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "F" }));
+    expect(updateNodeParams).toHaveBeenCalledWith("pg1", { ligandElements: [8, 9] });
+  });
+
+  it("max distance slider commits a parsed float", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("polyhedron_generator", { id: "pg1" });
+    usePipelineStore.setState({ updateNodeParams });
+    render(
+      <PolyhedronGeneratorNode
+        {...nodeProps("pg1", seeded.data.params as PolyhedronGeneratorParams)}
+      />,
+    );
+
+    const sliders = screen.getAllByRole("slider") as HTMLInputElement[];
+    // Order: max distance, opacity (edge width slider only renders when showEdges=true).
+    fireEvent.change(sliders[0], { target: { value: "3.5" } });
+    expect(updateNodeParams).toHaveBeenCalledWith("pg1", { maxDistance: 3.5 });
+  });
+
+  it("opacity slider commits a parsed float and shows percentage", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("polyhedron_generator", {
+      id: "pg1",
+      params: {
+        centerElements: [],
+        ligandElements: [8],
+        maxDistance: 2.5,
+        opacity: 0.4,
+        showEdges: false,
+        edgeColor: "#dddddd",
+        edgeWidth: 3,
+      },
+    });
+    usePipelineStore.setState({ updateNodeParams });
+    render(
+      <PolyhedronGeneratorNode
+        {...nodeProps("pg1", seeded.data.params as PolyhedronGeneratorParams)}
+      />,
+    );
+
+    expect(screen.getByText("40%")).toBeInTheDocument();
+    const sliders = screen.getAllByRole("slider") as HTMLInputElement[];
+    fireEvent.change(sliders[1], { target: { value: "0.75" } });
+    expect(updateNodeParams).toHaveBeenCalledWith("pg1", { opacity: 0.75 });
+  });
+
+  it("toggling Show edges flips the showEdges param", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("polyhedron_generator", { id: "pg1" });
+    usePipelineStore.setState({ updateNodeParams });
+    render(
+      <PolyhedronGeneratorNode
+        {...nodeProps("pg1", seeded.data.params as PolyhedronGeneratorParams)}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText(/Show edges/));
+    expect(updateNodeParams).toHaveBeenCalledWith("pg1", { showEdges: true });
+  });
+
+  it("hides the edge color and edge width controls when showEdges is false", () => {
+    const seeded = seedPipelineStore("polyhedron_generator", {
+      id: "pg1",
+      params: {
+        centerElements: [],
+        ligandElements: [8],
+        maxDistance: 2.5,
+        opacity: 0.5,
+        showEdges: false,
+        edgeColor: "#dddddd",
+        edgeWidth: 3,
+      },
+    });
+    render(
+      <PolyhedronGeneratorNode
+        {...nodeProps("pg1", seeded.data.params as PolyhedronGeneratorParams)}
+      />,
+    );
+
+    expect(screen.queryByText("Edge color")).toBeNull();
+    expect(screen.queryByText("Edge width")).toBeNull();
+  });
+
+  it("shows the edge color picker and edge width slider when showEdges is true", () => {
+    const seeded = seedPipelineStore("polyhedron_generator", {
+      id: "pg1",
+      params: {
+        centerElements: [],
+        ligandElements: [8],
+        maxDistance: 2.5,
+        opacity: 0.5,
+        showEdges: true,
+        edgeColor: "#abcdef",
+        edgeWidth: 4,
+      },
+    });
+    render(
+      <PolyhedronGeneratorNode
+        {...nodeProps("pg1", seeded.data.params as PolyhedronGeneratorParams)}
+      />,
+    );
+
+    expect(screen.getByText("Edge color")).toBeInTheDocument();
+    expect(screen.getByText("Edge width")).toBeInTheDocument();
+    expect(screen.getByText("4.0")).toBeInTheDocument();
+  });
+
+  it("changing the edge color input dispatches updateNodeParams with the new color", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("polyhedron_generator", {
+      id: "pg1",
+      params: {
+        centerElements: [],
+        ligandElements: [8],
+        maxDistance: 2.5,
+        opacity: 0.5,
+        showEdges: true,
+        edgeColor: "#dddddd",
+        edgeWidth: 3,
+      },
+    });
+    usePipelineStore.setState({ updateNodeParams });
+    render(
+      <PolyhedronGeneratorNode
+        {...nodeProps("pg1", seeded.data.params as PolyhedronGeneratorParams)}
+      />,
+    );
+
+    const colorInput = screen
+      .getByText("Edge color")
+      .parentElement!.querySelector('input[type="color"]') as HTMLInputElement;
+    fireEvent.change(colorInput, { target: { value: "#abcdef" } });
+
+    expect(updateNodeParams).toHaveBeenCalledWith("pg1", { edgeColor: "#abcdef" });
+  });
+
+  it("changing the edge width slider dispatches a parsed float", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("polyhedron_generator", {
+      id: "pg1",
+      params: {
+        centerElements: [],
+        ligandElements: [8],
+        maxDistance: 2.5,
+        opacity: 0.5,
+        showEdges: true,
+        edgeColor: "#dddddd",
+        edgeWidth: 3,
+      },
+    });
+    usePipelineStore.setState({ updateNodeParams });
+    render(
+      <PolyhedronGeneratorNode
+        {...nodeProps("pg1", seeded.data.params as PolyhedronGeneratorParams)}
+      />,
+    );
+
+    // Sliders in order: max distance, opacity, edge width
+    const sliders = screen.getAllByRole("slider") as HTMLInputElement[];
+    fireEvent.change(sliders[2], { target: { value: "5.5" } });
+    expect(updateNodeParams).toHaveBeenCalledWith("pg1", { edgeWidth: 5.5 });
+  });
+});

--- a/tests/ts/components/nodes/StreamingNode.test.tsx
+++ b/tests/ts/components/nodes/StreamingNode.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { usePipelineStore } from "@/pipeline/store";
+import { StreamingNode } from "@/components/nodes/StreamingNode";
+import type { StreamingParams } from "@/pipeline/types";
+import type { Snapshot } from "@/types";
+import type { FrameProvider } from "@/pipeline/types";
+import { seedPipelineStore } from "./_helpers";
+
+vi.mock("@xyflow/react", () => import("./_xyflowMock"));
+
+function nodeProps(id: string, params: StreamingParams, enabled = true) {
+  return {
+    id,
+    type: "streaming" as const,
+    data: { params, enabled },
+    selected: false,
+    isConnectable: true,
+    xPos: 0,
+    yPos: 0,
+    zIndex: 0,
+    dragging: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+function makeSnapshot(overrides: Partial<Snapshot> = {}): Snapshot {
+  return {
+    nAtoms: 3,
+    nBonds: 0,
+    positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    elements: new Uint8Array([1, 1, 8]),
+    bonds: new Uint32Array(),
+    bondOrders: null,
+    box: null,
+    ...overrides,
+  } as Snapshot;
+}
+
+function makeFrameProvider(nFrames: number): FrameProvider {
+  return {
+    kind: "stream",
+    meta: { nFrames, timestepPs: 0.002, nAtoms: 3 },
+    getFrame() {
+      return null;
+    },
+  };
+}
+
+const ACTIVE_GREEN = "rgb(34, 197, 94)";
+const INACTIVE_RED = "rgb(239, 68, 68)";
+
+describe("StreamingNode", () => {
+  beforeEach(() => {
+    cleanup();
+    usePipelineStore.setState({ nodeStreamingData: {} });
+  });
+
+  it("renders the Streaming title", () => {
+    const seeded = seedPipelineStore("streaming", { id: "s1" });
+    render(<StreamingNode {...nodeProps("s1", seeded.data.params as StreamingParams)} />);
+    expect(screen.getByText("Streaming")).toBeInTheDocument();
+  });
+
+  it("shows 'Disconnected' status with red dot when params.connected=false", () => {
+    const seeded = seedPipelineStore("streaming", {
+      id: "s1",
+      params: { connected: false },
+    });
+    render(<StreamingNode {...nodeProps("s1", seeded.data.params as StreamingParams)} />);
+
+    const status = screen.getByText("Disconnected");
+    expect(status).toBeInTheDocument();
+    expect(status.style.color).toBe(INACTIVE_RED);
+  });
+
+  it("shows 'Connected' status with green dot when params.connected=true", () => {
+    const seeded = seedPipelineStore("streaming", {
+      id: "s1",
+      params: { connected: true },
+    });
+    render(<StreamingNode {...nodeProps("s1", seeded.data.params as StreamingParams)} />);
+
+    const status = screen.getByText("Connected");
+    expect(status).toBeInTheDocument();
+    expect(status.style.color).toBe(ACTIVE_GREEN);
+  });
+
+  it("shows the WebSocket origin hint", () => {
+    const seeded = seedPipelineStore("streaming", { id: "s1" });
+    render(<StreamingNode {...nodeProps("s1", seeded.data.params as StreamingParams)} />);
+    expect(screen.getByText("WebSocket: same origin /ws")).toBeInTheDocument();
+  });
+
+  it("does not render the snapshot stat line when no streaming data is present", () => {
+    const seeded = seedPipelineStore("streaming", { id: "s1" });
+    render(<StreamingNode {...nodeProps("s1", seeded.data.params as StreamingParams)} />);
+    expect(screen.queryByText(/atoms/)).toBeNull();
+  });
+
+  it("renders the atom count when a snapshot is present", () => {
+    const seeded = seedPipelineStore("streaming", { id: "s1" });
+    usePipelineStore.setState({
+      nodeStreamingData: {
+        s1: { snapshot: makeSnapshot({ nAtoms: 42, nBonds: 0 }), streamProvider: null },
+      },
+    });
+    render(<StreamingNode {...nodeProps("s1", seeded.data.params as StreamingParams)} />);
+    expect(screen.getByText("42 atoms")).toBeInTheDocument();
+  });
+
+  it("includes the bond count when nBonds > 0", () => {
+    const seeded = seedPipelineStore("streaming", { id: "s1" });
+    usePipelineStore.setState({
+      nodeStreamingData: {
+        s1: { snapshot: makeSnapshot({ nAtoms: 10, nBonds: 9 }), streamProvider: null },
+      },
+    });
+    render(<StreamingNode {...nodeProps("s1", seeded.data.params as StreamingParams)} />);
+    expect(screen.getByText("10 atoms, 9 bonds")).toBeInTheDocument();
+  });
+
+  it("includes the frame count when streamProvider is present", () => {
+    const seeded = seedPipelineStore("streaming", { id: "s1" });
+    usePipelineStore.setState({
+      nodeStreamingData: {
+        s1: {
+          snapshot: makeSnapshot({ nAtoms: 5, nBonds: 4 }),
+          streamProvider: makeFrameProvider(123),
+        },
+      },
+    });
+    render(<StreamingNode {...nodeProps("s1", seeded.data.params as StreamingParams)} />);
+    expect(screen.getByText("5 atoms, 4 bonds, 123 frames")).toBeInTheDocument();
+  });
+
+  it("disables the bond / trajectory / cell handles when streaming data lacks them", () => {
+    const seeded = seedPipelineStore("streaming", { id: "s1" });
+    render(<StreamingNode {...nodeProps("s1", seeded.data.params as StreamingParams)} />);
+
+    const disabledColor = "rgb(203, 213, 225)"; // slate-300
+    expect(screen.getByTestId("handle-source-bond").style.background).toBe(disabledColor);
+    expect(screen.getByTestId("handle-source-trajectory").style.background).toBe(disabledColor);
+    expect(screen.getByTestId("handle-source-cell").style.background).toBe(disabledColor);
+    // particle output stays its data-type color (green, not slate-300)
+    expect(screen.getByTestId("handle-source-particle").style.background).not.toBe(disabledColor);
+  });
+
+  it("enables the bond / trajectory / cell handles based on snapshot contents", () => {
+    const seeded = seedPipelineStore("streaming", { id: "s1" });
+    usePipelineStore.setState({
+      nodeStreamingData: {
+        s1: {
+          snapshot: makeSnapshot({
+            nAtoms: 2,
+            nBonds: 1,
+            box: new Float32Array([10, 0, 0, 0, 10, 0, 0, 0, 10]),
+          }),
+          streamProvider: makeFrameProvider(5),
+        },
+      },
+    });
+    render(<StreamingNode {...nodeProps("s1", seeded.data.params as StreamingParams)} />);
+
+    const disabledColor = "rgb(203, 213, 225)";
+    expect(screen.getByTestId("handle-source-bond").style.background).not.toBe(disabledColor);
+    expect(screen.getByTestId("handle-source-trajectory").style.background).not.toBe(disabledColor);
+    expect(screen.getByTestId("handle-source-cell").style.background).not.toBe(disabledColor);
+  });
+});

--- a/tests/ts/components/nodes/VectorOverlayNode.test.tsx
+++ b/tests/ts/components/nodes/VectorOverlayNode.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { usePipelineStore } from "@/pipeline/store";
+import { VectorOverlayNode } from "@/components/nodes/VectorOverlayNode";
+import type { VectorOverlayParams } from "@/pipeline/types";
+import { seedPipelineStore } from "./_helpers";
+
+vi.mock("@xyflow/react", () => import("./_xyflowMock"));
+
+function nodeProps(id: string, params: VectorOverlayParams, enabled = true) {
+  return {
+    id,
+    type: "vector_overlay" as const,
+    data: { params, enabled },
+    selected: false,
+    isConnectable: true,
+    xPos: 0,
+    yPos: 0,
+    zIndex: 0,
+    dragging: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe("VectorOverlayNode", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it("renders the Vectors title and the Scale label", () => {
+    const seeded = seedPipelineStore("vector_overlay", { id: "vo1" });
+    render(<VectorOverlayNode {...nodeProps("vo1", seeded.data.params as VectorOverlayParams)} />);
+    expect(screen.getByText("Vectors")).toBeInTheDocument();
+    expect(screen.getByText("Scale")).toBeInTheDocument();
+  });
+
+  it("renders the slider with the value from params and a 1-decimal label", () => {
+    const seeded = seedPipelineStore("vector_overlay", {
+      id: "vo1",
+      params: { scale: 2.5 },
+    });
+    render(<VectorOverlayNode {...nodeProps("vo1", seeded.data.params as VectorOverlayParams)} />);
+
+    const slider = screen.getByRole("slider") as HTMLInputElement;
+    expect(slider.value).toBe("2.5");
+    expect(screen.getByText("2.5")).toBeInTheDocument();
+  });
+
+  it("changing the slider dispatches updateNodeParams with the parsed float", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("vector_overlay", { id: "vo1" });
+    usePipelineStore.setState({ updateNodeParams });
+    render(<VectorOverlayNode {...nodeProps("vo1", seeded.data.params as VectorOverlayParams)} />);
+
+    fireEvent.change(screen.getByRole("slider"), { target: { value: "3.2" } });
+    expect(updateNodeParams).toHaveBeenCalledWith("vo1", { scale: 3.2 });
+  });
+
+  it("slider has the 'nodrag' class so xyflow does not start a node drag", () => {
+    const seeded = seedPipelineStore("vector_overlay", { id: "vo1" });
+    render(<VectorOverlayNode {...nodeProps("vo1", seeded.data.params as VectorOverlayParams)} />);
+    expect(screen.getByRole("slider").className).toContain("nodrag");
+  });
+});


### PR DESCRIPTION
## Summary

Phase 5b of `docs/plans/test-coverage-roadmap.md`. Adds 56 unit tests across 7 files, completing the `src/components/nodes/` test pass started in #345.

New test files (all in `tests/ts/components/nodes/`):
- `LabelGeneratorNode.test.tsx` — 5 tests: TabSelector active/inactive colors, dispatch on tab change, active no-op
- `LoadTrajectoryNode.test.tsx` — 9 tests: file input + drag-and-drop for `.xtc` / `.lammpstrj` / `.dump`, unsupported-extension and handler-cleared guards, multi-file drop selects first match
- `LoadVectorNode.test.tsx` — 7 tests: same patterns for `.vec`
- `ModifyNode.test.tsx` — 7 tests: scale/opacity slider `parseFloat` paths, `%` and 2-decimal formatting, `nodrag` class
- `PolyhedronGeneratorNode.test.tsx` — 14 tests: 12 center + 5 ligand chip enumeration, set-toggle add/remove, slider order (max distance / opacity / edge width), `showEdges` controls visibility, color picker
- `StreamingNode.test.tsx` — 10 tests: connection status colors, `nodeStreamingData` snapshot/frame stat string, bond/trajectory/cell handle disable logic
- `VectorOverlayNode.test.tsx` — 4 tests: Vectors title, slider value/label, dispatch path, `nodrag` class

Reuses the shared `_xyflowMock.tsx` and `_helpers.tsx` (`seedPipelineStore`) scaffolding from Phase 5a — no production-code changes.

The roadmap is updated to mark Phase 5 complete (5a + 5b) and document the patterns used.

## Test plan

- [x] `npm run build:wasm`
- [x] `npm test -- --run tests/ts/components/nodes/` — 12 files / 102 tests pass
- [x] `npm test -- --run` — full suite 55 files / 625 tests pass
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run format:check` — clean
- [ ] CI green on the PR


---
_Generated by [Claude Code](https://claude.ai/code/session_013gQrpeigrmhwJN7q3DNVqi)_