### PR TITLE
test(jupyterlab): add unit tests for filetypes, wasmLoader, factory, skillLoaderStub

### DIFF
--- a/tests/ts/__stubs__/jupyterlab-coreutils.ts
+++ b/tests/ts/__stubs__/jupyterlab-coreutils.ts
@@ -1,0 +1,12 @@
+// Test-only stub for the `@jupyterlab/coreutils` package, which is a dep
+// of the `jupyterlab-megane/` workspace and is NOT installed at the repo root.
+// Vite's import-analysis pass needs every bare specifier to resolve, even when
+// vi.mock() will replace the module at runtime. This stub provides just enough
+// of the surface that `jupyterlab-megane/src/wasmLoader.ts` references.
+// See `vitest.config.ts` resolve.alias for the wiring.
+
+export const PageConfig = {
+  getOption(_key: string): string {
+    return "";
+  },
+};

--- a/tests/ts/__stubs__/jupyterlab-docregistry.ts
+++ b/tests/ts/__stubs__/jupyterlab-docregistry.ts
@@ -1,0 +1,35 @@
+// Test-only stub for `@jupyterlab/docregistry`. See sibling jupyterlab-coreutils.ts.
+// Provides minimal class shapes so `jupyterlab-megane/src/factory.ts` and
+// `filetypes.ts` resolve at transform time. vi.mock() supplies behavior in tests.
+
+export class ABCWidgetFactory<T = unknown, U = unknown> {
+  constructor(_options: unknown) {
+    void _options;
+  }
+}
+
+export class DocumentWidget<T = unknown, U = unknown> {
+  content: unknown;
+  context: unknown;
+  title = { iconClass: "" };
+  constructor(opts: { content: unknown; context: unknown }) {
+    this.content = opts.content;
+    this.context = opts.context;
+  }
+}
+
+export namespace DocumentRegistry {
+  export type Context = unknown;
+  export type IModel = unknown;
+  export type IFileType = {
+    name: string;
+    displayName?: string;
+    extensions?: string[];
+    mimeTypes?: string[];
+    fileFormat?: string;
+    contentType?: string;
+  };
+  export type IWidgetFactoryOptions<T = unknown> = unknown;
+}
+
+export type IDocumentWidget<T = unknown, U = unknown> = unknown;

--- a/tests/ts/__stubs__/jupyterlab-services.ts
+++ b/tests/ts/__stubs__/jupyterlab-services.ts
@@ -1,0 +1,8 @@
+// Test-only stub for `@jupyterlab/services`. Only `Contents.IManager` is
+// referenced (as a type), and TypeScript's `import type` erases it at runtime,
+// so a namespace with the type alias is enough to satisfy import resolution.
+// See sibling jupyterlab-coreutils.ts for the rationale.
+
+export namespace Contents {
+  export type IManager = unknown;
+}

