### PR TITLE
test(vscode): add unit tests for vscode-megane extension.ts (Phase 7)

### DIFF
--- a/docs/plans/test-coverage-roadmap.md
+++ b/docs/plans/test-coverage-roadmap.md
@@ -9,8 +9,8 @@
 - ✅ Phase 4 — `src/renderer/` pure helpers (Selection, Picking, CameraManager, shaders) — 4 files, 788 LOC, 69 tests
 - ✅ Phase 5a — `NodeShell` + 4 node components (commit `a9a0540`)
 - ✅ Phase 5b — remaining 7 node components (LabelGenerator, LoadTrajectory, LoadVector, Modify, PolyhedronGenerator, Streaming, VectorOverlay) — 7 files, 56 tests
-- ⬜ Phase 6 — `jupyterlab-megane/src/` (filetypes, wasmLoader, factory)
-- ⬜ Phase 7 — `vscode-megane/src/extension.ts` with vscode mock
+- ✅ Phase 6 — `jupyterlab-megane/src/` (filetypes, wasmLoader, factory, skillLoaderStub) — commit `ff31c30`
+- ✅ Phase 7 — `vscode-megane/src/extension.ts` with vscode mock — 1 file, 22 tests, ~440 LOC test source. New `tests/ts/__stubs__/vscode.ts` + `vitest.config.ts` alias. `webview/main.tsx` is intentionally deferred (roadmap-noted: requires module split into pure handlers, separate task).
 - ⬜ Phase 8 — codecov threshold tightening (`1% → 2%`) + `fail_ci_on_error: true`
 
 Total new tests added in Phases 0–4: **169** tests across 13 files (1,965 LOC test source).
@@ -170,15 +170,17 @@ main を取り込んだ直後のリポジトリでは、すでに以下が main 
 - **DocWidget は対象外**: `MeganeDocWidget.tsx`, `MeganePipelineDocWidget.tsx` は JupyterLab DocumentWidget / Comm 直結なので E2E (`tests/e2e/jupyterlab-doc.spec.ts`) に任せる
 - **規模**: S
 
-## Phase 7 — `vscode-megane/src/` (vscode API モック必須)
+## Phase 7 — `vscode-megane/src/` (vscode API モック必須) ✅ DONE
 
-`extension.ts` (257), `webview/main.tsx` (206)。
+**実施内容**: `tests/ts/vscode/extension.test.ts` (22 tests, ~440 LOC) を追加。`tests/ts/__stubs__/vscode.ts` で `Uri` / `workspace.fs.readFile` / `window.registerCustomEditorProvider` の最小スタブを用意し、`vitest.config.ts` の `resolve.alias` に `vscode` → スタブを追加 (jupyterlab パッケージと同じパターン)。テスト側は `vi.hoisted` + `vi.mock("vscode", () => ({...}))` で `mockState.registered` / `mockState.readFile` を駆動し、`activate()` 経由で各 provider インスタンスを captura → 直接 `openCustomDocument` / `resolveCustomEditor` を呼んで挙動を検証。
 
