### PR TITLE
fix(bonds): reuse InstancedBufferAttributes to stop per-frame GPU leak

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -134,6 +134,12 @@ export default defineConfig({
       use: { baseURL: `http://127.0.0.1:${PORT_WEBAPP}` },
     },
     {
+      name: "trajectory-bonds-vdw-leak",
+      testMatch: /trajectory-bonds-vdw-leak\.spec\.ts$/,
+      timeout: 120_000,
+      use: { baseURL: `http://127.0.0.1:${PORT_WEBAPP}` },
+    },
+    {
       name: "sidebar",
       testMatch: /sidebar\.spec\.ts$/,
       use: { baseURL: `http://127.0.0.1:${PORT_WEBAPP}` },

--- a/src/renderer/ImpostorBondMesh.ts
+++ b/src/renderer/ImpostorBondMesh.ts
@@ -47,6 +47,18 @@ export class ImpostorBondMesh {
   private opacityBuf: Float32Array; // per-visual-instance opacity override
   private logicalBondIdx: Float32Array; // CPU-only: maps visual instance → logical bond index
 
+  // Persistent InstancedBufferAttribute references. Recreated only when the
+  // backing typed arrays are reallocated by grow(); otherwise we just flip
+  // needsUpdate to re-upload, so the old GL buffer is reused (and not leaked).
+  private atomAAttr!: THREE.InstancedBufferAttribute;
+  private atomBAttr!: THREE.InstancedBufferAttribute;
+  private offsetXAttr!: THREE.InstancedBufferAttribute;
+  private offsetYAttr!: THREE.InstancedBufferAttribute;
+  private colorAttr!: THREE.InstancedBufferAttribute;
+  private radiusAttr!: THREE.InstancedBufferAttribute;
+  private dashedAttr!: THREE.InstancedBufferAttribute;
+  private opacityAttr!: THREE.InstancedBufferAttribute;
+
   // Position DataTexture (updated per frame)
   private positionTex: THREE.DataTexture;
   private positionTexData: Float32Array;
@@ -220,10 +232,12 @@ export class ImpostorBondMesh {
     // Reset per-bond override mode when loading a new snapshot
     this.bondMaterial.uniforms.uUsePerBondOverrides.value = 0;
 
-    // Recreate all InstancedBufferAttributes and re-register them.
-    // This forces Three.js to create new GPU buffers, ensuring data
-    // is uploaded even when loadSnapshot() is called repeatedly.
-    this.registerAttributes();
+    // Re-upload existing GL buffers in place. Recreating the
+    // InstancedBufferAttributes here would orphan the previous GL buffers
+    // (Three.js only frees them on the attribute's own dispose event), and
+    // when bondSource="distance" loadSnapshot runs every frame — that path
+    // exhausted GPU memory and triggered WebGL context loss.
+    this.markAttributesDirty();
     this.geo.instanceCount = idx;
   }
 
@@ -271,25 +285,71 @@ export class ImpostorBondMesh {
     }
   }
 
-  /** Recreate all instance attributes and re-register with geometry. */
+  /**
+   * (Re)allocate all instance attributes and register them with the
+   * geometry. Disposes any previously-held attributes first so their GL
+   * buffers are released — this is the only path that should churn GPU
+   * memory, and it only runs at construction and when grow() reallocates
+   * the typed arrays.
+   */
   private registerAttributes(): void {
-    const atomA = new THREE.InstancedBufferAttribute(this.atomABuf, 1);
-    const atomB = new THREE.InstancedBufferAttribute(this.atomBBuf, 1);
-    const offsetX = new THREE.InstancedBufferAttribute(this.offsetXBuf, 1);
-    const offsetY = new THREE.InstancedBufferAttribute(this.offsetYBuf, 1);
-    const color = new THREE.InstancedBufferAttribute(this.colorBuf, 3);
-    const radius = new THREE.InstancedBufferAttribute(this.radiusBuf, 1);
-    const dashed = new THREE.InstancedBufferAttribute(this.dashedBuf, 1);
-    const opacity = new THREE.InstancedBufferAttribute(this.opacityBuf, 1);
+    this.disposeAttributes();
 
-    this.geo.setAttribute("instanceAtomA", atomA);
-    this.geo.setAttribute("instanceAtomB", atomB);
-    this.geo.setAttribute("instanceOffsetX", offsetX);
-    this.geo.setAttribute("instanceOffsetY", offsetY);
-    this.geo.setAttribute("instanceColor", color);
-    this.geo.setAttribute("instanceRadius", radius);
-    this.geo.setAttribute("instanceDashed", dashed);
-    this.geo.setAttribute("instanceBondOpacity", opacity);
+    this.atomAAttr = new THREE.InstancedBufferAttribute(this.atomABuf, 1);
+    this.atomBAttr = new THREE.InstancedBufferAttribute(this.atomBBuf, 1);
+    this.offsetXAttr = new THREE.InstancedBufferAttribute(this.offsetXBuf, 1);
+    this.offsetYAttr = new THREE.InstancedBufferAttribute(this.offsetYBuf, 1);
+    this.colorAttr = new THREE.InstancedBufferAttribute(this.colorBuf, 3);
+    this.radiusAttr = new THREE.InstancedBufferAttribute(this.radiusBuf, 1);
+    this.dashedAttr = new THREE.InstancedBufferAttribute(this.dashedBuf, 1);
+    this.opacityAttr = new THREE.InstancedBufferAttribute(this.opacityBuf, 1);
+
+    this.geo.setAttribute("instanceAtomA", this.atomAAttr);
+    this.geo.setAttribute("instanceAtomB", this.atomBAttr);
+    this.geo.setAttribute("instanceOffsetX", this.offsetXAttr);
+    this.geo.setAttribute("instanceOffsetY", this.offsetYAttr);
+    this.geo.setAttribute("instanceColor", this.colorAttr);
+    this.geo.setAttribute("instanceRadius", this.radiusAttr);
+    this.geo.setAttribute("instanceDashed", this.dashedAttr);
+    this.geo.setAttribute("instanceBondOpacity", this.opacityAttr);
+  }
+
+  private disposeAttributes(): void {
+    // Three.js' WebGLAttributes registers a `dispose` listener on each
+    // BufferAttribute and frees the GL buffer when the event fires.
+    // BufferAttribute extends EventDispatcher at runtime but @types/three
+    // 0.183 omits it, so we cast to a minimal disposable shape. Without
+    // this, swapping attributes via setAttribute leaks the previous GL
+    // buffers — fatal under per-frame VDW bond recalculation.
+    type Disposable = {
+      dispose?: () => void;
+      dispatchEvent?: (e: { type: string }) => void;
+    };
+    const dispose = (a: THREE.InstancedBufferAttribute | undefined) => {
+      if (!a) return;
+      const d = a as unknown as Disposable;
+      if (typeof d.dispose === "function") d.dispose();
+      else d.dispatchEvent?.({ type: "dispose" });
+    };
+    dispose(this.atomAAttr);
+    dispose(this.atomBAttr);
+    dispose(this.offsetXAttr);
+    dispose(this.offsetYAttr);
+    dispose(this.colorAttr);
+    dispose(this.radiusAttr);
+    dispose(this.dashedAttr);
+    dispose(this.opacityAttr);
+  }
+
+  private markAttributesDirty(): void {
+    this.atomAAttr.needsUpdate = true;
+    this.atomBAttr.needsUpdate = true;
+    this.offsetXAttr.needsUpdate = true;
+    this.offsetYAttr.needsUpdate = true;
+    this.colorAttr.needsUpdate = true;
+    this.radiusAttr.needsUpdate = true;
+    this.dashedAttr.needsUpdate = true;
+    this.opacityAttr.needsUpdate = true;
   }
 
   private grow(needed: number): void {

--- a/src/renderer/MoleculeRenderer.ts
+++ b/src/renderer/MoleculeRenderer.ts
@@ -99,12 +99,18 @@ export interface MeganeSubsystemVisibility {
   polyhedra: boolean;
 }
 
+export interface MeganeRendererMemory {
+  geometries: number;
+  textures: number;
+}
+
 export interface MeganeTestApi {
   getProjectedAtomPositions: () => MeganeProjectedAtom[];
   getCameraState: () => MeganeCameraState | null;
   getVisibleSubsystems: () => MeganeSubsystemVisibility;
   setCameraMode: (mode: MeganeCameraMode) => void;
   resetCamera: () => void;
+  getRendererMemory: () => MeganeRendererMemory | null;
 }
 
 let _activeRenderer: MoleculeRenderer | null = null;
@@ -136,6 +142,10 @@ function _setActiveRenderer(r: MoleculeRenderer | null): void {
             },
       setCameraMode: (mode) => _activeRenderer?.setCameraMode(mode),
       resetCamera: () => _activeRenderer?.resetCamera(),
+      getRendererMemory: () => {
+        const info = _activeRenderer?.getRenderer().info.memory;
+        return info ? { geometries: info.geometries, textures: info.textures } : null;
+      },
     };
   }
 }