--- a/tests/ts/jupyterlab/factory.test.ts
+++ b/tests/ts/jupyterlab/factory.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Contents } from "@jupyterlab/services";
+
+vi.mock("../../../jupyterlab-megane/src/MeganeDocWidget", () => ({
+  MeganeReactView: vi.fn().mockImplementation((context: unknown) => ({
+    kind: "structure",
+    context,
+  })),
+}));
+
+vi.mock("../../../jupyterlab-megane/src/MeganePipelineDocWidget", () => ({
+  MeganePipelineReactView: vi
+    .fn()
+    .mockImplementation((context: unknown, contents: unknown) => ({
+      kind: "pipeline",
+      context,
+      contents,
+    })),
+}));
+
+vi.mock("@jupyterlab/docregistry", () => {
+  class ABCWidgetFactory {
+    options: unknown;
+    constructor(options: unknown) {
+      this.options = options;
+    }
+  }
+  const DocumentWidget = vi
+    .fn()
+    .mockImplementation((opts: { content: unknown; context: unknown }) => ({
+      content: opts.content,
+      context: opts.context,
+      title: { iconClass: "" },
+    }));
+  return { ABCWidgetFactory, DocumentWidget };
+});
+
+import { MeganeReactView } from "../../../jupyterlab-megane/src/MeganeDocWidget";
+import { MeganePipelineReactView } from "../../../jupyterlab-megane/src/MeganePipelineDocWidget";
+import { DocumentWidget } from "@jupyterlab/docregistry";
+import {
+  MeganeDocFactory,
+  MeganePipelineDocFactory,
+} from "../../../jupyterlab-megane/src/factory";
+
+type Exposed<R = unknown> = { createNewWidget: (ctx: unknown) => R };
+
+const factoryOptions = { name: "test", fileTypes: [] };
+const fakeContext = { id: "fake-context" };
+const fakeContents = {} as unknown as Contents.IManager;
+
+beforeEach(() => {
+  vi.mocked(MeganeReactView).mockClear();
+  vi.mocked(MeganePipelineReactView).mockClear();
+  vi.mocked(DocumentWidget).mockClear();
+});
+
+describe("MeganeDocFactory", () => {
+  it("constructs without throwing when given ABCWidgetFactory options", () => {
+    expect(() => new MeganeDocFactory(factoryOptions)).not.toThrow();
+  });
+
+  it("createNewWidget instantiates MeganeReactView with the context arg", () => {
+    const factory = new MeganeDocFactory(factoryOptions);
+    (factory as unknown as Exposed).createNewWidget(fakeContext);
+
+    expect(MeganeReactView).toHaveBeenCalledTimes(1);
+    expect(MeganeReactView).toHaveBeenCalledWith(fakeContext);
+  });
+
+  it("createNewWidget returns a DocumentWidget with the megane iconClass", () => {
+    const factory = new MeganeDocFactory(factoryOptions);
+    const widget = (factory as unknown as Exposed<{ title: { iconClass: string } }>)
+      .createNewWidget(fakeContext);
+
+    expect(DocumentWidget).toHaveBeenCalledTimes(1);
+    expect(widget.title.iconClass).toBe("jp-MaterialIcon jp-FileIcon");
+  });
+});
+
+describe("MeganePipelineDocFactory", () => {
+  it("stores the contents manager passed to the constructor", () => {
+    const factory = new MeganePipelineDocFactory(factoryOptions, fakeContents);
+    (factory as unknown as Exposed).createNewWidget(fakeContext);
+
+    expect(MeganePipelineReactView).toHaveBeenCalledTimes(1);
+    expect(MeganePipelineReactView).toHaveBeenCalledWith(fakeContext, fakeContents);
+  });
+
+  it("createNewWidget passes both context and contents through to MeganePipelineReactView", () => {
+    const customContents = { distinct: true } as unknown as Contents.IManager;
+    const factory = new MeganePipelineDocFactory(factoryOptions, customContents);
+    (factory as unknown as Exposed).createNewWidget(fakeContext);
+
+    expect(MeganePipelineReactView).toHaveBeenCalledWith(fakeContext, customContents);
+  });
+
+  it("createNewWidget returns a DocumentWidget with the megane iconClass", () => {
+    const factory = new MeganePipelineDocFactory(factoryOptions, fakeContents);
+    const widget = (factory as unknown as Exposed<{ title: { iconClass: string } }>)
+      .createNewWidget(fakeContext);
+
+    expect(DocumentWidget).toHaveBeenCalledTimes(1);
+    expect(widget.title.iconClass).toBe("jp-MaterialIcon jp-FileIcon");
+  });
+});
+
+describe("MeganeDocFactory vs MeganePipelineDocFactory", () => {
+  it("produce wrappers around different widget classes", () => {
+    const structureFactory = new MeganeDocFactory(factoryOptions);
+    const pipelineFactory = new MeganePipelineDocFactory(factoryOptions, fakeContents);
+
+    (structureFactory as unknown as Exposed).createNewWidget(fakeContext);
+    (pipelineFactory as unknown as Exposed).createNewWidget(fakeContext);
+
+    expect(MeganeReactView).toHaveBeenCalledTimes(1);
+    expect(MeganePipelineReactView).toHaveBeenCalledTimes(1);
+    expect(DocumentWidget).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/ts/jupyterlab/filetypes.test.ts
+++ b/tests/ts/jupyterlab/filetypes.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  FACTORY_NAME,
+  FACTORY_NAME_BINARY,
+  FACTORY_NAME_PIPELINE,
+  PIPELINE_FILETYPE,
+  PIPELINE_FILETYPE_NAME,
+  STRUCTURE_FILETYPES_BINARY,
+  STRUCTURE_FILETYPES_TEXT,
+  STRUCTURE_FILETYPE_NAMES_BINARY,
+  STRUCTURE_FILETYPE_NAMES_TEXT,
+} from "../../../jupyterlab-megane/src/filetypes";
+
+describe("jupyterlab filetypes", () => {
+  it("declares three distinct non-empty factory names", () => {
+    const names = [FACTORY_NAME, FACTORY_NAME_BINARY, FACTORY_NAME_PIPELINE];
+    for (const name of names) {
+      expect(typeof name).toBe("string");
+      expect(name.length).toBeGreaterThan(0);
+    }
+    expect(new Set(names).size).toBe(3);
+  });
+
+  it("aligns PIPELINE_FILETYPE_NAME with PIPELINE_FILETYPE.name", () => {
+    expect(PIPELINE_FILETYPE_NAME).toBe("megane-pipeline");
+    expect(PIPELINE_FILETYPE.name).toBe(PIPELINE_FILETYPE_NAME);
+  });
+
+  it("declares the pipeline filetype with .megane.json extension and JSON mime", () => {
+    expect(PIPELINE_FILETYPE.extensions).toEqual([".megane.json"]);
+    expect(PIPELINE_FILETYPE.mimeTypes).toEqual(["application/json"]);
+    expect(PIPELINE_FILETYPE.fileFormat).toBe("text");
+    expect(PIPELINE_FILETYPE.contentType).toBe("file");
+  });
+
+  it("ships exactly seven text structure filetypes", () => {
+    expect(STRUCTURE_FILETYPES_TEXT).toHaveLength(7);
+  });
+
+  it("includes the canonical PDB / GRO / XYZ / MOL / SDF / CIF / LAMMPS-data names", () => {
+    const names = STRUCTURE_FILETYPES_TEXT.map((f) => f.name).sort();
+    expect(names).toEqual(
+      [
+        "megane-pdb",
+        "megane-gro",
+        "megane-xyz",
+        "megane-mol",
+        "megane-sdf",
+        "megane-cif",
+        "megane-lammps-data",
+      ].sort(),
+    );
+  });
+
+  it("registers both .data and .lammps for the LAMMPS-data filetype", () => {
+    const lammps = STRUCTURE_FILETYPES_TEXT.find((f) => f.name === "megane-lammps-data");
+    expect(lammps).toBeDefined();
+    expect(lammps?.extensions).toEqual([".data", ".lammps"]);
+  });
+
+  it("ships a single ASE trajectory binary filetype", () => {
+    expect(STRUCTURE_FILETYPES_BINARY).toHaveLength(1);
+    const traj = STRUCTURE_FILETYPES_BINARY[0];
+    expect(traj.name).toBe("megane-ase-traj");
+    expect(traj.extensions).toEqual([".traj"]);
+    expect(traj.fileFormat).toBe("base64");
+    expect(traj.contentType).toBe("file");
+  });
+
+  it("ensures every extension starts with '.' and every name is unique across all arrays", () => {
+    const allFiletypes = [
+      PIPELINE_FILETYPE,
+      ...STRUCTURE_FILETYPES_TEXT,
+      ...STRUCTURE_FILETYPES_BINARY,
+    ];
+    const allExtensions = allFiletypes.flatMap((f) => f.extensions ?? []);
+    for (const ext of allExtensions) {
+      expect(ext.startsWith(".")).toBe(true);
+    }
+    const allNames = allFiletypes.map((f) => f.name);
+    expect(new Set(allNames).size).toBe(allNames.length);
+  });
+
+  it("derives the *_NAMES_* arrays from .map(f => f.name)", () => {
+    expect(STRUCTURE_FILETYPE_NAMES_TEXT).toEqual(
+      STRUCTURE_FILETYPES_TEXT.map((f) => f.name),
+    );
+    expect(STRUCTURE_FILETYPE_NAMES_BINARY).toEqual(
+      STRUCTURE_FILETYPES_BINARY.map((f) => f.name),
+    );
+    expect(STRUCTURE_FILETYPE_NAMES_TEXT).toHaveLength(7);
+    expect(STRUCTURE_FILETYPE_NAMES_BINARY).toHaveLength(1);
+  });
+});

--- a/tests/ts/jupyterlab/skillLoaderStub.test.ts
+++ b/tests/ts/jupyterlab/skillLoaderStub.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  buildToolDefinitions,
+  executeSkill,
+  getSkills,
+  loadSkills,
+  type PipelineSkill,
+} from "../../../jupyterlab-megane/src/skillLoaderStub";
+
+describe("jupyterlab skillLoaderStub", () => {
+  it("loadSkills returns an empty array (and a fresh reference each call)", () => {
+    const first = loadSkills();
+    const second = loadSkills();
+    expect(first).toEqual([]);
+    expect(second).toEqual([]);
+    expect(first).not.toBe(second);
+  });
+
+  it("getSkills returns an empty array", () => {
+    expect(getSkills()).toEqual([]);
+  });
+
+  it("buildToolDefinitions returns an empty array regardless of input", () => {
+    expect(buildToolDefinitions([])).toEqual([]);
+    const skills: PipelineSkill[] = [
+      { name: "foo", description: "d1", content: "c1" },
+      { name: "bar", description: "d2", content: "c2" },
+    ];
+    expect(buildToolDefinitions(skills)).toEqual([]);
+  });
+
+  it("executeSkill returns null on an empty skill set", () => {
+    expect(executeSkill([], "anything")).toBeNull();
+  });
+
+  it("executeSkill ignores its arguments and still returns null", () => {
+    const skills: PipelineSkill[] = [
+      { name: "skill-name", description: "d", content: "c" },
+    ];
+    expect(executeSkill(skills, "skill-name")).toBeNull();
+  });
+});

--- a/tests/ts/jupyterlab/wasmLoader.test.ts
+++ b/tests/ts/jupyterlab/wasmLoader.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+type GlobalWithWasm = Record<string, unknown> & {
+  __MEGANE_WASM_URL__?: unknown;
+};
+
+beforeEach(() => {
+  vi.resetModules();
+  delete (globalThis as GlobalWithWasm).__MEGANE_WASM_URL__;
+});
+
+afterEach(() => {
+  vi.doUnmock("@jupyterlab/coreutils");
+  delete (globalThis as GlobalWithWasm).__MEGANE_WASM_URL__;
+});
+
+describe("ensureWasmUrl — catch branch", () => {
+  it("constructs the labextension URL from PageConfig when the wasm import fails", async () => {
+    vi.doMock("@jupyterlab/coreutils", () => ({
+      PageConfig: { getOption: vi.fn(() => "https://lab.example.test/extensions") },
+    }));
+
+    const { ensureWasmUrl } = await import(
+      "../../../jupyterlab-megane/src/wasmLoader"
+    );
+    await ensureWasmUrl();
+
+    expect((globalThis as GlobalWithWasm).__MEGANE_WASM_URL__).toBe(
+      "https://lab.example.test/extensions/megane-jupyterlab/static/megane_wasm_bg.wasm",
+    );
+  });
+
+  it("rethrows the original wasm import error when PageConfig has no base URL", async () => {
+    vi.doMock("@jupyterlab/coreutils", () => ({
+      PageConfig: { getOption: vi.fn(() => "") },
+    }));
+
+    const { ensureWasmUrl } = await import(
+      "../../../jupyterlab-megane/src/wasmLoader"
+    );
+
+    await expect(ensureWasmUrl()).rejects.toBeDefined();
+    expect((globalThis as GlobalWithWasm).__MEGANE_WASM_URL__).toBeUndefined();
+  });
+});
+
+describe("ensureWasmUrl — promise cache", () => {
+  it("returns the same Promise reference on subsequent calls", async () => {
+    vi.doMock("@jupyterlab/coreutils", () => ({
+      PageConfig: { getOption: vi.fn(() => "/lab/extensions") },
+    }));
+
+    const { ensureWasmUrl } = await import(
+      "../../../jupyterlab-megane/src/wasmLoader"
+    );
+
+    const first = ensureWasmUrl();
+    const second = ensureWasmUrl();
+    expect(first).toBe(second);
+
+    await first;
+  });
+
+  it("invokes PageConfig.getOption only once across two ensureWasmUrl calls", async () => {
+    const getOption = vi.fn(() => "/lab/extensions");
+    vi.doMock("@jupyterlab/coreutils", () => ({ PageConfig: { getOption } }));
+
+    const { ensureWasmUrl } = await import(
+      "../../../jupyterlab-megane/src/wasmLoader"
+    );
+
+    await ensureWasmUrl();
+    await ensureWasmUrl();
+
+    expect(getOption).toHaveBeenCalledTimes(1);
+    expect(getOption).toHaveBeenCalledWith("fullLabextensionsUrl");
+  });
+
+  it("survives a fresh module load with a cleared cache (vi.resetModules)", async () => {
+    vi.doMock("@jupyterlab/coreutils", () => ({
+      PageConfig: { getOption: vi.fn(() => "/lab/extensions") },
+    }));
+
+    const first = await import("../../../jupyterlab-megane/src/wasmLoader");
+    await first.ensureWasmUrl();
+    expect((globalThis as GlobalWithWasm).__MEGANE_WASM_URL__).toBe(
+      "/lab/extensions/megane-jupyterlab/static/megane_wasm_bg.wasm",
+    );
+
+    delete (globalThis as GlobalWithWasm).__MEGANE_WASM_URL__;
+    vi.resetModules();
+
+    vi.doMock("@jupyterlab/coreutils", () => ({
+      PageConfig: { getOption: vi.fn(() => "/other/base") },
+    }));
+    const second = await import("../../../jupyterlab-megane/src/wasmLoader");
+    await second.ensureWasmUrl();
+    expect((globalThis as GlobalWithWasm).__MEGANE_WASM_URL__).toBe(
+      "/other/base/megane-jupyterlab/static/megane_wasm_bg.wasm",
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,22 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "src"),
+      // The `@jupyterlab/*` packages live in jupyterlab-megane/package.json,
+      // not the root, so vitest's import-analysis can't resolve bare specifiers
+      // referenced by `jupyterlab-megane/src/`. Tests mock these via vi.mock();
+      // the stubs only need to satisfy resolution, not provide behavior.
+      "@jupyterlab/coreutils": path.resolve(
+        __dirname,
+        "tests/ts/__stubs__/jupyterlab-coreutils.ts",
+      ),
+      "@jupyterlab/docregistry": path.resolve(
+        __dirname,
+        "tests/ts/__stubs__/jupyterlab-docregistry.ts",
+      ),
+      "@jupyterlab/services": path.resolve(
+        __dirname,
+        "tests/ts/__stubs__/jupyterlab-services.ts",
+      ),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Phase 6 of `docs/plans/test-coverage-roadmap.md`. Adds **26 vitest unit tests across 4 files** under `tests/ts/jupyterlab/`, covering the small self-contained modules in `jupyterlab-megane/src/`.

### Coverage delta (from 0% across the whole subtree)

| File | Before | After |
|---|---|---|
| `jupyterlab-megane/src/filetypes.ts` | 0% | **100%** (82/82) |
| `jupyterlab-megane/src/factory.ts` | 0% | **100%** (31/31) |
| `jupyterlab-megane/src/skillLoaderStub.ts` | 0% | **100%** (12/12) |
| `jupyterlab-megane/src/wasmLoader.ts` | 0% | **95.5%** (21/22) |

The single uncovered line in `wasmLoader.ts` is the `await import(".../megane_wasm_bg.wasm")` success path, which is a webpack `asset/resource` dynamic import that vitest cannot resolve as an ES module. That path is exercised by `tests/e2e/jupyterlab-doc.spec.ts` instead.

### Out of scope (covered by E2E `tests/e2e/jupyterlab-doc.spec.ts`)
- `jupyterlab-megane/src/MeganeDocWidget.tsx`
- `jupyterlab-megane/src/MeganePipelineDocWidget.tsx`
- `jupyterlab-megane/src/index.ts`

### Test infrastructure addition

Adds three minimal stubs under `tests/ts/__stubs__/` for `@jupyterlab/coreutils`, `@jupyterlab/docregistry`, and `@jupyterlab/services`. These packages live in `jupyterlab-megane/package.json` (not the root), so vitest's import-analysis cannot resolve bare specifiers from `jupyterlab-megane/src/` modules. The stubs only need to satisfy resolution; tests use `vi.mock()` to supply behavior. Wired via three new `resolve.alias` entries in `vitest.config.ts`.

## Test plan

- [x] `npm run build:wasm`
- [x] `./node_modules/.bin/vitest run tests/ts/jupyterlab` → 4 files / 26 tests passing
- [x] `./node_modules/.bin/vitest run` → full suite: 59 files / 651 tests passing (no regressions)
- [x] `npm run lint` → 0 errors (23 pre-existing warnings unchanged)
- [x] `npm run format:check` → all formatted
- [x] Coverage spot-check confirms 100% / 100% / 100% / 95.5% on the four target files
- [ ] CI green on this branch
- [ ] codecov per-flag report shows lifted `typescript` coverage

## Roadmap status after this PR

- ✅ Phase 0–5 (already merged)
- ✅ Phase 6 (this PR)
- ⬜ Phase 7 — `vscode-megane/src/extension.ts` with `vi.mock("vscode", ...)`
- ⬜ Phase 8 — codecov `threshold: 1% → 2%` + `fail_ci_on_error: true`

https://claude.ai/code/session_01VHsfM4fhsDcGkTFm41st94

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHsfM4fhsDcGkTFm41st94)_