### PR TITLE
feat(hosts): open .mol2 files in JupyterLab and VSCode extensions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -7,7 +7,7 @@ cat <<'JSON'
 {
   "hookSpecificOutput": {
     "hookEventName": "SessionStart",
-    "additionalContext": "## megane project bootstrap (MANDATORY)\n\nBefore producing your first response to the user, you MUST:\n\n1. Re-read the CRITICAL RULES section of CLAUDE.md and follow them strictly. They are the authoritative list; do not paraphrase or substitute remembered rules.\n2. Confirm via the `available skills` section of the system reminder that the 9 megane skills are loaded (`commit`, `github-cli`, `dev-setup`, `build`, `testing`, `e2e-coverage`, `preview`, `pre-release`, `post-release`). If any are missing, warn the user and suggest checking `.claude/skills/`.\n\nDo not skip these steps even on resumed/compacted sessions."
+    "additionalContext": "## megane project bootstrap (MANDATORY)\n\nBefore producing your first response to the user, you MUST:\n\n1. Re-read the CRITICAL RULES section of CLAUDE.md and follow them strictly. They are the authoritative list; do not paraphrase or substitute remembered rules.\n2. Confirm via the `available skills` section of the system reminder that the 10 megane skills are loaded (`commit`, `github-cli`, `dev-setup`, `build`, `testing`, `e2e-coverage`, `preview`, `pre-release`, `post-release`, `add-format`). If any are missing, warn the user and suggest checking `.claude/skills/`.\n\nDo not skip these steps even on resumed/compacted sessions."
   }
 }
 JSON