-- **追加テスト**:
-  - `tests/ts/vscode/extension.test.ts`: `vitest` の `vi.mock("vscode", ...)` で vscode API をモックし、`activate()` のコマンド登録 / contentProvider / postMessage 経路を検証
-  - `webview/main.tsx` のメッセージハンドラ部分はモジュール分割して純粋関数化したうえでテスト (本格的な分割は別タスク)
-- **既存契約参照**: `vscode-megane/webview/main.tsx:43-50` の `event.data` ディスパッチ
-- **規模**: M (vscode モック作成のオーバーヘッドあり)
+- `tests/ts/vscode/extension.test.ts` (4 describe ブロック / 22 tests):
+  - `activate / deactivate` (4 tests): 2 provider 登録順序 (`structureViewer` → `pipelineViewer`)、`subscriptions` プッシュ、`retainContextWhenHidden: true` + `supportsMultipleEditorsPerDocument: false`、`deactivate()` no-op
+  - `MeganeEditorProvider` 単一構造ファイル (8 tests): `openCustomDocument` の uri 保持と dispose noop、`webview.options` に `enableScripts` + `localResourceRoots` が media フォルダ 1 件のみ、`onDidReceiveMessage("ready")` での `postMessage` ペイロード (`type: "loadFile"`, `contentBytes`, `filename`, `wasmBytes`)、非 ready メッセージ無視、readFile 失敗時 `{type: "error", message}`、非 Error throw の文字列化、HTML 内の CSP / `__MEGANE_CONTEXT__ = "vscode"` / nonce 32 文字、`MEGANE_E2E_MODE=1` 時の `window.__MEGANE_TEST__ = true;` 注入と通常時の非注入、4 回連続呼び出しでの nonce 重複なし
+  - `MeganePipelineEditorProvider` パイプライン (8 tests): `openCustomDocument` の uri 保持、`load_structure` + `load_trajectory` ノードの相対パスを使った companion ファイル並走読み込み + ペイロード組み立て、`version !== 3` のエラーペイロード (`"version 3 required"`, `"got 2"`)、JSON malformed のエラーペイロード、絶対パス (`/etc/passwd`) スキップ、ディレクトリ脱出 (`../../escape.pdb`) スキップ、companion 読み失敗の silent skip + 残ノード継続、`fileName` 未設定 / `null` ノードのスキップ、`load_structure` / `load_trajectory` 以外の type のスキップ
+- **`webview/main.tsx` (206 LOC) は対象外**: `acquireVsCodeApi()` 直結 + ReactDOM.render + `usePipelineStore.openFile` ネットワーク経路で、message handler の純粋分離が前提。ロードマップが許容する「テスト + 必要最小の export 追加」枠を超えるため、本フェーズでは E2E (`tests/e2e/vscode-*.spec.ts`) に任せ、純粋関数化は別タスク。
+- **追加スタブ / alias**: `tests/ts/__stubs__/vscode.ts`、`vitest.config.ts` の resolve.alias へ `vscode` 追加。
+- **規模**: M (実績)
 
 ## Phase 8 — codecov しきい値の段階引き締め (締め)
 
@@ -200,8 +202,8 @@ Phase 0 (codecov flag fix)        ✅ DONE (c17462a)
         ├─ Phase 4 (renderer pure helpers)   ✅ DONE
         └─ Phase 5 (nodes UI)                 ✅ DONE (2 PR: 5a + 5b)
              │
-             ├─ Phase 6 (jupyterlab small files)  ⬜ TODO
-             └─ Phase 7 (vscode extension)        ⬜ TODO
+             ├─ Phase 6 (jupyterlab small files)  ✅ DONE (ff31c30)
+             └─ Phase 7 (vscode extension)        ✅ DONE
                   │
                   └─ Phase 8 (threshold tighten)  ⬜ TODO
 ```

--- a/tests/ts/__stubs__/vscode.ts
+++ b/tests/ts/__stubs__/vscode.ts
@@ -1,0 +1,81 @@
+// Test-only stub for the `vscode` module, which is injected by the VS Code
+// extension host at runtime and is NOT installed at the repo root. Vite's
+// import-analysis pass needs every bare specifier to resolve, even when
+// vi.mock() will replace the module at runtime. This stub provides just enough
+// of the surface that `vscode-megane/src/extension.ts` references.
+// See `vitest.config.ts` resolve.alias for the wiring.
+
+export class Uri {
+  scheme: string;
+  authority: string;
+  path: string;
+  query: string;
+  fragment: string;
+
+  constructor(scheme = "", authority = "", path = "", query = "", fragment = "") {
+    this.scheme = scheme;
+    this.authority = authority;
+    this.path = path;
+    this.query = query;
+    this.fragment = fragment;
+  }
+
+  get fsPath(): string {
+    return this.path;
+  }
+
+  static file(path: string): Uri {
+    return new Uri("file", "", path);
+  }
+
+  static joinPath(base: Uri, ...segments: string[]): Uri {
+    const joined = [base.path, ...segments].filter(Boolean).join("/").replace(/\/+/g, "/");
+    return new Uri(base.scheme, base.authority, joined);
+  }
+
+  toString(): string {
+    return `${this.scheme}://${this.authority}${this.path}`;
+  }
+}
+
+export const workspace = {
+  fs: {
+    readFile: (_uri: Uri): Promise<Uint8Array> => Promise.resolve(new Uint8Array()),
+  },
+};
+
+export const window = {
+  registerCustomEditorProvider: (
+    _viewType: string,
+    _provider: unknown,
+    _options?: unknown,
+  ): { dispose: () => void } => ({ dispose: () => {} }),
+};
+
+export interface Disposable {
+  dispose(): void;
+}
+
+export interface CustomDocument {
+  readonly uri: Uri;
+  dispose(): void;
+}
+
+export type CustomDocumentOpenContext = unknown;
+export type CancellationToken = unknown;
+export type ExtensionContext = unknown;
+export type WebviewPanel = unknown;
+export type Webview = unknown;
+
+export interface CustomReadonlyEditorProvider<T extends CustomDocument = CustomDocument> {
+  openCustomDocument(
+    uri: Uri,
+    openContext: CustomDocumentOpenContext,
+    token: CancellationToken,
+  ): T | Thenable<T>;
+  resolveCustomEditor(
+    document: T,
+    webviewPanel: WebviewPanel,
+    token: CancellationToken,
+  ): void | Thenable<void>;
+}

