### PR TITLE
ci(codecov): require 70% patch coverage and drop project status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,28 +1,10 @@
 coverage:
   status:
-    project:
-      default:
-        target: auto
-        threshold: 2%
-      python:
-        target: auto
-        threshold: 2%
-        flags:
-          - python
-      typescript:
-        target: auto
-        threshold: 2%
-        flags:
-          - typescript
-      rust:
-        target: auto
-        threshold: 2%
-        flags:
-          - rust
+    project: off
     patch:
       default:
-        target: auto
-        threshold: 1%
+        target: 70%
+        threshold: 0%
 
 comment:
   layout: "reach, diff, flags, files"


### PR DESCRIPTION
## Summary
- Replace the `target: auto` project/patch rules with a single blocking check on patch coverage at 70%.
- Disable Codecov project-level status so only changed lines gate merges.
- `flag_management` and `ignore` are unchanged so per-language uploads still flow.

## Follow-up (manual, not in this PR)
After merging, update `main` branch protection:
1. Remove the legacy `codecov` required check.
2. Wait for one PR run on the new config so Codecov posts `codecov/patch`.
3. Add `codecov/patch` to the required status checks.

## Test plan
- [ ] CI green on this PR.
- [ ] Codecov comment shows only the patch status (no project status).
- [ ] After merge, a follow-up PR confirms `codecov/patch` is posted and can be selected as a required check.

https://claude.ai/code/session_01MfT5oQCW7DirQNNja2vrrT

---
_Generated by [Claude Code](https://claude.ai/code/session_01MfT5oQCW7DirQNNja2vrrT)_