### PR TITLE
feat: persist camera state across sessions (#374)

### DIFF
--- a/python/megane/widget.py
+++ b/python/megane/widget.py
@@ -67,6 +67,11 @@ class MolecularViewer(anywidget.AnyWidget):
     # Measurement result (JS → Python)
     _measurement_json = traitlets.Unicode("").tag(sync=True)
 
+    # Camera state (JS ↔ Python). Persisted by anywidget kernel-side storage.
+    # Schema: {"mode": "orthographic"|"perspective", "position": [x,y,z],
+    #           "target": [x,y,z], "zoom": float}
+    camera_state = traitlets.Dict({}).tag(sync=True)
+
     # Pipeline data delivery (the visual pipeline editor is intentionally
     # not surfaced in the widget — it lives in the standalone webapp,
     # JupyterLab labextension and VSCode extension only).

--- a/src/components/MeganeViewer.tsx
+++ b/src/components/MeganeViewer.tsx
@@ -19,6 +19,7 @@ import { inferBondsVdwJS } from "../parsers/inferBondsJS";
 import { processPbcBonds } from "../pipeline/executors/addBond";
 import { usePipelineStore } from "../pipeline/store";
 import { usePlaybackStore } from "../stores/usePlaybackStore";
+import { useViewStateStore } from "../stores/useViewStateStore";
 import { applyViewportState, applyVectorsForFrame } from "../pipeline/apply";
 import { useAtomSelection } from "../hooks/useAtomSelection";
 import { useNodeLoadHandlers } from "../hooks/useNodeLoadHandlers";
@@ -50,6 +51,18 @@ interface MeganeViewerProps {
   height?: string | number;
   /** Host context tag for E2E tests: "webapp" | "jupyterlab-doc" | "vscode". Defaults to "webapp". */
   testContext?: string;
+  /**
+   * Override the initial camera state to restore on first snapshot load.
+   * When provided, takes precedence over localStorage. Used by hosts (VSCode,
+   * JupyterLab) that manage their own persistent storage.
+   */
+  initialCameraState?: import("../renderer/MoleculeRenderer").MeganeCameraState | null;
+  /**
+   * Called whenever the camera state changes (after user interaction ends).
+   * Allows hosts to persist camera state in their own storage backends.
+   * When omitted, the built-in localStorage store is used.
+   */
+  onCameraStateChange?: (state: import("../renderer/MoleculeRenderer").MeganeCameraState) => void;
 }
 
 export function MeganeViewer({
@@ -70,6 +83,8 @@ export function MeganeViewer({
   width = "100%",
   height = "100%",
   testContext = "webapp",
+  initialCameraState,
+  onCameraStateChange,
 }: MeganeViewerProps) {
   const rendererRef = useRef<MoleculeRenderer | null>(null);
   const [hoverInfo, setHoverInfo] = useState<HoverInfo>(null);
@@ -79,6 +94,7 @@ export function MeganeViewer({
   const pipelineCollapsedRef = useRef(isNarrow);
   const pipelineWidthRef = useRef(480);
   const prevViewportStateRef = useRef<ViewportState | null>(null);
+  const hasRestoredCameraRef = useRef(false);
 
   // Shared atom selection & measurement
   const { selection, measurement, handleAtomRightClick, handleClearSelection, handleFrameUpdated } =
@@ -112,7 +128,8 @@ export function MeganeViewer({
 
   // When the snapshot identity changes, the Viewport's child loadSnapshot
   // effect resets per-atom overrides, so we re-apply the pipeline viewport
-  // state immediately afterwards.
+  // state immediately afterwards. Viewport's effect (child) runs before this
+  // parent effect, so fitToView has already been called by the time we run.
   useEffect(() => {
     setBondCount(snapshot?.nBonds ?? 0);
     const renderer = rendererRef.current;
@@ -120,8 +137,19 @@ export function MeganeViewer({
       const vs = usePipelineStore.getState().viewportState;
       applyViewportState(renderer, vs, null, primaryNodeIdRef.current);
       prevViewportStateRef.current = vs;
+
+      // On first snapshot load after mount, restore persisted camera state
+      // (overrides fitToView). Hosts supply initialCameraState for their own
+      // storage; otherwise falls back to the localStorage-backed store.
+      if (snapshot && !hasRestoredCameraRef.current) {
+        hasRestoredCameraRef.current = true;
+        const saved = initialCameraState !== undefined ? initialCameraState : useViewStateStore.getState().camera;
+        if (saved) {
+          renderer.applyCameraState(saved);
+        }
+      }
     }
-  }, [snapshot]);
+  }, [snapshot, initialCameraState]);
 
   // Apply viewportState changes to the renderer + drive playback / bond-count
   // updates without triggering a React re-render of MeganeViewer. Subscribing
@@ -240,6 +268,9 @@ export function MeganeViewer({
     }
   }, [currentFrame]);
 
+  const onCameraStateChangeRef = useRef(onCameraStateChange);
+  onCameraStateChangeRef.current = onCameraStateChange;
+
   const handleRendererReady = useCallback((renderer: MoleculeRenderer) => {
     rendererRef.current = renderer;
     renderer.setViewInsets(0, pipelineCollapsedRef.current ? 0 : pipelineWidthRef.current + 12);
@@ -250,6 +281,17 @@ export function MeganeViewer({
       primaryNodeIdRef.current,
     );
     prevViewportStateRef.current = usePipelineStore.getState().viewportState;
+
+    // Register camera change callback for persistence
+    renderer.setCameraChangeCallback(() => {
+      const state = renderer.getCameraState();
+      if (!state) return;
+      if (onCameraStateChangeRef.current) {
+        onCameraStateChangeRef.current(state);
+      } else {
+        useViewStateStore.getState().updateCamera(state);
+      }
+    });
   }, []);
 
   const handleTogglePipeline = useCallback(() => {
@@ -283,6 +325,13 @@ export function MeganeViewer({
     rendererRef.current?.setViewInsets(0, pipelineCollapsed ? 0 : pipelineWidthRef.current + 12);
     updateTourAnchor();
   }, [pipelineCollapsed, updateTourAnchor]);
+
+  const handleResetView = useCallback(() => {
+    const renderer = rendererRef.current;
+    if (!renderer) return;
+    renderer.resetCamera();
+    useViewStateStore.getState().clearViewState();
+  }, []);
 
   return (
     <div
@@ -318,6 +367,29 @@ export function MeganeViewer({
           opacity: 0,
         }}
       />
+      <button
+        data-testid="reset-view-btn"
+        title="Reset view (fit to structure)"
+        onClick={handleResetView}
+        style={{
+          position: "absolute",
+          top: 12,
+          left: 12,
+          padding: "4px 8px",
+          fontSize: 11,
+          lineHeight: 1,
+          background: "rgba(255,255,255,0.85)",
+          border: "1px solid rgba(0,0,0,0.15)",
+          borderRadius: 4,
+          cursor: "pointer",
+          color: "#374151",
+          backdropFilter: "blur(4px)",
+          zIndex: 10,
+          userSelect: "none",
+        }}
+      >
+        Reset View
+      </button>
       <PipelineEditor
         collapsed={pipelineCollapsed}
         onToggleCollapse={handleTogglePipeline}

--- a/src/components/MeganeViewer.tsx
+++ b/src/components/MeganeViewer.tsx
@@ -143,7 +143,10 @@ export function MeganeViewer({
       // storage; otherwise falls back to the localStorage-backed store.
       if (snapshot && !hasRestoredCameraRef.current) {
         hasRestoredCameraRef.current = true;
-        const saved = initialCameraState !== undefined ? initialCameraState : useViewStateStore.getState().camera;
+        const saved =
+          initialCameraState !== undefined
+            ? initialCameraState
+            : useViewStateStore.getState().camera;
         if (saved) {
           renderer.applyCameraState(saved);
         }

--- a/src/components/WidgetViewer.tsx
+++ b/src/components/WidgetViewer.tsx
@@ -14,7 +14,7 @@ import { Viewport } from "./Viewport";
 import { Timeline } from "./Timeline";
 import { Tooltip } from "./Tooltip";
 import { MeasurementPanel } from "./MeasurementPanel";
-import { MoleculeRenderer } from "../renderer/MoleculeRenderer";
+import { MoleculeRenderer, type MeganeCameraState } from "../renderer/MoleculeRenderer";
 import { useAtomSelection } from "../hooks/useAtomSelection";
 import { inferBondsVdwJS } from "../parsers/inferBondsJS";
 import { processPbcBonds } from "../pipeline/executors/addBond";
@@ -35,6 +35,10 @@ interface WidgetViewerProps {
   pipelineJson?: string;
   nodeSnapshotsData?: Record<string, DataView>;
   onPipelineChange?: (json: string) => void;
+  /** Initial camera state to restore on first snapshot load. */
+  initialCameraState?: MeganeCameraState | null;
+  /** Called when camera state changes (after user interaction ends). */
+  onCameraStateChange?: (state: MeganeCameraState) => void;
   // Optional pipeline store override. Each Jupyter widget mount creates its
   // own private store so multiple MolecularViewers in the same notebook do
   // not share state. Tests pass their own store to inspect internal state.
@@ -63,6 +67,8 @@ export function WidgetViewer({
   onMeasurementChange,
   pipelineJson,
   nodeSnapshotsData,
+  initialCameraState,
+  onCameraStateChange,
   pipelineStore: pipelineStoreProp,
 }: WidgetViewerProps) {
   // Each WidgetViewer instance owns a private pipeline store. The webapp
@@ -80,6 +86,10 @@ export function WidgetViewer({
   const [hoverInfo, setHoverInfo] = useState<HoverInfo | null>(null);
   const [bondCount, setBondCount] = useState<number>(0);
   const prevViewportStateRef = useRef<ViewportState | null>(null);
+  const hasRestoredCameraRef = useRef(false);
+  const onCameraStateChangeRef = useRef(onCameraStateChange);
+  onCameraStateChangeRef.current = onCameraStateChange;
+  const initialCameraStateRef = useRef(initialCameraState);
 
   const {
     selection,
@@ -156,6 +166,15 @@ export function WidgetViewer({
       const vs = pipelineStore.getState().viewportState;
       applyViewportState(renderer, vs, null);
       prevViewportStateRef.current = vs;
+
+      // Restore persisted camera on first load (Viewport's loadSnapshot/fitToView
+      // runs before this effect because child effects execute first).
+      const effectiveSnap = pipelineStore.getState().snapshot ?? snapshot;
+      if (effectiveSnap && !hasRestoredCameraRef.current) {
+        hasRestoredCameraRef.current = true;
+        const saved = initialCameraStateRef.current;
+        if (saved) renderer.applyCameraState(saved);
+      }
     }
   }, [snapshot, nodeSnapshotsData, pipelineJson, setSnapshot, pipelineStore]);
 
@@ -222,6 +241,11 @@ export function WidgetViewer({
       prevViewportStateRef.current = pipelineStore.getState().viewportState;
       // Apply initial selectedAtoms that may have arrived before the renderer was ready
       setExternalSelection(selectedAtomsRef.current ?? []);
+      // Register camera change callback for host-side persistence
+      renderer.setCameraChangeCallback(() => {
+        const state = renderer.getCameraState();
+        if (state) onCameraStateChangeRef.current?.(state);
+      });
     },
     [setExternalSelection, pipelineStore],
   );

--- a/src/renderer/MoleculeRenderer.ts
+++ b/src/renderer/MoleculeRenderer.ts
@@ -240,6 +240,9 @@ export class MoleculeRenderer {
   /** True until the first frame has been rendered after mount; used for perf hook. */
   private firstFramePending = true;
 
+  /** Called when the user finishes a camera interaction (drag end). */
+  private _cameraChangeCallback: (() => void) | null = null;
+
   /** Structure layers for multi-structure overlay rendering. */
   private layers = new Map<string, StructureLayer>();
 
@@ -317,6 +320,9 @@ export class MoleculeRenderer {
     this.attachPivotCancelListener();
     this.attachWheelZoomListener();
     this.attachCustomPanListener();
+    this.controls.addEventListener("end", () => {
+      this._cameraChangeCallback?.();
+    });
 
     // Lighting - hemisphere + 3-point
     const hemi = new THREE.HemisphereLight(0xddeeff, 0x997744, 0.4);
@@ -1442,6 +1448,7 @@ export class MoleculeRenderer {
   /** Switch projection mode by name (wraps setPerspective for symmetry). */
   setCameraMode(mode: MeganeCameraMode): void {
     this.setPerspective(mode === "perspective");
+    this._cameraChangeCallback?.();
   }
 
   /** Re-fit the camera to the current snapshot's bounding box. */
@@ -1458,6 +1465,43 @@ export class MoleculeRenderer {
         this.lastExtent,
       );
     }
+    this._frustumPanX = 0;
+    this._frustumPanY = 0;
+    this._cameraChangeCallback?.();
+  }
+
+  /** Register a callback invoked after each user camera interaction ends. */
+  setCameraChangeCallback(cb: (() => void) | null): void {
+    this._cameraChangeCallback = cb;
+  }
+
+  /** Read current camera state. Returns null before mount. */
+  getCameraState(): MeganeCameraState | null {
+    if (!this.camera || !this.controls) return null;
+    const pos = this.camera.position;
+    const tgt = this.controls.target;
+    return {
+      mode: this.perspectiveMode ? "perspective" : "orthographic",
+      position: [pos.x, pos.y, pos.z],
+      target: [tgt.x, tgt.y, tgt.z],
+      zoom: this.camera.zoom,
+    };
+  }
+
+  /** Restore camera to a previously saved state. */
+  applyCameraState(state: MeganeCameraState): void {
+    if (!this.camera || !this.controls) return;
+    if ((state.mode === "perspective") !== this.perspectiveMode) {
+      this.setPerspective(state.mode === "perspective");
+    }
+    this.camera.position.set(...state.position);
+    this.controls.target.set(...state.target);
+    this.camera.zoom = state.zoom;
+    this.camera.updateProjectionMatrix();
+    const wasDamping = this.controls.enableDamping;
+    this.controls.enableDamping = false;
+    this.controls.update();
+    this.controls.enableDamping = wasDamping;
     this._frustumPanX = 0;
     this._frustumPanY = 0;
   }

--- a/src/stores/useViewStateStore.ts
+++ b/src/stores/useViewStateStore.ts
@@ -1,0 +1,60 @@
+/**
+ * View state persistence store.
+ * Saves camera position/orientation to localStorage so that camera state
+ * survives page reloads. Follows the same pattern as useAIConfigStore.
+ */
+
+import { create } from "zustand";
+import type { MeganeCameraState } from "../renderer/MoleculeRenderer";
+
+export interface PersistedViewState {
+  camera: MeganeCameraState | null;
+}
+
+const STORAGE_KEY = "megane-view-state";
+
+function loadViewState(): PersistedViewState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (parsed.camera && typeof parsed.camera === "object") {
+        return { camera: parsed.camera as MeganeCameraState };
+      }
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return { camera: null };
+}
+
+function saveViewState(state: PersistedViewState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // ignore storage errors (private browsing, quota exceeded)
+  }
+}
+
+interface ViewStateStore extends PersistedViewState {
+  updateCamera: (camera: MeganeCameraState) => void;
+  clearViewState: () => void;
+}
+
+export const useViewStateStore = create<ViewStateStore>((set) => ({
+  ...loadViewState(),
+
+  updateCamera: (camera) => {
+    set({ camera });
+    saveViewState({ camera });
+  },
+
+  clearViewState: () => {
+    set({ camera: null });
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // ignore
+    }
+  },
+}));

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -19,6 +19,7 @@ import {
   MSG_FRAME,
 } from "./protocol/protocol";
 import type { Snapshot, Frame, Measurement } from "./types";
+import type { MeganeCameraState } from "./renderer/MoleculeRenderer";
 
 interface AnyWidgetModel {
   get(key: string): unknown;
@@ -92,6 +93,25 @@ function render({ model, el }: { model: AnyWidgetModel; el: HTMLElement }) {
     model.save_changes();
   }
 
+  function handleCameraStateChange(state: MeganeCameraState) {
+    model.set("camera_state", state);
+    model.save_changes();
+  }
+
+  function getInitialCameraState(): MeganeCameraState | null {
+    const saved = model.get("camera_state") as Record<string, unknown> | null;
+    if (
+      saved &&
+      typeof saved.mode === "string" &&
+      Array.isArray(saved.position) &&
+      Array.isArray(saved.target) &&
+      typeof saved.zoom === "number"
+    ) {
+      return saved as unknown as MeganeCameraState;
+    }
+    return null;
+  }
+
   function renderApp() {
     if (!root || disposed) return;
     const frameIndex = (model.get("frame_index") as number) || 0;
@@ -112,6 +132,8 @@ function render({ model, el }: { model: AnyWidgetModel; el: HTMLElement }) {
         pipelineJson: pipelineJson,
         nodeSnapshotsData: nodeSnapshotsData,
         onPipelineChange: handlePipelineChange,
+        initialCameraState: getInitialCameraState(),
+        onCameraStateChange: handleCameraStateChange,
       }),
     );
   }

--- a/tests/ts/renderer/MoleculeRendererCamera.test.ts
+++ b/tests/ts/renderer/MoleculeRendererCamera.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi } from "vitest";
+import * as THREE from "three";
+import { MoleculeRenderer, type MeganeCameraState } from "@/renderer/MoleculeRenderer";
+
+/**
+ * Tests for the camera-state persistence API added in PR #392:
+ *   - getCameraState()        — read current camera/controls into a snapshot
+ *   - applyCameraState()      — restore a previously captured snapshot
+ *   - setCameraChangeCallback() — hook user-driven camera changes
+ *
+ * MoleculeRenderer's full mount() requires a real WebGL context and DOM, which
+ * jsdom does not supply. These tests instead instantiate the class without
+ * mounting and inject minimal stand-ins for `camera` and `controls`. The new
+ * methods only touch those two fields, so this is sufficient to exercise the
+ * branches added by the patch.
+ */
+
+interface ControlsStub {
+  target: THREE.Vector3;
+  enableDamping: boolean;
+  update: ReturnType<typeof vi.fn>;
+}
+
+function makeControls(enableDamping = true): ControlsStub {
+  return {
+    target: new THREE.Vector3(),
+    enableDamping,
+    update: vi.fn(),
+  };
+}
+
+/**
+ * Build a renderer instance with just enough state for the camera-state API.
+ * We bypass mount() (which needs WebGL) by directly assigning the private
+ * `camera`/`controls`/`perspectiveMode` fields via a typed cast.
+ */
+function makeRenderer(opts: {
+  camera: THREE.OrthographicCamera | THREE.PerspectiveCamera;
+  controls: ControlsStub;
+  perspectiveMode: boolean;
+}): MoleculeRenderer {
+  const r = new MoleculeRenderer();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const internals = r as any;
+  internals.camera = opts.camera;
+  internals.controls = opts.controls;
+  internals.perspectiveMode = opts.perspectiveMode;
+  return r;
+}
+
+describe("MoleculeRenderer.getCameraState", () => {
+  it("returns null when camera is missing", () => {
+    const r = new MoleculeRenderer();
+    expect(r.getCameraState()).toBeNull();
+  });
+
+  it("returns null when controls are missing", () => {
+    const r = new MoleculeRenderer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (r as any).camera = new THREE.OrthographicCamera();
+    // controls is still undefined
+    expect(r.getCameraState()).toBeNull();
+  });
+
+  it("captures orthographic camera position, target, and zoom", () => {
+    const cam = new THREE.OrthographicCamera(-5, 5, 5, -5, 0.1, 100);
+    cam.position.set(1, 2, 3);
+    cam.zoom = 2.5;
+    const ctrls = makeControls();
+    ctrls.target.set(4, 5, 6);
+    const r = makeRenderer({ camera: cam, controls: ctrls, perspectiveMode: false });
+
+    const state = r.getCameraState();
+    expect(state).toEqual({
+      mode: "orthographic",
+      position: [1, 2, 3],
+      target: [4, 5, 6],
+      zoom: 2.5,
+    });
+  });
+
+  it("reports perspective mode when perspectiveMode flag is true", () => {
+    const cam = new THREE.PerspectiveCamera(50, 1, 0.1, 1000);
+    cam.position.set(0, -10, 0);
+    cam.zoom = 1;
+    const r = makeRenderer({ camera: cam, controls: makeControls(), perspectiveMode: true });
+    expect(r.getCameraState()?.mode).toBe("perspective");
+  });
+});
+
+describe("MoleculeRenderer.applyCameraState", () => {
+  it("is a no-op when camera is missing", () => {
+    const r = new MoleculeRenderer();
+    // Should not throw even though camera/controls are undefined.
+    expect(() =>
+      r.applyCameraState({
+        mode: "orthographic",
+        position: [1, 1, 1],
+        target: [0, 0, 0],
+        zoom: 1,
+      }),
+    ).not.toThrow();
+  });
+
+  it("writes position, target, and zoom into camera/controls", () => {
+    const cam = new THREE.OrthographicCamera();
+    const ctrls = makeControls();
+    const r = makeRenderer({ camera: cam, controls: ctrls, perspectiveMode: false });
+
+    const state: MeganeCameraState = {
+      mode: "orthographic",
+      position: [9, 8, 7],
+      target: [1, 2, 3],
+      zoom: 3.25,
+    };
+    r.applyCameraState(state);
+
+    expect(cam.position.toArray()).toEqual([9, 8, 7]);
+    expect(ctrls.target.toArray()).toEqual([1, 2, 3]);
+    expect(cam.zoom).toBe(3.25);
+    expect(ctrls.update).toHaveBeenCalled();
+  });
+
+  it("temporarily disables damping during the update and restores it", () => {
+    const cam = new THREE.OrthographicCamera();
+    const ctrls = makeControls(/* enableDamping */ true);
+    let dampingDuringUpdate: boolean | null = null;
+    ctrls.update.mockImplementation(() => {
+      dampingDuringUpdate = ctrls.enableDamping;
+    });
+    const r = makeRenderer({ camera: cam, controls: ctrls, perspectiveMode: false });
+
+    r.applyCameraState({
+      mode: "orthographic",
+      position: [0, 0, 0],
+      target: [0, 0, 0],
+      zoom: 1,
+    });
+
+    expect(dampingDuringUpdate).toBe(false);
+    // After the call, the previous damping value must be restored.
+    expect(ctrls.enableDamping).toBe(true);
+  });
+
+  it("resets accumulated frustum pan offsets", () => {
+    const cam = new THREE.OrthographicCamera();
+    const ctrls = makeControls();
+    const r = makeRenderer({ camera: cam, controls: ctrls, perspectiveMode: false });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internals = r as any;
+    internals._frustumPanX = 12;
+    internals._frustumPanY = -7;
+
+    r.applyCameraState({
+      mode: "orthographic",
+      position: [0, 0, 0],
+      target: [0, 0, 0],
+      zoom: 1,
+    });
+
+    expect(internals._frustumPanX).toBe(0);
+    expect(internals._frustumPanY).toBe(0);
+  });
+
+  it("calls setPerspective when the requested mode differs from the current mode", () => {
+    const cam = new THREE.OrthographicCamera();
+    const ctrls = makeControls();
+    const r = makeRenderer({ camera: cam, controls: ctrls, perspectiveMode: false });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internals = r as any;
+
+    // Without a container set, setPerspective() flips the flag and early-returns
+    // before touching renderer/controls — safe to invoke from an unmounted instance.
+    r.applyCameraState({
+      mode: "perspective",
+      position: [0, 0, 0],
+      target: [0, 0, 0],
+      zoom: 1,
+    });
+
+    expect(internals.perspectiveMode).toBe(true);
+  });
+
+  it("skips setPerspective when the requested mode matches the current mode", () => {
+    const cam = new THREE.OrthographicCamera();
+    const ctrls = makeControls();
+    const r = makeRenderer({ camera: cam, controls: ctrls, perspectiveMode: false });
+    const setPerspectiveSpy = vi.spyOn(r, "setPerspective");
+
+    r.applyCameraState({
+      mode: "orthographic",
+      position: [0, 0, 0],
+      target: [0, 0, 0],
+      zoom: 1,
+    });
+
+    expect(setPerspectiveSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("MoleculeRenderer.setCameraChangeCallback", () => {
+  it("stores the callback so subsequent camera ops can fire it", () => {
+    const cam = new THREE.OrthographicCamera();
+    const ctrls = makeControls();
+    const r = makeRenderer({ camera: cam, controls: ctrls, perspectiveMode: false });
+
+    const cb = vi.fn();
+    r.setCameraChangeCallback(cb);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((r as any)._cameraChangeCallback).toBe(cb);
+  });
+
+  it("setCameraMode fires the registered callback", () => {
+    const cam = new THREE.OrthographicCamera();
+    const ctrls = makeControls();
+    // Start in orthographic; setCameraMode("orthographic") must still fire the
+    // callback because the patch invokes it unconditionally after setPerspective.
+    const r = makeRenderer({ camera: cam, controls: ctrls, perspectiveMode: false });
+    const cb = vi.fn();
+    r.setCameraChangeCallback(cb);
+
+    r.setCameraMode("orthographic");
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("clearing the callback prevents future invocations", () => {
+    const cam = new THREE.OrthographicCamera();
+    const ctrls = makeControls();
+    const r = makeRenderer({ camera: cam, controls: ctrls, perspectiveMode: false });
+    const cb = vi.fn();
+    r.setCameraChangeCallback(cb);
+    r.setCameraChangeCallback(null);
+
+    r.setCameraMode("orthographic");
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ts/stores/useViewStateStore.test.ts
+++ b/tests/ts/stores/useViewStateStore.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { MeganeCameraState } from "@/renderer/MoleculeRenderer";
+
+// Note: useViewStateStore reads localStorage at module load time, so each test
+// resets localStorage and re-imports the module to start from a clean slate.
+
+const STORAGE_KEY = "megane-view-state";
+
+function makeCameraState(overrides: Partial<MeganeCameraState> = {}): MeganeCameraState {
+  return {
+    mode: "orthographic",
+    position: [1, 2, 3],
+    target: [0, 0, 0],
+    zoom: 1,
+    ...overrides,
+  };
+}
+
+async function freshStore() {
+  vi.resetModules();
+  return (await import("@/stores/useViewStateStore")).useViewStateStore;
+}
+
+describe("useViewStateStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe("loadViewState (initial state)", () => {
+    it("starts with camera = null when localStorage is empty", async () => {
+      const store = await freshStore();
+      expect(store.getState().camera).toBeNull();
+    });
+
+    it("hydrates camera from localStorage when valid JSON is present", async () => {
+      const cam = makeCameraState({ position: [10, 20, 30] });
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ camera: cam }));
+      const store = await freshStore();
+      expect(store.getState().camera).toEqual(cam);
+    });
+
+    it("returns null camera when JSON is malformed", async () => {
+      localStorage.setItem(STORAGE_KEY, "{not valid json");
+      const store = await freshStore();
+      expect(store.getState().camera).toBeNull();
+    });
+
+    it("returns null camera when payload has no camera key", async () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ other: "value" }));
+      const store = await freshStore();
+      expect(store.getState().camera).toBeNull();
+    });
+
+    it("returns null camera when stored camera is not an object", async () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ camera: 42 }));
+      const store = await freshStore();
+      expect(store.getState().camera).toBeNull();
+    });
+  });
+
+  describe("updateCamera", () => {
+    it("sets the in-memory camera state", async () => {
+      const store = await freshStore();
+      const cam = makeCameraState();
+      store.getState().updateCamera(cam);
+      expect(store.getState().camera).toEqual(cam);
+    });
+
+    it("persists the camera state to localStorage", async () => {
+      const store = await freshStore();
+      const cam = makeCameraState({ zoom: 2.5 });
+      store.getState().updateCamera(cam);
+      const raw = localStorage.getItem(STORAGE_KEY);
+      expect(raw).not.toBeNull();
+      expect(JSON.parse(raw!)).toEqual({ camera: cam });
+    });
+
+    it("overwrites a previously persisted camera", async () => {
+      const store = await freshStore();
+      store.getState().updateCamera(makeCameraState({ zoom: 1 }));
+      store.getState().updateCamera(makeCameraState({ zoom: 9 }));
+      expect(store.getState().camera?.zoom).toBe(9);
+      expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!).camera.zoom).toBe(9);
+    });
+
+    it("silently ignores localStorage write errors", async () => {
+      const store = await freshStore();
+      const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+        throw new Error("QuotaExceededError");
+      });
+      try {
+        // Should not throw despite setItem rejecting
+        expect(() => store.getState().updateCamera(makeCameraState())).not.toThrow();
+        // In-memory state still updates even when persistence fails
+        expect(store.getState().camera).not.toBeNull();
+      } finally {
+        setItemSpy.mockRestore();
+      }
+    });
+  });
+
+  describe("clearViewState", () => {
+    it("resets camera to null", async () => {
+      const store = await freshStore();
+      store.getState().updateCamera(makeCameraState());
+      store.getState().clearViewState();
+      expect(store.getState().camera).toBeNull();
+    });
+
+    it("removes the localStorage key", async () => {
+      const store = await freshStore();
+      store.getState().updateCamera(makeCameraState());
+      expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+      store.getState().clearViewState();
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    it("silently ignores localStorage removal errors", async () => {
+      const store = await freshStore();
+      store.getState().updateCamera(makeCameraState());
+      const removeSpy = vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+        throw new Error("storage unavailable");
+      });
+      try {
+        expect(() => store.getState().clearViewState()).not.toThrow();
+        expect(store.getState().camera).toBeNull();
+      } finally {
+        removeSpy.mockRestore();
+      }
+    });
+  });
+
+  describe("round-trip", () => {
+    it("persisted state survives a fresh module reload", async () => {
+      const store1 = await freshStore();
+      const cam = makeCameraState({
+        mode: "perspective",
+        position: [5, 6, 7],
+        target: [1, 1, 1],
+        zoom: 1.5,
+      });
+      store1.getState().updateCamera(cam);
+
+      // Simulate reload: re-import the module and confirm initial state
+      // is restored from localStorage.
+      const store2 = await freshStore();
+      expect(store2.getState().camera).toEqual(cam);
+    });
+  });
+});

--- a/tests/ts/widget.test.ts
+++ b/tests/ts/widget.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Tests for src/widget.ts — the anywidget render entry point.
+ *
+ * Focus: the camera-state plumbing added in PR #392 (handleCameraStateChange,
+ * getInitialCameraState, plus its propagation as WidgetViewer props).
+ *
+ * The full render() closure is exercised by mocking the React layer so the
+ * callbacks remain reachable without a real WebGL/canvas mount.
+ */
+
+// Capture the props that widget.ts passes into <WidgetViewer/> on each render.
+const widgetViewerCalls: Array<Record<string, unknown>> = [];
+
+vi.mock("@/components/WidgetViewer", () => ({
+  WidgetViewer: vi.fn((props: Record<string, unknown>) => {
+    widgetViewerCalls.push(props);
+    return null;
+  }),
+}));
+
+// react-dom/client.createRoot — return a stub Root that captures the rendered
+// element (we only care about the props passed into createElement).
+const renderedElements: Array<{ type: unknown; props: Record<string, unknown> }> = [];
+vi.mock("react-dom/client", () => ({
+  createRoot: vi.fn(() => ({
+    render: vi.fn((el: { type: unknown; props: Record<string, unknown> }) => {
+      renderedElements.push(el);
+    }),
+    unmount: vi.fn(),
+  })),
+}));
+
+// Avoid pulling in the real perf hook (no-op is fine).
+vi.mock("@/perf", () => ({
+  perfMark: vi.fn(),
+  perfMeasure: vi.fn(),
+}));
+
+// Stub protocol decoders so parseSnapshot/parseFrame return null in tests
+// (we don't need real binary decoding for the camera-state tests).
+vi.mock("@/protocol/protocol", () => ({
+  decodeSnapshot: vi.fn(() => null),
+  decodeFrame: vi.fn(() => null),
+  decodeHeader: vi.fn(() => ({ msgType: 0 })),
+  MSG_SNAPSHOT: 0,
+  MSG_FRAME: 1,
+}));
+
+import widgetEntry from "@/widget";
+import { WidgetViewer } from "@/components/WidgetViewer";
+
+const mockedWidgetViewer = vi.mocked(WidgetViewer);
+
+interface MockModel {
+  get: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  save_changes: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+  // expose the registered change-event callbacks for tests to invoke
+  listeners: Map<string, () => void>;
+  // mutable backing store for get()
+  state: Record<string, unknown>;
+}
+
+function makeMockModel(initial: Record<string, unknown> = {}): MockModel {
+  const state: Record<string, unknown> = { ...initial };
+  const listeners = new Map<string, () => void>();
+  return {
+    state,
+    listeners,
+    get: vi.fn((key: string) => state[key]),
+    set: vi.fn((key: string, value: unknown) => {
+      state[key] = value;
+    }),
+    save_changes: vi.fn(),
+    on: vi.fn((event: string, cb: () => void) => {
+      listeners.set(event, cb);
+    }),
+  };
+}
+
+function makeContainer(): HTMLElement {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  return el;
+}
+
+// jsdom does not implement layout, so HTMLElement#clientWidth/Height are 0.
+// widget.ts's initApp() bails on 0×0 containers, so we override the
+// prototype with non-zero values during these tests.
+let clientWidthDescriptor: PropertyDescriptor | undefined;
+let clientHeightDescriptor: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  widgetViewerCalls.length = 0;
+  renderedElements.length = 0;
+  mockedWidgetViewer.mockClear();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).ResizeObserver = class {
+    observe(): void {}
+    disconnect(): void {}
+    unobserve(): void {}
+  };
+
+  clientWidthDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientWidth");
+  clientHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientHeight");
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get: () => 800,
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get: () => 600,
+  });
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  if (clientWidthDescriptor) {
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", clientWidthDescriptor);
+  }
+  if (clientHeightDescriptor) {
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", clientHeightDescriptor);
+  }
+});
+
+describe("widget.ts — render", () => {
+  it("registers change listeners for all expected model keys", () => {
+    const model = makeMockModel();
+    const el = makeContainer();
+    widgetEntry.render({ model: model as never, el });
+
+    const expected = [
+      "change:_snapshot_data",
+      "change:_frame_data",
+      "change:frame_index",
+      "change:total_frames",
+      "change:selected_atoms",
+      "change:_node_snapshots_data",
+      "change:_pipeline_json",
+    ];
+    for (const ev of expected) {
+      expect(model.listeners.has(ev), `listener ${ev}`).toBe(true);
+    }
+  });
+
+  it("passes initialCameraState=null when model has no camera_state", () => {
+    const model = makeMockModel();
+    const el = makeContainer();
+    widgetEntry.render({ model: model as never, el });
+
+    const last = renderedElements[renderedElements.length - 1];
+    expect(last.props.initialCameraState).toBeNull();
+    expect(last.props.onCameraStateChange).toBeTypeOf("function");
+  });
+
+  it("returns the persisted camera state when model.camera_state is well-formed", () => {
+    const cam = {
+      mode: "perspective",
+      position: [1, 2, 3],
+      target: [0, 0, 0],
+      zoom: 1.5,
+    };
+    const model = makeMockModel({ camera_state: cam });
+    const el = makeContainer();
+    widgetEntry.render({ model: model as never, el });
+
+    const last = renderedElements[renderedElements.length - 1];
+    expect(last.props.initialCameraState).toEqual(cam);
+  });
+
+  it("rejects malformed camera_state shapes (returns null)", () => {
+    const cases = [
+      { mode: 42, position: [0, 0, 0], target: [0, 0, 0], zoom: 1 }, // bad mode
+      { mode: "orthographic", position: "nope", target: [0, 0, 0], zoom: 1 }, // bad position
+      { mode: "orthographic", position: [0, 0, 0], target: "nope", zoom: 1 }, // bad target
+      { mode: "orthographic", position: [0, 0, 0], target: [0, 0, 0], zoom: "x" }, // bad zoom
+      null,
+    ];
+    for (const cam of cases) {
+      renderedElements.length = 0;
+      const model = makeMockModel({ camera_state: cam });
+      const el = makeContainer();
+      widgetEntry.render({ model: model as never, el });
+      const last = renderedElements[renderedElements.length - 1];
+      expect(last.props.initialCameraState).toBeNull();
+    }
+  });
+
+  it("onCameraStateChange writes back to model and triggers save_changes", () => {
+    const model = makeMockModel();
+    const el = makeContainer();
+    widgetEntry.render({ model: model as never, el });
+
+    const last = renderedElements[renderedElements.length - 1];
+    const onCameraStateChange = last.props.onCameraStateChange as (
+      s: Record<string, unknown>,
+    ) => void;
+
+    const newState = {
+      mode: "orthographic",
+      position: [10, 20, 30],
+      target: [1, 1, 1],
+      zoom: 2,
+    };
+    onCameraStateChange(newState);
+
+    expect(model.set).toHaveBeenCalledWith("camera_state", newState);
+    expect(model.save_changes).toHaveBeenCalled();
+  });
+
+  it("re-renders propagate updated camera_state through getInitialCameraState", () => {
+    const model = makeMockModel();
+    const el = makeContainer();
+    widgetEntry.render({ model: model as never, el });
+
+    // Update model state and trigger a re-render via one of the change listeners.
+    const cam = {
+      mode: "orthographic",
+      position: [4, 5, 6],
+      target: [0, 0, 0],
+      zoom: 1,
+    };
+    model.state.camera_state = cam;
+    model.listeners.get("change:frame_index")?.();
+
+    const last = renderedElements[renderedElements.length - 1];
+    expect(last.props.initialCameraState).toEqual(cam);
+  });
+
+  it("handlePipelineChange writes _pipeline_json", () => {
+    const model = makeMockModel();
+    const el = makeContainer();
+    widgetEntry.render({ model: model as never, el });
+
+    const last = renderedElements[renderedElements.length - 1];
+    const onPipelineChange = last.props.onPipelineChange as (j: string) => void;
+    onPipelineChange("{}");
+
+    expect(model.set).toHaveBeenCalledWith("_pipeline_json", "{}");
+    expect(model.save_changes).toHaveBeenCalled();
+  });
+
+  it("handleSeek writes the requested frame index", () => {
+    const model = makeMockModel({ total_frames: 5 });
+    const el = makeContainer();
+    widgetEntry.render({ model: model as never, el });
+
+    const last = renderedElements[renderedElements.length - 1];
+    const onSeek = last.props.onSeek as (frame: number) => void;
+    onSeek(3);
+
+    expect(model.set).toHaveBeenCalledWith("frame_index", 3);
+  });
+
+  it("handleSeek with -1 advances to the next frame (wrap-around)", () => {
+    const model = makeMockModel({ total_frames: 4, frame_index: 3 });
+    const el = makeContainer();
+    widgetEntry.render({ model: model as never, el });
+
+    const last = renderedElements[renderedElements.length - 1];
+    const onSeek = last.props.onSeek as (frame: number) => void;
+    onSeek(-1);
+
+    expect(model.set).toHaveBeenCalledWith("frame_index", 0);
+  });
+
+  it("cleanup function unmounts and disconnects without errors", () => {
+    const model = makeMockModel();
+    const el = makeContainer();
+    const cleanup = widgetEntry.render({ model: model as never, el }) as () => void;
+    expect(() => cleanup()).not.toThrow();
+  });
+});