--- a/tests/ts/vscode/extension.test.ts
+++ b/tests/ts/vscode/extension.test.ts
@@ -1,0 +1,562 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+interface FakeProvider {
+  openCustomDocument: (
+    uri: FakeUri,
+    openContext: unknown,
+    token: unknown,
+  ) => { uri: FakeUri; dispose: () => void };
+  resolveCustomEditor: (
+    document: { uri: FakeUri; dispose: () => void },
+    webviewPanel: FakeWebviewPanel,
+    token: unknown,
+  ) => Promise<void>;
+}
+
+interface RegisteredProvider {
+  viewType: string;
+  provider: FakeProvider;
+  options: {
+    webviewOptions?: { retainContextWhenHidden?: boolean };
+    supportsMultipleEditorsPerDocument?: boolean;
+  };
+}
+
+interface FakeUri {
+  scheme: string;
+  authority: string;
+  path: string;
+  fsPath: string;
+  toString(): string;
+}
+
+interface FakeWebview {
+  options: unknown;
+  html: string;
+  cspSource: string;
+  onDidReceiveMessage: ReturnType<typeof vi.fn>;
+  postMessage: ReturnType<typeof vi.fn>;
+  asWebviewUri: (uri: FakeUri) => string;
+}
+
+interface FakeWebviewPanel {
+  webview: FakeWebview;
+}
+
+const { mockState } = vi.hoisted(() => ({
+  mockState: {
+    registered: [] as RegisteredProvider[],
+    readFile: vi.fn<(uri: FakeUri) => Promise<Uint8Array>>(),
+  },
+}));
+
+vi.mock("vscode", () => {
+  class Uri {
+    scheme: string;
+    authority: string;
+    path: string;
+    constructor(scheme = "", authority = "", path = "") {
+      this.scheme = scheme;
+      this.authority = authority;
+      this.path = path;
+    }
+    get fsPath(): string {
+      return this.path;
+    }
+    static file(p: string): Uri {
+      return new Uri("file", "", p);
+    }
+    static joinPath(base: Uri, ...segs: string[]): Uri {
+      const trimmed = base.path.replace(/\/+$/, "");
+      const joined = [trimmed, ...segs].filter((s) => s.length > 0).join("/");
+      return new Uri(base.scheme, base.authority, joined);
+    }
+    toString(): string {
+      return `${this.scheme}://${this.authority}${this.path}`;
+    }
+  }
+  return {
+    Uri,
+    workspace: { fs: { readFile: mockState.readFile } },
+    window: {
+      registerCustomEditorProvider: vi.fn(
+        (viewType: string, provider: FakeProvider, options: RegisteredProvider["options"]) => {
+          mockState.registered.push({ viewType, provider, options });
+          return { dispose: vi.fn() };
+        },
+      ),
+    },
+  };
+});
+
+import * as vscode from "vscode";
+import { activate, deactivate } from "../../../vscode-megane/src/extension";
+
+const VscodeUri = (vscode as unknown as { Uri: { file: (p: string) => FakeUri } }).Uri;
+
+function makeContext(extensionPath = "/ext"): {
+  extensionUri: FakeUri;
+  subscriptions: Array<{ dispose: () => void }>;
+} {
+  return {
+    extensionUri: VscodeUri.file(extensionPath),
+    subscriptions: [],
+  };
+}
+
+function makeWebviewPanel(): {
+  panel: FakeWebviewPanel;
+  fireMessage: (msg: unknown) => void;
+} {
+  let onMessage: ((m: unknown) => void) | undefined;
+  const webview: FakeWebview = {
+    options: undefined,
+    html: "",
+    cspSource: "vscode-webview://test",
+    onDidReceiveMessage: vi.fn((handler: (m: unknown) => void) => {
+      onMessage = handler;
+      return { dispose: vi.fn() };
+    }),
+    postMessage: vi.fn(),
+    asWebviewUri: (uri: FakeUri) => `webview:${uri.toString()}`,
+  };
+  return {
+    panel: { webview },
+    fireMessage: (msg) => {
+      if (!onMessage) throw new Error("onDidReceiveMessage not registered");
+      onMessage(msg);
+    },
+  };
+}
+
+function getProvider(viewType: string): FakeProvider {
+  const entry = mockState.registered.find((r) => r.viewType === viewType);
+  if (!entry) throw new Error(`provider not registered: ${viewType}`);
+  return entry.provider;
+}
+
+beforeEach(() => {
+  mockState.registered.length = 0;
+  mockState.readFile.mockReset();
+  vi.mocked(vscode.window.registerCustomEditorProvider).mockClear();
+  delete process.env.MEGANE_E2E_MODE;
+});
+
+afterEach(() => {
+  delete process.env.MEGANE_E2E_MODE;
+});
+
+describe("activate / deactivate", () => {
+  it("registers two custom editor providers", () => {
+    const ctx = makeContext();
+    activate(ctx as unknown as Parameters<typeof activate>[0]);
+
+    expect(mockState.registered.map((r) => r.viewType)).toEqual([
+      "megane.structureViewer",
+      "megane.pipelineViewer",
+    ]);
+  });
+
+  it("pushes both registration disposables onto context.subscriptions", () => {
+    const ctx = makeContext();
+    activate(ctx as unknown as Parameters<typeof activate>[0]);
+
+    expect(ctx.subscriptions).toHaveLength(2);
+    for (const sub of ctx.subscriptions) {
+      expect(typeof sub.dispose).toBe("function");
+    }
+  });
+
+  it("configures retainContextWhenHidden and disables multi-editor for both providers", () => {
+    activate(makeContext() as unknown as Parameters<typeof activate>[0]);
+
+    for (const reg of mockState.registered) {
+      expect(reg.options.webviewOptions?.retainContextWhenHidden).toBe(true);
+      expect(reg.options.supportsMultipleEditorsPerDocument).toBe(false);
+    }
+  });
+
+  it("deactivate is a no-op", () => {
+    expect(() => deactivate()).not.toThrow();
+    expect(deactivate()).toBeUndefined();
+  });
+});
+
+describe("MeganeEditorProvider — structureViewer", () => {
+  beforeEach(() => {
+    activate(makeContext("/ext") as unknown as Parameters<typeof activate>[0]);
+  });
+
+  it("openCustomDocument returns a CustomDocument bound to the supplied uri", () => {
+    const provider = getProvider("megane.structureViewer");
+    const uri = VscodeUri.file("/work/sample.pdb");
+    const doc = provider.openCustomDocument(uri, {}, {});
+    expect(doc.uri).toBe(uri);
+    expect(typeof doc.dispose).toBe("function");
+    expect(() => doc.dispose()).not.toThrow();
+  });
+
+  it("sets webview.options with enableScripts and the media folder as the only resource root", async () => {
+    const provider = getProvider("megane.structureViewer");
+    mockState.readFile.mockResolvedValue(new Uint8Array([1]));
+
+    const doc = { uri: VscodeUri.file("/work/sample.pdb"), dispose: vi.fn() };
+    const { panel } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    const options = panel.webview.options as {
+      enableScripts: boolean;
+      localResourceRoots: FakeUri[];
+    };
+    expect(options.enableScripts).toBe(true);
+    expect(options.localResourceRoots).toHaveLength(1);
+    expect(options.localResourceRoots[0].path).toBe("/ext/media");
+  });
+
+  it("posts loadFile payload (file bytes + wasm bytes + filename) when the webview signals ready", async () => {
+    const provider = getProvider("megane.structureViewer");
+    mockState.readFile
+      .mockResolvedValueOnce(new Uint8Array([72, 73, 74])) // doc bytes
+      .mockResolvedValueOnce(new Uint8Array([1, 2, 3])); // wasm bytes
+
+    const doc = { uri: VscodeUri.file("/work/sample.pdb"), dispose: vi.fn() };
+    const { panel, fireMessage } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    expect(panel.webview.postMessage).not.toHaveBeenCalled();
+    fireMessage({ type: "ready" });
+
+    expect(panel.webview.postMessage).toHaveBeenCalledWith({
+      type: "loadFile",
+      contentBytes: [72, 73, 74],
+      filename: "sample.pdb",
+      wasmBytes: [1, 2, 3],
+    });
+  });
+
+  it("ignores webview messages whose type is not 'ready'", async () => {
+    const provider = getProvider("megane.structureViewer");
+    mockState.readFile.mockResolvedValue(new Uint8Array([0]));
+
+    const doc = { uri: VscodeUri.file("/work/sample.pdb"), dispose: vi.fn() };
+    const { panel, fireMessage } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    fireMessage({ type: "selectionChanged" });
+    fireMessage({});
+    expect(panel.webview.postMessage).not.toHaveBeenCalled();
+  });
+
+  it("posts an error payload when reading the document fails", async () => {
+    const provider = getProvider("megane.structureViewer");
+    mockState.readFile.mockRejectedValueOnce(new Error("ENOENT: missing"));
+    mockState.readFile.mockResolvedValueOnce(new Uint8Array());
+
+    const doc = { uri: VscodeUri.file("/work/sample.pdb"), dispose: vi.fn() };
+    const { panel, fireMessage } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    fireMessage({ type: "ready" });
+    expect(panel.webview.postMessage).toHaveBeenCalledWith({
+      type: "error",
+      message: "ENOENT: missing",
+    });
+  });
+
+  it("coerces non-Error throws into a string message", async () => {
+    const provider = getProvider("megane.structureViewer");
+    mockState.readFile.mockRejectedValueOnce("filesystem unavailable");
+    mockState.readFile.mockResolvedValueOnce(new Uint8Array());
+
+    const doc = { uri: VscodeUri.file("/work/sample.pdb"), dispose: vi.fn() };
+    const { panel, fireMessage } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    fireMessage({ type: "ready" });
+    expect(panel.webview.postMessage).toHaveBeenCalledWith({
+      type: "error",
+      message: "filesystem unavailable",
+    });
+  });
+
+  it("renders webview.html with CSP, vscode context flag, and a 32-char nonce", async () => {
+    const provider = getProvider("megane.structureViewer");
+    mockState.readFile.mockResolvedValue(new Uint8Array());
+
+    const doc = { uri: VscodeUri.file("/work/sample.pdb"), dispose: vi.fn() };
+    const { panel } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    const html = panel.webview.html;
+    expect(html).toContain("Content-Security-Policy");
+    expect(html).toContain('window.__MEGANE_CONTEXT__ = "vscode"');
+    expect(html).toContain("__MEGANE_WASM_URL__");
+    expect(html).not.toContain("__MEGANE_TEST__");
+
+    const nonceMatch = html.match(/nonce-([A-Za-z0-9]+)/);
+    expect(nonceMatch).not.toBeNull();
+    expect(nonceMatch![1]).toHaveLength(32);
+  });
+
+  it("emits __MEGANE_TEST__ when MEGANE_E2E_MODE=1 is set on the extension host", async () => {
+    process.env.MEGANE_E2E_MODE = "1";
+    const provider = getProvider("megane.structureViewer");
+    mockState.readFile.mockResolvedValue(new Uint8Array());
+
+    const doc = { uri: VscodeUri.file("/work/sample.pdb"), dispose: vi.fn() };
+    const { panel } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    expect(panel.webview.html).toContain("window.__MEGANE_TEST__ = true;");
+  });
+
+  it("each call to getNonce produces a fresh random nonce", async () => {
+    const provider = getProvider("megane.structureViewer");
+    mockState.readFile.mockResolvedValue(new Uint8Array());
+
+    const seen = new Set<string>();
+    for (let i = 0; i < 4; i++) {
+      const doc = { uri: VscodeUri.file("/work/sample.pdb"), dispose: vi.fn() };
+      const { panel } = makeWebviewPanel();
+      await provider.resolveCustomEditor(doc, panel, {});
+      const nonce = panel.webview.html.match(/nonce-([A-Za-z0-9]+)/)?.[1];
+      expect(nonce).toBeDefined();
+      seen.add(nonce!);
+    }
+    // Random — collisions across 4 picks of 32-char strings should be effectively impossible.
+    expect(seen.size).toBe(4);
+  });
+});
+
+describe("MeganePipelineEditorProvider — pipelineViewer", () => {
+  beforeEach(() => {
+    activate(makeContext("/ext") as unknown as Parameters<typeof activate>[0]);
+  });
+
+  function pipelineBytes(payload: unknown): Uint8Array {
+    return new TextEncoder().encode(JSON.stringify(payload));
+  }
+
+  it("openCustomDocument returns a CustomDocument bound to the supplied uri", () => {
+    const provider = getProvider("megane.pipelineViewer");
+    const uri = VscodeUri.file("/work/pipe.megane.json");
+    const doc = provider.openCustomDocument(uri, {}, {});
+    expect(doc.uri).toBe(uri);
+    expect(() => doc.dispose()).not.toThrow();
+  });
+
+  it("posts loadPipeline with structure + trajectory companions resolved relative to the pipeline file", async () => {
+    const provider = getProvider("megane.pipelineViewer");
+    const pipeline = {
+      version: 3,
+      nodes: [
+        { id: "n1", type: "load_structure", fileName: "struct.pdb" },
+        { id: "n2", type: "load_trajectory", fileName: "traj.xtc" },
+      ],
+      edges: [],
+    };
+    mockState.readFile
+      .mockResolvedValueOnce(pipelineBytes(pipeline))
+      .mockResolvedValueOnce(new Uint8Array([1, 2, 3]))
+      .mockResolvedValueOnce(new TextEncoder().encode("ATOM 1"))
+      .mockResolvedValueOnce(new Uint8Array([9, 8, 7]));
+
+    const doc = { uri: VscodeUri.file("/work/pipe.megane.json"), dispose: vi.fn() };
+    const { panel, fireMessage } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    fireMessage({ type: "ready" });
+    expect(panel.webview.postMessage).toHaveBeenCalledTimes(1);
+    const payload = panel.webview.postMessage.mock.calls[0][0] as {
+      type: string;
+      pipeline: unknown;
+      structureFiles: Array<{ nodeId: string; content: string; filename: string }>;
+      trajectoryFiles: Array<{ nodeId: string; content: ArrayBuffer; filename: string }>;
+      wasmBytes: number[];
+    };
+
+    expect(payload.type).toBe("loadPipeline");
+    expect(payload.pipeline).toEqual(pipeline);
+    expect(payload.structureFiles).toEqual([
+      { nodeId: "n1", content: "ATOM 1", filename: "struct.pdb" },
+    ]);
+    expect(payload.trajectoryFiles).toHaveLength(1);
+    expect(payload.trajectoryFiles[0].nodeId).toBe("n2");
+    expect(payload.trajectoryFiles[0].filename).toBe("traj.xtc");
+    expect(new Uint8Array(payload.trajectoryFiles[0].content as ArrayBuffer)).toEqual(
+      new Uint8Array([9, 8, 7]),
+    );
+    expect(payload.wasmBytes).toEqual([1, 2, 3]);
+  });
+
+  it("rejects pipelines whose version is not 3", async () => {
+    const provider = getProvider("megane.pipelineViewer");
+    mockState.readFile
+      .mockResolvedValueOnce(pipelineBytes({ version: 2, nodes: [], edges: [] }))
+      .mockResolvedValueOnce(new Uint8Array());
+
+    const doc = { uri: VscodeUri.file("/work/pipe.megane.json"), dispose: vi.fn() };
+    const { panel, fireMessage } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    fireMessage({ type: "ready" });
+    const payload = panel.webview.postMessage.mock.calls[0][0] as {
+      type: string;
+      message: string;
+    };
+    expect(payload.type).toBe("error");
+    expect(payload.message).toContain("version 3 required");
+    expect(payload.message).toContain("got 2");
+  });
+
+  it("posts an error payload when the pipeline JSON is malformed", async () => {
+    const provider = getProvider("megane.pipelineViewer");
+    mockState.readFile
+      .mockResolvedValueOnce(new TextEncoder().encode("{ not json"))
+      .mockResolvedValueOnce(new Uint8Array());
+
+    const doc = { uri: VscodeUri.file("/work/pipe.megane.json"), dispose: vi.fn() };
+    const { panel, fireMessage } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    fireMessage({ type: "ready" });
+    const payload = panel.webview.postMessage.mock.calls[0][0] as {
+      type: string;
+      message: string;
+    };
+    expect(payload.type).toBe("error");
+    expect(payload.message.length).toBeGreaterThan(0);
+  });
+
+  it("skips nodes referencing absolute fileName paths (path traversal protection)", async () => {
+    const provider = getProvider("megane.pipelineViewer");
+    const pipeline = {
+      version: 3,
+      nodes: [{ id: "n1", type: "load_structure", fileName: "/etc/passwd" }],
+      edges: [],
+    };
+    mockState.readFile
+      .mockResolvedValueOnce(pipelineBytes(pipeline))
+      .mockResolvedValueOnce(new Uint8Array());
+
+    const doc = { uri: VscodeUri.file("/work/pipe.megane.json"), dispose: vi.fn() };
+    const { panel, fireMessage } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    fireMessage({ type: "ready" });
+    const payload = panel.webview.postMessage.mock.calls[0][0] as {
+      structureFiles: unknown[];
+      trajectoryFiles: unknown[];
+    };
+    expect(payload.structureFiles).toEqual([]);
+    expect(payload.trajectoryFiles).toEqual([]);
+    // Only pipeline + wasm read; no companion read attempted.
+    expect(mockState.readFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips nodes whose fileName escapes the pipeline directory", async () => {
+    const provider = getProvider("megane.pipelineViewer");
+    const pipeline = {
+      version: 3,
+      nodes: [{ id: "n1", type: "load_structure", fileName: "../../escape.pdb" }],
+      edges: [],
+    };
+    mockState.readFile
+      .mockResolvedValueOnce(pipelineBytes(pipeline))
+      .mockResolvedValueOnce(new Uint8Array());
+
+    const doc = { uri: VscodeUri.file("/work/sub/pipe.megane.json"), dispose: vi.fn() };
+    const { panel, fireMessage } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    fireMessage({ type: "ready" });
+    const payload = panel.webview.postMessage.mock.calls[0][0] as {
+      structureFiles: unknown[];
+    };
+    expect(payload.structureFiles).toEqual([]);
+    expect(mockState.readFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("silently skips nodes whose companion file cannot be read", async () => {
+    const provider = getProvider("megane.pipelineViewer");
+    const pipeline = {
+      version: 3,
+      nodes: [
+        { id: "n1", type: "load_structure", fileName: "missing.pdb" },
+        { id: "n2", type: "load_trajectory", fileName: "ok.xtc" },
+      ],
+      edges: [],
+    };
+    mockState.readFile
+      .mockResolvedValueOnce(pipelineBytes(pipeline))
+      .mockResolvedValueOnce(new Uint8Array([1]))
+      .mockRejectedValueOnce(new Error("ENOENT")) // missing.pdb
+      .mockResolvedValueOnce(new Uint8Array([4, 5])); // ok.xtc
+
+    const doc = { uri: VscodeUri.file("/work/pipe.megane.json"), dispose: vi.fn() };
+    const { panel, fireMessage } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    fireMessage({ type: "ready" });
+    const payload = panel.webview.postMessage.mock.calls[0][0] as {
+      type: string;
+      structureFiles: Array<{ nodeId: string }>;
+      trajectoryFiles: Array<{ nodeId: string }>;
+    };
+    expect(payload.type).toBe("loadPipeline");
+    expect(payload.structureFiles).toEqual([]);
+    expect(payload.trajectoryFiles).toHaveLength(1);
+    expect(payload.trajectoryFiles[0].nodeId).toBe("n2");
+  });
+
+  it("skips nodes that have no fileName at all", async () => {
+    const provider = getProvider("megane.pipelineViewer");
+    const pipeline = {
+      version: 3,
+      nodes: [
+        { id: "n1", type: "filter" },
+        { id: "n2", type: "load_structure", fileName: null },
+      ],
+      edges: [],
+    };
+    mockState.readFile
+      .mockResolvedValueOnce(pipelineBytes(pipeline))
+      .mockResolvedValueOnce(new Uint8Array());
+
+    const doc = { uri: VscodeUri.file("/work/pipe.megane.json"), dispose: vi.fn() };
+    const { panel, fireMessage } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    fireMessage({ type: "ready" });
+    expect(mockState.readFile).toHaveBeenCalledTimes(2);
+    const payload = panel.webview.postMessage.mock.calls[0][0] as {
+      structureFiles: unknown[];
+    };
+    expect(payload.structureFiles).toEqual([]);
+  });
+
+  it("ignores companion reads for node types other than load_structure / load_trajectory", async () => {
+    const provider = getProvider("megane.pipelineViewer");
+    const pipeline = {
+      version: 3,
+      nodes: [{ id: "n1", type: "filter", fileName: "filter.txt" }],
+      edges: [],
+    };
+    mockState.readFile
+      .mockResolvedValueOnce(pipelineBytes(pipeline))
+      .mockResolvedValueOnce(new Uint8Array());
+
+    const doc = { uri: VscodeUri.file("/work/pipe.megane.json"), dispose: vi.fn() };
+    const { panel, fireMessage } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    fireMessage({ type: "ready" });
+    expect(mockState.readFile).toHaveBeenCalledTimes(2);
+    const payload = panel.webview.postMessage.mock.calls[0][0] as {
+      structureFiles: unknown[];
+      trajectoryFiles: unknown[];
+    };
+    expect(payload.structureFiles).toEqual([]);
+    expect(payload.trajectoryFiles).toEqual([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
         __dirname,
         "tests/ts/__stubs__/jupyterlab-services.ts",
       ),
+      // `vscode` is injected by the VS Code extension host at runtime and is
+      // not present in any node_modules. Tests mock it via vi.mock(); the stub
+      // only needs to satisfy resolution.
+      vscode: path.resolve(__dirname, "tests/ts/__stubs__/vscode.ts"),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Phase 7 of `docs/plans/test-coverage-roadmap.md`: 22 unit tests for `vscode-megane/src/extension.ts` exercising both `CustomReadonlyEditorProvider`s (`structureViewer`, `pipelineViewer`).

- `activate / deactivate` — provider registration order, subscription pushes, `retainContextWhenHidden: true`, `supportsMultipleEditorsPerDocument: false`, deactivate no-op
- `MeganeEditorProvider` — `openCustomDocument` shape; `webview.options` (`enableScripts` + media-only `localResourceRoots`); `loadFile` payload (`contentBytes` / `filename` / `wasmBytes`) on `ready`; non-`ready` messages ignored; `Error` and non-`Error` rejection paths produce `{ type: "error", message }`; HTML CSP / `__MEGANE_CONTEXT__ = "vscode"` / fresh 32-char nonce; `MEGANE_E2E_MODE=1` toggles `window.__MEGANE_TEST__`
- `MeganePipelineEditorProvider` — pipeline + companion file payload; `version !== 3` rejection; malformed JSON rejection; absolute-path traversal rejection (`/etc/passwd`); directory-escape rejection (`../../escape.pdb`); silent skip of missing companion files; nodes without `fileName` skipped; non-`load_*` node types skipped

## Approach

The `vscode` module is injected by the extension host at runtime and is not in any `node_modules`. Following the existing `@jupyterlab/*` pattern:

- Add `tests/ts/__stubs__/vscode.ts` (minimal `Uri` / `workspace.fs.readFile` / `window.registerCustomEditorProvider`) so vite import-analysis resolves
- Add `vscode` → stub alias in `vitest.config.ts`
- Per-test behavior comes from `vi.hoisted` + `vi.mock("vscode", () => ({...}))`, capturing each registered provider so `openCustomDocument` / `resolveCustomEditor` can be invoked directly

## Out of scope (deferred)

`vscode-megane/webview/main.tsx` requires splitting its message handler into pure functions before unit testing is meaningful. The roadmap explicitly defers this to a separate task; E2E coverage (`tests/e2e/vscode-*.spec.ts`) continues to cover the integrated flow.

## Test plan

- [x] `npm run build:wasm`
- [x] `npx vitest run` — 60 files, 673 tests pass (incl. 22 new)
- [x] `npx vitest run tests/ts/vscode/` — 22 pass
- [x] `npm run lint` — no new errors (only pre-existing warnings in `src/`)
- [x] `npm run format:check` — clean
- [ ] CI green on PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2fwGHGYR6E9qC5Ag1x2oc)_