--- a/.claude/skills/add-format/SKILL.md
+++ b/.claude/skills/add-format/SKILL.md
@@ -1,0 +1,86 @@
+---
+description: Register a new file format across every megane host (standalone webapp, Jupyter widget, JupyterLab labextension, VSCode extension, Python). Use whenever you add a parser to `megane-core`, expose it via WASM/PyO3, or notice that an existing parser is missing from one of the host openers. Enforces CRITICAL RULE #6 in CLAUDE.md.
+---
+
+# Adding a new file format to megane
+
+A new format is **not done** until it is openable on every host where it makes sense. The Rust core, WASM bindings, and Python bindings only get you the parser — each host has a separate registration point and they drift independently. This checklist mirrors CRITICAL RULE #6 in `CLAUDE.md`.
+
+## When to use this skill
+
+- Adding a new parser to `crates/megane-core/`.
+- Exposing an existing core parser through WASM or PyO3 for the first time.
+- Reviewing a bug report like "format X works on the webapp but won't open in VSCode / JupyterLab".
+- Bumping an existing format's host coverage (e.g. trajectory format that was Standalone-only).
+
+## Registration checklist
+
+Walk every item. Skipping one means the format silently fails on at least one host.
+
+### 1. Core + bindings
+
+- [ ] `crates/megane-core/src/<format>.rs` — parser implementation + unit tests.
+- [ ] `crates/megane-core/src/lib.rs` — module export.
+- [ ] `crates/megane-wasm/src/lib.rs` — `pub use ... <format>` and `#[wasm_bindgen] pub fn parse_<format>(text|bytes) -> Result<ParseResult, JsError>`.
+- [ ] `crates/megane-python/src/lib.rs` — PyO3 `parse_<format>` if you want Python API access.
+- [ ] Run `npm run build:wasm` and `maturin develop --release` so downstream code can resolve the new symbol.
+
+### 2. TypeScript parser dispatch (shared by **all** browser hosts)
+
+- [ ] `src/parsers/structure.ts` — add the new export to the `WasmModule` interface, hook it up in the dynamic `import("../../crates/megane-wasm/pkg/megane_wasm.js")` block, and add a `case ".<ext>":` to `getParserForExtension`. (Trajectory formats: `src/parsers/trajectory.ts` instead.)
+
+This is the only file that knows how to dispatch by extension; every host below relies on it.
+
+### 3. Standalone webapp openers
+
+- [ ] `src/components/nodes/LoadStructureNode.tsx` — append `.<ext>` to **both** `STRUCTURE_ACCEPT` (file dialog filter) and `STRUCTURE_EXTS` (drag-drop guard).
+- [ ] `src/components/nodes/LoadTrajectoryNode.tsx` — same, if it is a trajectory format.
+
+### 4. JupyterLab labextension
+
+- [ ] `jupyterlab-megane/src/filetypes.ts` — add a new entry to either `STRUCTURE_FILETYPES_TEXT` or `STRUCTURE_FILETYPES_BINARY` (binary needs `fileFormat: "base64"`). The labextension iterates these arrays at activation, so adding the entry is sufficient — no other wiring needed.
+
+### 5. VSCode extension
+
+- [ ] `vscode-megane/package.json` — add `{ "filenamePattern": "*.<ext>" }` to the `megane.structureViewer` `customEditors[0].selector` array.
+- [ ] `vscode-megane/package.json` — extend the top-level `description` so the marketplace listing mentions the new format.
+
+### 6. Documentation
+
+- [ ] `docs/docs/platform-support.md` — add a row to the Structure or Trajectory table with the correct symbols (`✓` / `API` / `—`) for every host. **`platform-support.md` is the single source of truth** — don't leave it stale.
+- [ ] `README.md` — add a row to the format table near the existing PDB / GRO / … entries.
+- [ ] If the format has format-specific quirks (e.g. trajectory needs topology), add a note next to the table.
+
+### 7. Tests + fixtures
+
+- [ ] `tests/fixtures/<sample>.<ext>` — commit a small but realistic fixture.
+- [ ] Rust unit test in the new `<format>.rs`.
+- [ ] TypeScript test in `src/parsers/__tests__/` if dispatch logic is non-trivial.
+- [ ] Optional: add the fixture to an existing E2E spec (e.g. `tests/e2e/format-loading.spec.ts`) so the matrix exercises the new opener on every host. E2E is local-only — re-baseline with `MEGANE_E2E_UPDATE=1` per the `e2e-coverage` skill.
+
+### 8. Verification
+
+- [ ] `cargo test -p megane-core`
+- [ ] `npm run build:wasm && npm test`
+- [ ] `npm run build` (catches Vite, JupyterLab, and webview bundle issues at once)
+- [ ] Manual smoke test: open the new fixture from the webapp file dialog **and** from at least one host extension (JupyterLab file browser or VSCode explorer) before declaring done.
+
+## Common omissions caught by this checklist
+
+| Symptom | Missing step |
+|---|---|
+| Format works on webapp but VSCode shows "no editor" | §5 — `customEditors` selector |
+| Format silently rejected by drag-drop in webapp | §3 — `STRUCTURE_EXTS` (different from `STRUCTURE_ACCEPT`) |
+| Double-click in JupyterLab opens it as plain text | §4 — `filetypes.ts` registration |
+| `parseStructureText` falls back to PDB and produces garbage | §2 — `getParserForExtension` switch case |
+| `platform-support.md` claims `✓` but the host can't open it | §6 — table not updated alongside code |
+
+## Source-of-truth pointers
+
+These match CLAUDE.md CRITICAL RULE #6:
+
+- Browser parsers: `crates/megane-wasm/src/lib.rs`
+- Standalone accept lists: `src/components/nodes/LoadStructureNode.tsx`, `src/components/nodes/LoadTrajectoryNode.tsx`
+- JupyterLab filetypes: `jupyterlab-megane/src/filetypes.ts`
+- VSCode customEditors: `vscode-megane/package.json`
+- Cross-host status: `docs/docs/platform-support.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 3. **Always build WASM before running the dev server or full build.** The WASM pkg directory (`crates/megane-wasm/pkg/`) does not exist until `npm run build:wasm` is run.
 4. **Always create a PR after pushing changes.** Use `gh pr create` to open a pull request. PR titles and descriptions must be in English. See the `github-cli` skill for remote URL workaround. Before reporting completion, verify CI passes with `gh run list`.
 5. **In plan mode, strictly follow the approved plan.** Do not skip steps, reorder them, or add unplanned work. If the plan needs changes, explain the reason and get approval before deviating.
-6. **All file formats should behave consistently across hosts.** When you add a parser or feature to one platform (standalone webapp, Jupyter widget, JupyterLab labextension, VSCode extension), register it on every host unless there is a host-specific reason not to. The single source of truth is `docs/docs/platform-support.md`; update its tables in the same PR. Host registration points: `crates/megane-wasm/src/lib.rs` (browser parsers), `src/components/nodes/LoadStructureNode.tsx` / `LoadTrajectoryNode.tsx` (standalone accept lists), `jupyterlab-megane/src/filetypes.ts`, `vscode-megane/package.json` `customEditors`.
+6. **All file formats should behave consistently across hosts.** When you add a parser or feature to one platform (standalone webapp, Jupyter widget, JupyterLab labextension, VSCode extension), register it on every host unless there is a host-specific reason not to. The single source of truth is `docs/docs/platform-support.md`; update its tables in the same PR. Host registration points: `crates/megane-wasm/src/lib.rs` (browser parsers), `src/components/nodes/LoadStructureNode.tsx` / `LoadTrajectoryNode.tsx` (standalone accept lists), `jupyterlab-megane/src/filetypes.ts`, `vscode-megane/package.json` `customEditors`. Walk the full checklist in the `add-format` skill — drift between hosts is the #1 source of "format X works in the webapp but not in VSCode/JupyterLab" bugs.
 7. **The Jupyter widget (anywidget `MolecularViewer`) does not mount the visual pipeline editor.** Pipeline data still flows in via `MolecularViewer.set_pipeline()` (`_pipeline_json` + `_node_snapshots_data`), but the in-cell `PipelineEditor` UI is intentionally not rendered — the host cell chrome cannot reliably lay it out. Do not re-introduce a `pipeline=True` opt-in or a `_pipeline_enabled` traitlet. Visual editing lives in the standalone webapp, JupyterLab labextension, and VSCode extension only.
 
 ## Dev Environment Setup
@@ -102,8 +102,9 @@ A SessionStart hook (`.claude/hooks/session-start.sh`) injects a reminder pointi
 | `preview` | Screenshot/video capture for visual review |
 | `pre-release` | Pre-release checklist (tests, version bump, dry-run, tag) |
 | `post-release` | Post-release verification (publish workflows, package availability, docs) |
+| `add-format` | Per-host registration checklist for new file formats (enforces CRITICAL RULE #6) |
 
-Total: 9 skills.
+Total: 10 skills.
 
 ## Architecture
 

--- a/jupyterlab-megane/src/filetypes.ts
+++ b/jupyterlab-megane/src/filetypes.ts
@@ -57,6 +57,14 @@ export const STRUCTURE_FILETYPES_TEXT: DocumentRegistry.IFileType[] = [
     contentType: "file",
   },
   {
+    name: "megane-mol2",
+    displayName: "MOL2",
+    extensions: [".mol2"],
+    mimeTypes: ["chemical/x-mol2"],
+    fileFormat: "text",
+    contentType: "file",
+  },
+  {
     name: "megane-cif",
     displayName: "CIF",
     extensions: [".cif"],

--- a/src/components/nodes/LoadStructureNode.tsx
+++ b/src/components/nodes/LoadStructureNode.tsx
@@ -13,13 +13,14 @@ import { NodeShell } from "./NodeShell";
 import { smallBtnStyle, fileNameStyle } from "../ui";
 import { useRef, useCallback } from "react";
 
-const STRUCTURE_ACCEPT = ".pdb,.gro,.xyz,.mol,.sdf,.cif,.data,.lammps,.traj";
+const STRUCTURE_ACCEPT = ".pdb,.gro,.xyz,.mol,.sdf,.mol2,.cif,.data,.lammps,.traj";
 const STRUCTURE_EXTS = [
   ".pdb",
   ".gro",
   ".xyz",
   ".mol",
   ".sdf",
+  ".mol2",
   ".cif",
   ".data",
   ".lammps",

--- a/tests/ts/jupyterlab/filetypes.test.ts
+++ b/tests/ts/jupyterlab/filetypes.test.ts
@@ -34,11 +34,11 @@ describe("jupyterlab filetypes", () => {
     expect(PIPELINE_FILETYPE.contentType).toBe("file");
   });
 
-  it("ships eight text structure filetypes (incl. LAMMPS dump trajectory)", () => {
-    expect(STRUCTURE_FILETYPES_TEXT).toHaveLength(8);
+  it("ships nine text structure filetypes (incl. LAMMPS dump trajectory)", () => {
+    expect(STRUCTURE_FILETYPES_TEXT).toHaveLength(9);
   });
 
-  it("includes the canonical PDB / GRO / XYZ / MOL / SDF / CIF / LAMMPS-data / LAMMPS-dump names", () => {
+  it("includes the canonical PDB / GRO / XYZ / MOL / SDF / MOL2 / CIF / LAMMPS-data / LAMMPS-dump names", () => {
     const names = STRUCTURE_FILETYPES_TEXT.map((f) => f.name).sort();
     expect(names).toEqual(
       [
@@ -47,6 +47,7 @@ describe("jupyterlab filetypes", () => {
         "megane-xyz",
         "megane-mol",
         "megane-sdf",
+        "megane-mol2",
         "megane-cif",
         "megane-lammps-data",
         "megane-lammps-dump",
@@ -100,7 +101,7 @@ describe("jupyterlab filetypes", () => {
     expect(STRUCTURE_FILETYPE_NAMES_BINARY).toEqual(
       STRUCTURE_FILETYPES_BINARY.map((f) => f.name),
     );
-    expect(STRUCTURE_FILETYPE_NAMES_TEXT).toHaveLength(8);
+    expect(STRUCTURE_FILETYPE_NAMES_TEXT).toHaveLength(9);
     expect(STRUCTURE_FILETYPE_NAMES_BINARY).toHaveLength(2);
   });
 });

--- a/tests/ts/vscode/packageManifest.test.ts
+++ b/tests/ts/vscode/packageManifest.test.ts
@@ -29,6 +29,7 @@ describe("vscode-megane package.json", () => {
         "*.lammps",
         "*.lammpstrj",
         "*.mol",
+        "*.mol2",
         "*.pdb",
         "*.sdf",
         "*.traj",

--- a/vscode-megane/package.json
+++ b/vscode-megane/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-megane",
   "displayName": "megane - Molecular Viewer",
-  "description": "View molecular structure files (PDB, GRO, XYZ, MOL, SDF, CIF, LAMMPS data, ASE traj, XTC, LAMMPS dump) with megane",
+  "description": "View molecular structure files (PDB, GRO, XYZ, MOL, SDF, MOL2, CIF, LAMMPS data, ASE traj, XTC, LAMMPS dump) with megane",
   "version": "0.7.0",
   "publisher": "hodakamori",
   "license": "MIT",
@@ -37,6 +37,9 @@
           },
           {
             "filenamePattern": "*.sdf"
+          },
+          {
+            "filenamePattern": "*.mol2"
           },
           {
             "filenamePattern": "*.cif"


### PR DESCRIPTION
## Summary

The MOL2 parser already existed in `megane-core` and WASM (`parse_mol2`), and `src/parsers/structure.ts` dispatched `.mol2` correctly — but the standalone webapp file dialog, JupyterLab labextension, and VSCode `customEditor` never registered the extension. The ✓ marks for MOL2 in `docs/docs/platform-support.md` were therefore aspirational on those hosts: opening a `.mol2` from the JupyterLab file browser or VS Code explorer fell through to a plain text editor.

This PR wires `.mol2` into every host registration point listed in `CLAUDE.md` CRITICAL RULE #6, so MOL2 can be opened from any host UI just like PDB / GRO / XYZ / MOL / SDF.

## Changes

- **Standalone webapp** — `src/components/nodes/LoadStructureNode.tsx`: add `.mol2` to both `STRUCTURE_ACCEPT` (file dialog filter) and `STRUCTURE_EXTS` (drag-drop guard).
- **JupyterLab labextension** — `jupyterlab-megane/src/filetypes.ts`: register a `megane-mol2` `IFileType` (`.mol2`, `chemical/x-mol2`, text). The labextension iterates `STRUCTURE_FILETYPES_TEXT` at activation, so this is sufficient to route `.mol2` to the molecular viewer factory.
- **VSCode extension** — `vscode-megane/package.json`: add `*.mol2` to the `megane.structureViewer` `customEditors[0].selector` array, and extend the marketplace `description` to mention MOL2.
- **Tests** — update `tests/ts/jupyterlab/filetypes.test.ts` (length 8 → 9 + new name) and `tests/ts/vscode/packageManifest.test.ts` (sorted pattern list) for the new entry.

## New skill: `add-format`

To avoid this kind of host drift in the future, this PR also adds a new project skill at `.claude/skills/add-format/SKILL.md` that codifies the full per-host registration checklist (core, WASM, PyO3, parser dispatch, standalone openers, JupyterLab filetype, VSCode customEditor, docs, tests, and verification commands). It mirrors and reinforces CRITICAL RULE #6.

`CLAUDE.md` and the SessionStart bootstrap hook are updated to register the new skill (count bumped 9 → 10) and CRITICAL RULE #6 now points at the skill explicitly.

## Test plan

- [x] `npm run build:wasm`
- [x] `npx tsc --noEmit -p tsconfig.json` (clean)
- [x] `npx vitest run` — **63 files / 689 tests pass** (incl. updated jupyterlab `filetypes.test.ts` and `vscode/packageManifest.test.ts`)
- [ ] Manual: open `tests/fixtures/methanol.mol2` from the JupyterLab file browser and from the VS Code explorer
- [ ] Manual: drag-drop `methanol.mol2` into the standalone webapp `LoadStructureNode`

https://claude.ai/code/session_01LAWfM3xs8vHnc15nbZEsgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAWfM3xs8vHnc15nbZEsgv)_