--- a/tests/e2e/trajectory-bonds-vdw-leak.spec.ts
+++ b/tests/e2e/trajectory-bonds-vdw-leak.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * Regression spec for the VDW (distance-based) AddBond crash on long
+ * trajectory playback.
+ *
+ * Bug: when the user set AddBond.source to "vdw" (params.bondSource ===
+ * "distance") on the default caffeine_water trajectory, every frame ran
+ * `ImpostorBondMesh.loadSnapshot()`, which unconditionally rebuilt all
+ * eight `InstancedBufferAttribute`s. Three.js' WebGLAttributes keeps
+ * each attribute's GL buffer alive until the attribute itself fires
+ * `dispose`, so replacing them via setAttribute leaked one set of
+ * GPU buffers per frame. After ~100–300 frames the WebGL context was
+ * lost and the browser hard-reloaded the page.
+ *
+ * This spec drives many more frame swaps than the leaky path can
+ * survive and asserts:
+ *   1. No `webglcontextlost` event fires on the bond canvas.
+ *   2. The page does not navigate (reload).
+ *   3. Rendering keeps up — `renderEpoch` advances at least once per
+ *      seek, proving the renderer is still alive at the end.
+ *   4. Three.js' renderer.info.memory is bounded (geometries/textures
+ *      do not grow unboundedly, even though Three.js does not count
+ *      orphaned attribute GL buffers there — kept as a sanity check).
+ */
+
+import { test, expect } from "playwright/test";
+import { waitForReady, getReadyState } from "./lib/setup";
+import { findNodeIdByType, setNodeParam } from "./lib/pipeline";
+
+const FRAME_SWAPS = 250;
+const TRAJECTORY_LENGTH = 5; // caffeine_water_vibration.xtc
+
+test.describe.configure({ mode: "serial" });
+
+test("trajectory-bonds-vdw-leak: 250 frame swaps with bondSource=distance survives without WebGL context loss", async ({
+  page,
+}) => {
+  // The leaky path empirically kills the renderer in ~100–300 frames;
+  // 250 swaps is comfortably above that threshold but the loop itself
+  // costs ~1 rAF per swap so we extend the per-test budget.
+  test.setTimeout(90_000);
+  const recordedEvents: string[] = [];
+
+  await page.exposeFunction("__megane_record_event", (name: string) => {
+    recordedEvents.push(name);
+  });
+
+  await page.addInitScript(() => {
+    const w = window as Window & {
+      __megane_record_event?: (name: string) => void;
+      __megane_canvas_listener_installed?: boolean;
+    };
+    const tryAttach = () => {
+      if (w.__megane_canvas_listener_installed) return;
+      const canvas = document.querySelector(
+        '[data-testid="megane-viewer"] canvas',
+      ) as HTMLCanvasElement | null;
+      if (!canvas) return;
+      canvas.addEventListener("webglcontextlost", () => {
+        w.__megane_record_event?.("webglcontextlost");
+      });
+      w.__megane_canvas_listener_installed = true;
+    };
+    const observer = new MutationObserver(tryAttach);
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+    tryAttach();
+  });
+
+  await page.goto("/?test=1", { waitUntil: "domcontentloaded" });
+  await waitForReady(page);
+
+  // Attach navigation listener AFTER the initial goto so we only see
+  // unexpected reloads triggered by the renderer (the bug under test
+  // crashed the GPU process which the browser recovers from with a
+  // hard reload of the renderer process).
+  page.on("framenavigated", (frame) => {
+    if (frame === page.mainFrame()) recordedEvents.push("framenavigated");
+  });
+
+  // Switch the default add_bond node from "structure" to "distance"
+  // (the VDW source) and wait for the resulting render epoch.
+  const before = await getReadyState(page);
+  const bondNodeId = await findNodeIdByType(page, "add_bond");
+  await setNodeParam(page, bondNodeId, { bondSource: "distance" });
+  await waitForReady(page, { untilEpoch: before.renderEpoch + 1, timeout: 10_000 });
+
+  // Sanity: bonds were inferred and the listener attached.
+  const bondCount = await page
+    .locator('[data-testid="megane-viewer"]')
+    .first()
+    .getAttribute("data-bond-count");
+  expect(Number(bondCount)).toBeGreaterThan(100);
+
+  const memBefore = await page.evaluate(() => {
+    const w = window as Window & {
+      __megane_test?: { getRendererMemory?: () => { geometries: number; textures: number } | null };
+    };
+    return w.__megane_test?.getRendererMemory?.() ?? null;
+  });
+  expect(memBefore, "renderer memory hook must be exposed in test mode").not.toBeNull();
+
+  const epochBefore = (await getReadyState(page)).renderEpoch;
+
+  // Drive frame swaps inside the page so we don't pay the Playwright
+  // round-trip per iteration. Each iteration seeks to a new frame and
+  // waits one rAF for the renderer to react. Frame budget guards
+  // against GPU-driver slowdown — the leaky path quickly accumulates
+  // hundreds of orphaned GL buffers, which makes each rAF take far
+  // longer than steady-state.
+  const loopReport = await page.evaluate(
+    async ([swaps, length, maxFrameMs]: [number, number, number]) => {
+      const w = window as unknown as {
+        __megane_test_playback_store?: {
+          getState: () => { seekFrame: (i: number) => void };
+        };
+      };
+      const store = w.__megane_test_playback_store;
+      if (!store) throw new Error("__megane_test_playback_store not exposed");
+      const start = performance.now();
+      let worst = 0;
+      for (let i = 0; i < swaps; i++) {
+        const t0 = performance.now();
+        store.getState().seekFrame(i % length);
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+        const dt = performance.now() - t0;
+        if (dt > worst) worst = dt;
+        if (dt > maxFrameMs) {
+          return { completed: i + 1, total: swaps, worstMs: worst, bailed: true };
+        }
+      }
+      return { completed: swaps, total: swaps, worstMs: worst, totalMs: performance.now() - start, bailed: false };
+    },
+    [FRAME_SWAPS, TRAJECTORY_LENGTH, 1500],
+  );
+  expect(
+    loopReport.bailed,
+    `frame loop bailed at swap ${loopReport.completed}/${loopReport.total}, worst frame ${loopReport.worstMs.toFixed(1)}ms — likely GPU buffer leak`,
+  ).toBe(false);
+
+  // Reload / context-loss detection.
+  expect(recordedEvents, `unexpected events during playback: ${recordedEvents.join(", ")}`).not.toContain(
+    "webglcontextlost",
+  );
+  expect(recordedEvents).not.toContain("framenavigated");
+
+  // Renderer must still be alive and have advanced through the swaps.
+  const epochAfter = (await getReadyState(page)).renderEpoch;
+  expect(
+    epochAfter - epochBefore,
+    `renderer stalled: epoch advanced ${epochAfter - epochBefore} of ${FRAME_SWAPS} expected`,
+  ).toBeGreaterThanOrEqual(FRAME_SWAPS / 2);
+
+  // Three.js geometry/texture counts shouldn't grow unboundedly. (Note:
+  // Three.js does not count orphaned BufferAttribute GL buffers here, so
+  // this is a soft check — the primary signal is webglcontextlost above.)
+  const memAfter = await page.evaluate(() => {
+    const w = window as Window & {
+      __megane_test?: { getRendererMemory?: () => { geometries: number; textures: number } | null };
+    };
+    return w.__megane_test?.getRendererMemory?.() ?? null;
+  });
+  expect(memAfter).not.toBeNull();
+  expect(memAfter!.geometries - memBefore!.geometries).toBeLessThan(20);
+  expect(memAfter!.textures - memBefore!.textures).toBeLessThan(20);
+
+  // Final live-renderer check: bond count is still plausible after the loop.
+  const bondCountAfter = await page
+    .locator('[data-testid="megane-viewer"]')
+    .first()
+    .getAttribute("data-bond-count");
+  expect(Number(bondCountAfter)).toBeGreaterThan(100);
+});


