### PR TITLE
feat: add URL-shareable pipeline permalinks

### DIFF
--- a/src/components/PipelineEditor.tsx
+++ b/src/components/PipelineEditor.tsx
@@ -17,7 +17,7 @@ import type { Connection } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { usePipelineStore } from "../pipeline/store";
 import { downloadBlob } from "../renderer/RenderCapture";
-import { buildShareUrl } from "../pipeline/shareLink";
+import { shareCurrentPipeline } from "../pipeline/shareLink";
 import type { PipelineNodeType } from "../pipeline/types";
 import {
   NODE_TYPE_LABELS,
@@ -634,22 +634,9 @@ function PipelineEditorInner({
 
   const handleShare = useCallback(async () => {
     const serialized = usePipelineStore.getState().serialize();
-    const { url, tooLong } = await buildShareUrl(serialized);
-    if (tooLong) {
-      setShareFeedback("Pipeline too large for a share link — use Export instead");
-      setTimeout(() => setShareFeedback(null), 4000);
-      return;
-    }
-    try {
-      await navigator.clipboard.writeText(url);
-      // Also update the browser URL so the current tab reflects the shared state
-      history.replaceState(null, "", new URL(url).hash);
-      setShareFeedback("Link copied to clipboard!");
-    } catch {
-      setShareFeedback("Copy failed — see console for the link");
-      console.info("Share URL:", url);
-    }
-    setTimeout(() => setShareFeedback(null), 3000);
+    const outcome = await shareCurrentPipeline(serialized);
+    setShareFeedback(outcome.message);
+    setTimeout(() => setShareFeedback(null), outcome.clearAfterMs);
   }, []);
 
   const memoizedNodeTypes = useMemo(() => nodeTypes, []);

--- a/src/components/PipelineEditor.tsx
+++ b/src/components/PipelineEditor.tsx
@@ -17,6 +17,7 @@ import type { Connection } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { usePipelineStore } from "../pipeline/store";
 import { downloadBlob } from "../renderer/RenderCapture";
+import { buildShareUrl } from "../pipeline/shareLink";
 import type { PipelineNodeType } from "../pipeline/types";
 import {
   NODE_TYPE_LABELS,
@@ -132,6 +133,16 @@ const IconPlus = (
   <svg {...iconProps} strokeWidth="2.5">
     <line x1="12" y1="5" x2="12" y2="19" />
     <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+);
+
+const IconShare = (
+  <svg {...iconProps}>
+    <circle cx="18" cy="5" r="3" />
+    <circle cx="6" cy="12" r="3" />
+    <circle cx="18" cy="19" r="3" />
+    <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+    <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
   </svg>
 );
 
@@ -333,6 +344,13 @@ const importBtnStyle: React.CSSProperties = {
   color: "#6366f1",
 };
 
+const shareBtnStyle: React.CSSProperties = {
+  ...textBtnBase,
+  background: "rgba(16, 185, 129, 0.08)",
+  border: "1px solid rgba(16, 185, 129, 0.25)",
+  color: "#059669",
+};
+
 const guideBtnStyle: React.CSSProperties = {
   ...textBtnBase,
   background: "rgba(100, 116, 139, 0.08)",
@@ -466,6 +484,7 @@ function PipelineEditorInner({
   const [showAddMenu, setShowAddMenu] = useState(false);
   const [showTemplateMenu, setShowTemplateMenu] = useState(false);
   const [showRenderModal, setShowRenderModal] = useState(false);
+  const [shareFeedback, setShareFeedback] = useState<string | null>(null);
   const [panelWidth, setPanelWidth] = useState(DEFAULT_WIDTH);
   const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
   const flowContainerRef = useRef<HTMLDivElement | null>(null);
@@ -613,6 +632,26 @@ function PipelineEditorInner({
     [deserialize, fitView],
   );
 
+  const handleShare = useCallback(async () => {
+    const serialized = usePipelineStore.getState().serialize();
+    const { url, tooLong } = await buildShareUrl(serialized);
+    if (tooLong) {
+      setShareFeedback("Pipeline too large for a share link — use Export instead");
+      setTimeout(() => setShareFeedback(null), 4000);
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(url);
+      // Also update the browser URL so the current tab reflects the shared state
+      history.replaceState(null, "", new URL(url).hash);
+      setShareFeedback("Link copied to clipboard!");
+    } catch {
+      setShareFeedback("Copy failed — see console for the link");
+      console.info("Share URL:", url);
+    }
+    setTimeout(() => setShareFeedback(null), 3000);
+  }, []);
+
   const memoizedNodeTypes = useMemo(() => nodeTypes, []);
 
   const headerExtra = (
@@ -722,6 +761,15 @@ function PipelineEditorInner({
           {IconImport} Import
         </button>
         <button
+          data-testid="pipeline-editor-share"
+          onClick={() => void handleShare()}
+          style={shareBtnStyle}
+          title="Copy shareable link"
+          aria-label="Copy shareable link"
+        >
+          {IconShare} Share
+        </button>
+        <button
           data-testid="pipeline-editor-render"
           onClick={() => setShowRenderModal(true)}
           style={renderBtnStyle}
@@ -730,6 +778,19 @@ function PipelineEditorInner({
           {IconRender} Render
         </button>
       </div>
+      {shareFeedback && (
+        <div
+          style={{
+            fontSize: 10,
+            color: shareFeedback.startsWith("Pipeline too") ? "#dc2626" : "#059669",
+            padding: "2px 0 0 68px",
+          }}
+          role="status"
+          aria-live="polite"
+        >
+          {shareFeedback}
+        </div>
+      )}
 
       {/* Row 3 — Others: help */}
       <div style={toolbarRowStyle}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,7 @@ import { MeganeViewer } from "./components/MeganeViewer";
 import { useDataSource } from "./hooks/useDataSource";
 import { usePipelineStore } from "./pipeline/store";
 import { usePlaybackStore } from "./stores/usePlaybackStore";
-import { readPipelineFromHash } from "./pipeline/shareLink";
+import { restorePipelineFromHash } from "./pipeline/shareLink";
 import { useTour } from "./tour/useTour";
 import { parseXTCFile } from "./parsers/xtc";
 import { MemoryFrameProvider } from "./pipeline/types";
@@ -43,15 +43,10 @@ function App() {
   // load the bundled demo so first-time visitors see something immediately.
   useEffect(() => {
     (async () => {
-      const hashPipeline = await readPipelineFromHash();
-      if (hashPipeline) {
-        try {
-          usePipelineStore.getState().deserialize(hashPipeline);
-          return;
-        } catch {
-          // Fall through to demo on malformed hash
-        }
-      }
+      const restored = await restorePipelineFromHash((p) =>
+        usePipelineStore.getState().deserialize(p),
+      );
+      if (restored) return;
       await ds.local.loadText(defaultPDB);
       const resp = await fetch(defaultXtcUrl);
       const blob = await resp.blob();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ import { MeganeViewer } from "./components/MeganeViewer";
 import { useDataSource } from "./hooks/useDataSource";
 import { usePipelineStore } from "./pipeline/store";
 import { usePlaybackStore } from "./stores/usePlaybackStore";
+import { readPipelineFromHash } from "./pipeline/shareLink";
 import { useTour } from "./tour/useTour";
 import { parseXTCFile } from "./parsers/xtc";
 import { MemoryFrameProvider } from "./pipeline/types";
@@ -38,11 +39,20 @@ function App() {
   const setFps = usePlaybackStore((s) => s.setFps);
   const seekFrame = usePlaybackStore((s) => s.seekFrame);
 
-  // Load bundled demo PDB + XTC on first mount
+  // Restore pipeline from URL hash (#pipeline=...) when present; otherwise
+  // load the bundled demo so first-time visitors see something immediately.
   useEffect(() => {
     (async () => {
+      const hashPipeline = await readPipelineFromHash();
+      if (hashPipeline) {
+        try {
+          usePipelineStore.getState().deserialize(hashPipeline);
+          return;
+        } catch {
+          // Fall through to demo on malformed hash
+        }
+      }
       await ds.local.loadText(defaultPDB);
-      // Load demo trajectory
       const resp = await fetch(defaultXtcUrl);
       const blob = await resp.blob();
       const xtcFile = new File([blob], "caffeine_water_vibration.xtc");

--- a/src/pipeline/shareLink.ts
+++ b/src/pipeline/shareLink.ts
@@ -15,13 +15,13 @@ const MAX_HASH_LENGTH = 8000;
 
 // ── byte ↔ base64url ────────────────────────────────────────────────────────
 
-function bytesToBase64url(bytes: Uint8Array): string {
+function bytesToBase64url(bytes: Uint8Array<ArrayBuffer>): string {
   let binary = "";
   for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
   return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
 }
 
-function base64urlToBytes(str: string): Uint8Array {
+function base64urlToBytes(str: string): Uint8Array<ArrayBuffer> {
   const padded = str.replace(/-/g, "+").replace(/_/g, "/");
   const padding = (4 - (padded.length % 4)) % 4;
   const binary = atob(padded + "=".repeat(padding));
@@ -32,7 +32,7 @@ function base64urlToBytes(str: string): Uint8Array {
 
 // ── deflate-raw helpers (async, CompressionStream) ──────────────────────────
 
-async function deflate(data: Uint8Array): Promise<Uint8Array> {
+async function deflate(data: Uint8Array<ArrayBuffer>): Promise<Uint8Array<ArrayBuffer>> {
   const cs = new CompressionStream("deflate-raw");
   const writer = cs.writable.getWriter();
   await writer.write(data);
@@ -40,7 +40,7 @@ async function deflate(data: Uint8Array): Promise<Uint8Array> {
   return collectStream(cs.readable);
 }
 
-async function inflate(data: Uint8Array): Promise<Uint8Array> {
+async function inflate(data: Uint8Array<ArrayBuffer>): Promise<Uint8Array<ArrayBuffer>> {
   const ds = new DecompressionStream("deflate-raw");
   const writer = ds.writable.getWriter();
   await writer.write(data);
@@ -48,7 +48,9 @@ async function inflate(data: Uint8Array): Promise<Uint8Array> {
   return collectStream(ds.readable);
 }
 
-async function collectStream(readable: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+async function collectStream(
+  readable: ReadableStream<Uint8Array>,
+): Promise<Uint8Array<ArrayBuffer>> {
   const chunks: Uint8Array[] = [];
   const reader = readable.getReader();
   for (;;) {
@@ -69,8 +71,8 @@ async function collectStream(readable: ReadableStream<Uint8Array>): Promise<Uint
 // ── public API ───────────────────────────────────────────────────────────────
 
 /**
- * Encode a pipeline to the hash fragment value.
- * Returns the encoded string and whether the resulting URL would be too long.
+ * Encode a pipeline to a shareable URL.
+ * Returns the URL and whether the resulting hash would be too long to share.
  */
 export async function buildShareUrl(
   pipeline: SerializedPipeline,

--- a/src/pipeline/shareLink.ts
+++ b/src/pipeline/shareLink.ts
@@ -13,6 +13,13 @@ const HASH_PARAM = "pipeline";
 /** Warn the user when the hash fragment would exceed this many characters. */
 const MAX_HASH_LENGTH = 8000;
 
+const TOO_LONG_MESSAGE = "Pipeline too large for a share link — use Export instead";
+const COPIED_MESSAGE = "Link copied to clipboard!";
+const COPY_FAILED_MESSAGE = "Copy failed — see console for the link";
+
+const COPIED_TOAST_MS = 3000;
+const TOO_LONG_TOAST_MS = 4000;
+
 // ── byte ↔ base64url ────────────────────────────────────────────────────────
 
 function bytesToBase64url(bytes: Uint8Array<ArrayBuffer>): string {
@@ -129,5 +136,82 @@ export async function readPipelineFromHash(): Promise<SerializedPipeline | null>
     return parsed as SerializedPipeline;
   } catch {
     return null;
+  }
+}
+
+// ── share-button outcome helper ─────────────────────────────────────────────
+
+export type ShareOutcome = {
+  /** Toast message to surface to the user. */
+  message: string;
+  /** Milliseconds the toast should remain visible before auto-clearing. */
+  clearAfterMs: number;
+  /** The share URL (always set, even when copy failed). */
+  url: string;
+  /** True when the pipeline was too large to fit a shareable hash. */
+  tooLong: boolean;
+  /** True when navigator.clipboard.writeText threw. */
+  copyFailed: boolean;
+};
+
+/**
+ * Build a share URL for the given pipeline, copy it to the clipboard, and
+ * mirror the resulting hash into the address bar. Returns a presentation-ready
+ * outcome that the caller can render as a toast.
+ *
+ * Pure side effects (clipboard write, history.replaceState, console.info on
+ * failure) are kept out of the React component so the flow is testable.
+ */
+export async function shareCurrentPipeline(pipeline: SerializedPipeline): Promise<ShareOutcome> {
+  const { url, tooLong } = await buildShareUrl(pipeline);
+  if (tooLong) {
+    return {
+      message: TOO_LONG_MESSAGE,
+      clearAfterMs: TOO_LONG_TOAST_MS,
+      url,
+      tooLong: true,
+      copyFailed: false,
+    };
+  }
+  try {
+    await navigator.clipboard.writeText(url);
+    history.replaceState(null, "", new URL(url).hash);
+    return {
+      message: COPIED_MESSAGE,
+      clearAfterMs: COPIED_TOAST_MS,
+      url,
+      tooLong: false,
+      copyFailed: false,
+    };
+  } catch {
+    console.info("Share URL:", url);
+    return {
+      message: COPY_FAILED_MESSAGE,
+      clearAfterMs: COPIED_TOAST_MS,
+      url,
+      tooLong: false,
+      copyFailed: true,
+    };
+  }
+}
+
+// ── hash-restore helper ─────────────────────────────────────────────────────
+
+/**
+ * Read a pipeline from the URL hash (if present) and apply it via the supplied
+ * deserializer. Returns true on a successful restore so the caller can skip
+ * loading default content. Any failure (no hash, malformed payload, throwing
+ * deserializer) is swallowed and reported as `false`.
+ */
+export async function restorePipelineFromHash(
+  deserialize: (pipeline: SerializedPipeline) => void,
+): Promise<boolean> {
+  const hashPipeline = await readPipelineFromHash();
+  if (!hashPipeline) return false;
+  try {
+    deserialize(hashPipeline);
+    return true;
+  } catch {
+    return false;
   }
 }

--- a/src/pipeline/shareLink.ts
+++ b/src/pipeline/shareLink.ts
@@ -1,0 +1,131 @@
+/**
+ * URL permalink encoding/decoding for pipeline state.
+ * Serializes the pipeline JSON to a base64url string stored in the URL hash
+ * so viewers can share a reproducible pipeline state via link.
+ *
+ * Format: `#pipeline=<base64url(deflate-raw(JSON))>`
+ * Falls back to uncompressed base64url when CompressionStream is unavailable.
+ */
+
+import type { SerializedPipeline } from "./types";
+
+const HASH_PARAM = "pipeline";
+/** Warn the user when the hash fragment would exceed this many characters. */
+const MAX_HASH_LENGTH = 8000;
+
+// ── byte ↔ base64url ────────────────────────────────────────────────────────
+
+function bytesToBase64url(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+function base64urlToBytes(str: string): Uint8Array {
+  const padded = str.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = (4 - (padded.length % 4)) % 4;
+  const binary = atob(padded + "=".repeat(padding));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+// ── deflate-raw helpers (async, CompressionStream) ──────────────────────────
+
+async function deflate(data: Uint8Array): Promise<Uint8Array> {
+  const cs = new CompressionStream("deflate-raw");
+  const writer = cs.writable.getWriter();
+  await writer.write(data);
+  await writer.close();
+  return collectStream(cs.readable);
+}
+
+async function inflate(data: Uint8Array): Promise<Uint8Array> {
+  const ds = new DecompressionStream("deflate-raw");
+  const writer = ds.writable.getWriter();
+  await writer.write(data);
+  await writer.close();
+  return collectStream(ds.readable);
+}
+
+async function collectStream(readable: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = [];
+  const reader = readable.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  const total = chunks.reduce((n, c) => n + c.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.length;
+  }
+  return out;
+}
+
+// ── public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Encode a pipeline to the hash fragment value.
+ * Returns the encoded string and whether the resulting URL would be too long.
+ */
+export async function buildShareUrl(
+  pipeline: SerializedPipeline,
+): Promise<{ url: string; tooLong: boolean }> {
+  const json = JSON.stringify(pipeline);
+  const raw = new TextEncoder().encode(json);
+
+  let encoded: string;
+  try {
+    encoded = bytesToBase64url(await deflate(raw));
+  } catch {
+    // CompressionStream not available — fall back to plain base64url
+    encoded = bytesToBase64url(raw);
+  }
+
+  const hash = `${HASH_PARAM}=${encoded}`;
+  const url = `${location.origin}${location.pathname}#${hash}`;
+  return { url, tooLong: hash.length > MAX_HASH_LENGTH };
+}
+
+/**
+ * Read and decode a pipeline from the current URL hash.
+ * Returns null when no pipeline is present or decoding fails.
+ */
+export async function readPipelineFromHash(): Promise<SerializedPipeline | null> {
+  if (typeof location === "undefined") return null;
+  const hash = location.hash.slice(1);
+  if (!hash) return null;
+  const params = new URLSearchParams(hash);
+  const encoded = params.get(HASH_PARAM);
+  if (!encoded) return null;
+
+  try {
+    const bytes = base64urlToBytes(encoded);
+
+    let json: string;
+    try {
+      json = new TextDecoder().decode(await inflate(bytes));
+    } catch {
+      // Not compressed — treat as plain UTF-8 base64url
+      json = new TextDecoder().decode(bytes);
+    }
+
+    const parsed: unknown = JSON.parse(json);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      !("version" in parsed) ||
+      !("nodes" in parsed) ||
+      !("edges" in parsed)
+    ) {
+      return null;
+    }
+    return parsed as SerializedPipeline;
+  } catch {
+    return null;
+  }
+}

--- a/tests/ts/pipeline/shareLink.test.ts
+++ b/tests/ts/pipeline/shareLink.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { buildShareUrl, readPipelineFromHash } from "@/pipeline/shareLink";
+import type { SerializedPipeline } from "@/pipeline/types";
+
+const samplePipeline: SerializedPipeline = {
+  version: 3,
+  nodes: [
+    {
+      id: "n1",
+      type: "load_structure",
+      position: { x: 0, y: 0 },
+      enabled: true,
+      fileName: null,
+      hasTrajectory: false,
+      hasCell: false,
+    } as SerializedPipeline["nodes"][number],
+    {
+      id: "n2",
+      type: "viewport",
+      position: { x: 200, y: 0 },
+      enabled: true,
+      perspective: false,
+      cellAxesVisible: true,
+    } as SerializedPipeline["nodes"][number],
+  ],
+  edges: [{ source: "n1", target: "n2", sourceHandle: "particle", targetHandle: "particle" }],
+};
+
+function setHash(hash: string): void {
+  window.location.hash = hash;
+}
+
+describe("buildShareUrl", () => {
+  beforeEach(() => {
+    setHash("");
+  });
+
+  it("encodes a pipeline into a URL with #pipeline= hash", async () => {
+    const { url, tooLong } = await buildShareUrl(samplePipeline);
+    expect(url.startsWith(location.origin + location.pathname + "#pipeline=")).toBe(true);
+    expect(tooLong).toBe(false);
+  });
+
+  it("round-trips through readPipelineFromHash via the encoded hash", async () => {
+    const { url } = await buildShareUrl(samplePipeline);
+    const hashIndex = url.indexOf("#");
+    setHash(url.slice(hashIndex + 1));
+
+    const parsed = await readPipelineFromHash();
+    expect(parsed).not.toBeNull();
+    expect(parsed?.version).toBe(3);
+    expect(parsed?.nodes).toHaveLength(2);
+    expect(parsed?.edges[0]).toEqual(samplePipeline.edges[0]);
+  });
+
+  it("emits base64url alphabet only (no +, /, =)", async () => {
+    const { url } = await buildShareUrl(samplePipeline);
+    const encoded = url.split("#pipeline=")[1];
+    expect(encoded).not.toMatch(/[+/=]/);
+  });
+
+  it("flags tooLong=true when the encoded payload exceeds 8000 chars", async () => {
+    const big: SerializedPipeline = {
+      version: 3,
+      nodes: Array.from({ length: 800 }, (_, i) => ({
+        id: `node-${i}`,
+        type: "load_structure",
+        position: { x: i, y: i },
+        enabled: true,
+        // pad with random-ish unique data so deflate cannot collapse it
+        fileName: `${i}-${Math.random().toString(36).repeat(5)}-${"x".repeat(30)}`,
+        hasTrajectory: false,
+        hasCell: false,
+      })) as SerializedPipeline["nodes"],
+      edges: [],
+    };
+    const { tooLong } = await buildShareUrl(big);
+    expect(tooLong).toBe(true);
+  });
+
+  it("falls back to plain base64url when CompressionStream is unavailable", async () => {
+    const original = globalThis.CompressionStream;
+    // Simulate older browsers by removing CompressionStream entirely.
+    // The implementation catches the resulting ReferenceError/TypeError and
+    // falls back to encoding the raw JSON bytes.
+    // @ts-expect-error - intentional removal for fallback test
+    delete globalThis.CompressionStream;
+    try {
+      const { url } = await buildShareUrl(samplePipeline);
+      const encoded = url.split("#pipeline=")[1];
+      // The fallback path stores the raw JSON, so atob(decode) should yield JSON text.
+      const padded = encoded.replace(/-/g, "+").replace(/_/g, "/");
+      const padding = (4 - (padded.length % 4)) % 4;
+      const decoded = atob(padded + "=".repeat(padding));
+      expect(decoded.startsWith("{")).toBe(true);
+      const parsed = JSON.parse(decoded);
+      expect(parsed.version).toBe(3);
+    } finally {
+      globalThis.CompressionStream = original;
+    }
+  });
+});
+
+describe("readPipelineFromHash", () => {
+  beforeEach(() => {
+    setHash("");
+  });
+
+  it("returns null when the hash is empty", async () => {
+    setHash("");
+    expect(await readPipelineFromHash()).toBeNull();
+  });
+
+  it("returns null when the hash has no pipeline= param", async () => {
+    setHash("other=value");
+    expect(await readPipelineFromHash()).toBeNull();
+  });
+
+  it("returns null when the encoded payload is not valid base64url", async () => {
+    setHash("pipeline=!!!not-base64!!!");
+    expect(await readPipelineFromHash()).toBeNull();
+  });
+
+  it("returns null when decoded JSON is malformed", async () => {
+    // base64url("not json") → "bm90IGpzb24"
+    const encoded = btoa("not json").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+    setHash(`pipeline=${encoded}`);
+    expect(await readPipelineFromHash()).toBeNull();
+  });
+
+  it("returns null when JSON is structurally invalid (missing required keys)", async () => {
+    const encoded = btoa(JSON.stringify({ version: 3, nodes: [] /* edges missing */ }))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=/g, "");
+    setHash(`pipeline=${encoded}`);
+    expect(await readPipelineFromHash()).toBeNull();
+  });
+
+  it("returns null when the parsed value is not an object", async () => {
+    const encoded = btoa(JSON.stringify("just a string"))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=/g, "");
+    setHash(`pipeline=${encoded}`);
+    expect(await readPipelineFromHash()).toBeNull();
+  });
+
+  it("decodes a plain (uncompressed) base64url payload as fallback", async () => {
+    const encoded = btoa(JSON.stringify(samplePipeline))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=/g, "");
+    setHash(`pipeline=${encoded}`);
+    const parsed = await readPipelineFromHash();
+    expect(parsed).not.toBeNull();
+    expect(parsed?.version).toBe(3);
+    expect(parsed?.nodes).toHaveLength(2);
+  });
+
+  it("returns null when location is undefined (non-browser env)", async () => {
+    const originalLocation = globalThis.location;
+    // @ts-expect-error - intentional removal to exercise the typeof guard
+    delete globalThis.location;
+    try {
+      expect(await readPipelineFromHash()).toBeNull();
+    } finally {
+      globalThis.location = originalLocation;
+    }
+  });
+});
+
+describe("buildShareUrl ↔ readPipelineFromHash compatibility", () => {
+  let originalCompression: typeof CompressionStream | undefined;
+  let originalDecompression: typeof DecompressionStream | undefined;
+
+  afterEach(() => {
+    if (originalCompression !== undefined) {
+      globalThis.CompressionStream = originalCompression;
+      originalCompression = undefined;
+    }
+    if (originalDecompression !== undefined) {
+      globalThis.DecompressionStream = originalDecompression;
+      originalDecompression = undefined;
+    }
+    setHash("");
+  });
+
+  it("readPipelineFromHash recovers a pipeline encoded without CompressionStream", async () => {
+    originalCompression = globalThis.CompressionStream;
+    // @ts-expect-error - simulate browser without CompressionStream
+    delete globalThis.CompressionStream;
+
+    const { url } = await buildShareUrl(samplePipeline);
+    const hashIndex = url.indexOf("#");
+    setHash(url.slice(hashIndex + 1));
+
+    // Restore compression so the decoder will try inflate first; the inflate
+    // attempt should fail on plain bytes, and the catch should fall through
+    // to the plain UTF-8 path.
+    globalThis.CompressionStream = originalCompression;
+    originalCompression = undefined;
+
+    const parsed = await readPipelineFromHash();
+    expect(parsed).not.toBeNull();
+    expect(parsed?.version).toBe(3);
+    expect(parsed?.edges).toEqual(samplePipeline.edges);
+  });
+
+  it("CompressionStream throwing is treated as fallback (no rethrow)", async () => {
+    originalCompression = globalThis.CompressionStream;
+    const spy = vi.fn(() => {
+      throw new Error("boom");
+    });
+    // @ts-expect-error - mock constructor that throws
+    globalThis.CompressionStream = spy;
+
+    const { url, tooLong } = await buildShareUrl(samplePipeline);
+    expect(spy).toHaveBeenCalled();
+    expect(tooLong).toBe(false);
+    expect(url).toContain("#pipeline=");
+  });
+});

--- a/tests/ts/pipeline/shareLink.test.ts
+++ b/tests/ts/pipeline/shareLink.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { buildShareUrl, readPipelineFromHash } from "@/pipeline/shareLink";
+import {
+  buildShareUrl,
+  readPipelineFromHash,
+  restorePipelineFromHash,
+  shareCurrentPipeline,
+} from "@/pipeline/shareLink";
 import type { SerializedPipeline } from "@/pipeline/types";
 
 const samplePipeline: SerializedPipeline = {
@@ -219,5 +224,129 @@ describe("buildShareUrl ↔ readPipelineFromHash compatibility", () => {
     expect(spy).toHaveBeenCalled();
     expect(tooLong).toBe(false);
     expect(url).toContain("#pipeline=");
+  });
+});
+
+describe("shareCurrentPipeline", () => {
+  let writeText: ReturnType<typeof vi.fn>;
+  let originalClipboard: PropertyDescriptor | undefined;
+  let replaceStateSpy: ReturnType<typeof vi.spyOn>;
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    writeText = vi.fn().mockResolvedValue(undefined);
+    originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    replaceStateSpy = vi.spyOn(history, "replaceState").mockImplementation(() => {});
+    infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    window.location.hash = "";
+  });
+
+  afterEach(() => {
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    } else {
+      // @ts-expect-error - remove the test-installed property
+      delete navigator.clipboard;
+    }
+    replaceStateSpy.mockRestore();
+    infoSpy.mockRestore();
+  });
+
+  it("ok path: writes to clipboard, mirrors hash, returns success outcome", async () => {
+    const outcome = await shareCurrentPipeline(samplePipeline);
+    expect(outcome.tooLong).toBe(false);
+    expect(outcome.copyFailed).toBe(false);
+    expect(outcome.message).toBe("Link copied to clipboard!");
+    expect(outcome.clearAfterMs).toBe(3000);
+    expect(outcome.url).toContain("#pipeline=");
+    expect(writeText).toHaveBeenCalledWith(outcome.url);
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+    // Second arg of replaceState is the URL fragment (e.g. "#pipeline=...")
+    const replaceArgs = replaceStateSpy.mock.calls[0];
+    expect(String(replaceArgs[2])).toMatch(/^#pipeline=/);
+  });
+
+  it("tooLong path: skips clipboard, returns 4-second toast", async () => {
+    const big: SerializedPipeline = {
+      version: 3,
+      nodes: Array.from({ length: 800 }, (_, i) => ({
+        id: `n-${i}`,
+        type: "load_structure",
+        position: { x: i, y: i },
+        enabled: true,
+        fileName: `${i}-${Math.random().toString(36).repeat(5)}-${"x".repeat(30)}`,
+        hasTrajectory: false,
+        hasCell: false,
+      })) as SerializedPipeline["nodes"],
+      edges: [],
+    };
+    const outcome = await shareCurrentPipeline(big);
+    expect(outcome.tooLong).toBe(true);
+    expect(outcome.copyFailed).toBe(false);
+    expect(outcome.message).toBe("Pipeline too large for a share link — use Export instead");
+    expect(outcome.clearAfterMs).toBe(4000);
+    expect(writeText).not.toHaveBeenCalled();
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+  });
+
+  it("copyFailed path: clipboard rejection logs URL and returns failure outcome", async () => {
+    writeText.mockRejectedValueOnce(new Error("denied"));
+    const outcome = await shareCurrentPipeline(samplePipeline);
+    expect(outcome.tooLong).toBe(false);
+    expect(outcome.copyFailed).toBe(true);
+    expect(outcome.message).toBe("Copy failed — see console for the link");
+    expect(outcome.clearAfterMs).toBe(3000);
+    expect(infoSpy).toHaveBeenCalledWith("Share URL:", outcome.url);
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("restorePipelineFromHash", () => {
+  beforeEach(() => {
+    window.location.hash = "";
+  });
+
+  it("returns false and skips deserialize when no hash is present", async () => {
+    const deserialize = vi.fn();
+    const restored = await restorePipelineFromHash(deserialize);
+    expect(restored).toBe(false);
+    expect(deserialize).not.toHaveBeenCalled();
+  });
+
+  it("returns false when hash payload is malformed", async () => {
+    window.location.hash = "pipeline=!!!not-base64!!!";
+    const deserialize = vi.fn();
+    const restored = await restorePipelineFromHash(deserialize);
+    expect(restored).toBe(false);
+    expect(deserialize).not.toHaveBeenCalled();
+  });
+
+  it("returns true and calls deserialize on a valid hash", async () => {
+    const { url } = await buildShareUrl(samplePipeline);
+    window.location.hash = url.slice(url.indexOf("#") + 1);
+
+    const deserialize = vi.fn();
+    const restored = await restorePipelineFromHash(deserialize);
+    expect(restored).toBe(true);
+    expect(deserialize).toHaveBeenCalledTimes(1);
+    const arg = deserialize.mock.calls[0][0];
+    expect(arg.version).toBe(3);
+    expect(arg.nodes).toHaveLength(2);
+  });
+
+  it("returns false when the deserializer throws", async () => {
+    const { url } = await buildShareUrl(samplePipeline);
+    window.location.hash = url.slice(url.indexOf("#") + 1);
+
+    const deserialize = vi.fn(() => {
+      throw new Error("bad pipeline");
+    });
+    const restored = await restorePipelineFromHash(deserialize);
+    expect(restored).toBe(false);
+    expect(deserialize).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

Closes #376. Adds shareable URL permalinks so users can copy a link that encodes the current pipeline state and share it with others.

- **`src/pipeline/shareLink.ts`** (new): `buildShareUrl()` serializes the pipeline to JSON, compresses it with `deflate-raw` via `CompressionStream`, and encodes it as base64url in the URL hash (`#pipeline=<encoded>`). Falls back to uncompressed base64url when `CompressionStream` is unavailable. `readPipelineFromHash()` reverses the process.
- **`src/index.tsx`**: On app start, reads `#pipeline=…` from the URL hash and restores the pipeline via `usePipelineStore.deserialize()`. Falls back to loading the bundled demo when no hash is present or decoding fails.
- **`src/components/PipelineEditor.tsx`**: Adds a **Share** button to the I/O toolbar row. Clicking it compresses the current pipeline, copies the URL to the clipboard, and updates the browser address bar via `history.replaceState`. Shows an inline status message ("Link copied to clipboard!" / "Pipeline too large for a share link — use Export instead").

### Key design decisions
- Pipelines larger than 8 000 hash characters (≈ 6 KB base64url) show a "too large" warning and suggest the Export-to-file option — no file content is ever embedded in the URL.
- The `readPipelineFromHash()` fallback handles plain (uncompressed) encoded hashes in case the browser that created the link lacked `CompressionStream`.
- `data-testid="pipeline-editor-share"` added for future E2E coverage.

## Test plan

- [x] TypeScript type-check clean (`npx tsc --noEmit`)
- [x] 552 TypeScript unit tests pass (`npm test`) — 5 pre-existing WASM-build failures unchanged
- [ ] Open webapp, click **Share**, verify URL hash updates and clipboard contains the correct URL
- [ ] Open the copied URL in a new tab — pipeline is restored identically
- [ ] Verify the bundled demo still loads when no hash is present
- [ ] Verify a malformed hash falls back gracefully to the demo

https://claude.ai/code/session_01JSDEo4GbbyjEgHGSSuGWtR