--- a/vscode-megane/webview/main.tsx
+++ b/vscode-megane/webview/main.tsx
@@ -18,6 +18,7 @@ import { MeganeViewer } from "../../src/components/MeganeViewer";
 import { useMeganeLocal } from "../../src/hooks/useMeganeLocal";
 import { usePipelineStore } from "../../src/pipeline/store";
 import type { SerializedPipeline } from "../../src/pipeline/types";
+import type { MeganeCameraState } from "../../src/renderer/MoleculeRenderer";
 import { useTour } from "../../src/tour/useTour";
 import "../../src/styles/megane.css";
 
@@ -30,11 +31,26 @@ function setWasmUrlFromBytes(wasmBytes: number[] | undefined): void {
   (globalThis as Record<string, unknown>).__MEGANE_WASM_URL__ = URL.createObjectURL(wasmBlob);
 }
 
+interface VsCodeState {
+  camera?: MeganeCameraState;
+}
+
 function App() {
   const local = useMeganeLocal();
   useTour({ host: "vscode" });
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Per-document camera persistence using VS Code's webview state API.
+  const [initialCameraState] = useState<MeganeCameraState | null>(() => {
+    const saved = vscode.getState() as VsCodeState | undefined;
+    return saved?.camera ?? null;
+  });
+
+  const handleCameraStateChange = useCallback((state: MeganeCameraState) => {
+    const current = (vscode.getState() as VsCodeState | undefined) ?? {};
+    vscode.setState({ ...current, camera: state });
+  }, []);
 
   useEffect(() => {
     const handler = (event: MessageEvent) => {
@@ -192,6 +208,8 @@ function App() {
       onVectorSourceChange={(s) => local.setVectorSource(s as "none" | "file" | "demo")}
       onLoadVectorFile={(f) => local.loadVectorFile(f)}
       onLoadDemoVectors={() => local.loadDemoVectors()}
+      initialCameraState={initialCameraState}
+      onCameraStateChange={handleCameraStateChange}
     />
   );
 }


### PR DESCRIPTION
## Summary

Closes #374. Adds camera state persistence so that the viewer camera angle, zoom, and mode survive page reloads and editor restores across all three hosts.

- **Webapp**: camera state saved to `localStorage` via a new `useViewStateStore` (Zustand, mirrors the `useAIConfigStore` pattern)
- **VSCode extension**: per-document camera state saved/restored via `vscode.getState()` / `vscode.setState()` — each open file remembers its own camera angle
- **Jupyter widget**: new `camera_state` traitlet (Dict, synced) persists camera in anywidget kernel-side storage; Python side can read/set it programmatically
- **Reset View button**: a small "Reset View" button is added to the viewport in `MeganeViewer`; clicking it re-fits the camera to the current structure and clears the persisted state

### Key implementation details

| File | Change |
|------|--------|
| `src/stores/useViewStateStore.ts` | New Zustand store with `updateCamera` / `clearViewState`, backed by `localStorage` |
| `src/renderer/MoleculeRenderer.ts` | New `getCameraState()`, `applyCameraState()`, `setCameraChangeCallback()` public methods; `controls.addEventListener("end")` fires the callback |
| `src/components/MeganeViewer.tsx` | Registers camera change callback in `handleRendererReady`; restores on first snapshot load; new `initialCameraState` + `onCameraStateChange` props for host overrides |
| `src/components/WidgetViewer.tsx` | Same camera save/restore wiring for the Jupyter widget path |
| `src/widget.ts` | Reads/writes `camera_state` model key; passes `initialCameraState` + `onCameraStateChange` to `WidgetViewer` |
| `vscode-megane/webview/main.tsx` | Reads initial camera from `vscode.getState()` on mount; saves on every change |
| `python/megane/widget.py` | `camera_state = traitlets.Dict({}).tag(sync=True)` |

## Test plan

- [x] TypeScript type check clean (`npx tsc --noEmit`)
- [x] TypeScript unit tests: no new failures (17 pre-existing WASM-build failures unchanged, 552 tests pass)
- [ ] Webapp: load a molecule, rotate/zoom, reload — camera is restored
- [ ] Webapp: click "Reset View" — camera fits to structure, subsequent reload starts from fit view
- [ ] VSCode: open a PDB, rotate, close and re-open — camera is restored
- [ ] Jupyter widget: `viewer.camera_state` reflects camera after interaction

https://claude.ai/code/session_01VWKYp5myuoSr1od2zU6aE3