### PR DESCRIPTION
## Summary

When `AddBond` `source` was set to **VDW** (`bondSource: "distance"`) on a multi-frame trajectory — including the default caffeine-in-water demo — the viewer crashed after a few hundred frames and the browser hard-reloaded the page. The root cause was a per-frame GPU buffer leak in `ImpostorBondMesh`.

`MeganeViewer.tsx:175-209` recomputes bonds every frame for `bondSource === "distance"` and pushes them through `MoleculeRenderer.updateBondsExt(...)` → `ImpostorBondMesh.loadSnapshot()`. `loadSnapshot()` unconditionally called `registerAttributes()`, which constructed eight new `THREE.InstancedBufferAttribute` instances and replaced the geometry's attribute slots via `setAttribute`. Three.js' `WebGLAttributes` only frees an attribute's GL buffer when the attribute itself fires its `dispose` event, so each per-frame `setAttribute` swap orphaned eight live GL buffers. On caffeine_water (3024 atoms, ~3000 vdw bonds) this exhausted GPU memory within ~100–300 frames, triggering `webglcontextlost` and a renderer-process reload.

## Fix

`src/renderer/ImpostorBondMesh.ts`

- Hold the eight `InstancedBufferAttribute`s as instance fields.
- In the common per-frame path (`loadSnapshot` → `markAttributesDirty`) just flip `needsUpdate`, so the existing GL buffers are re-uploaded with the new topology data instead of being orphaned.
- Only re-create the attributes when `grow()` reallocates the backing typed arrays. In that path, `disposeAttributes()` dispatches `dispose` on each previous attribute first so its GL buffer is actually released.

`bondSource: "structure"` (the default) was unaffected because `loadSnapshot` runs only once at load — but the fix is general and removes per-frame buffer churn for both paths.

## Regression test

`tests/e2e/trajectory-bonds-vdw-leak.spec.ts` (new project `trajectory-bonds-vdw-leak` in `playwright.config.ts`):

1. Loads the webapp default (caffeine_water, 3024 atoms, 5 frames) with `?test=1`.
2. Flips the `add_bond` node to `bondSource: "distance"` (= VDW).
3. Drives **250 frame swaps** in a tight rAF loop inside `page.evaluate`, with a 1.5 s per-iteration time budget that bails out fast when GPU work compounds.
4. Asserts no `webglcontextlost`, no page navigation, `renderEpoch` advanced, `renderer.info.memory` is bounded, and `data-bond-count` stays plausible.

Validated against the buggy code: bails at swap ~89/250 with a worst-frame latency of ~3 s. With the fix: passes with steady frame timing.

A small renderer-side hook is added: `MeganeTestApi.getRendererMemory()` returns `{ geometries, textures }` from `THREE.WebGLRenderer.info.memory`, only in test mode.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npm test` (vitest) — 680 passed
- [x] `npx playwright test --project=trajectory-bonds-vdw-leak` — passes on fix; fails on the buggy revision (verified by stash + rerun)
- [x] `npx playwright test --project=webapp` — 4/4 passed
- [ ] Pixel-baseline specs (`playback`, `contract`, `trajectory-bonds__webapp`) show pre-existing baseline drift (~85% pixel diff on the rendered viewer region) on this dev environment. Verified that the same drift exists on `main` without my changes — not caused by this PR.

https://claude.ai/code/session_011EMkwTVbH6j5F5NfKwwp54

---
_Generated by [Claude Code](https://claude.ai/code/session_011EMkwTVbH6j5F5NfKwwp54)_