### PR TITLE
docs: document Codecov merge gate in CLAUDE.md and skills

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -23,10 +23,11 @@ Keep the first line under 72 characters. Add details in the body if needed.
 
 ## Before Committing
 
-1. Run relevant tests for the changed code:
-   - Rust changes: `cargo test -p megane-core`
-   - TypeScript changes: `npm test`
-   - Python changes: `python -m pytest`
+1. Run relevant tests for the changed code, **with coverage** so you can confirm the Codecov patch gate (≥ 70 % per `codecov.yml`) before pushing — see CRITICAL RULE #8 in `CLAUDE.md` and the `testing` skill's "Coverage & Codecov" section. CI uploads with `fail_ci_on_error: true`, so an uncovered diff blocks merge.
+   - Rust changes: `cargo llvm-cov --package megane-core --lcov --output-path lcov.info` (or `cargo test -p megane-core` if the diff is test-only)
+   - TypeScript changes: `npm test -- --coverage`
+   - Python changes: `python -m pytest` (coverage is auto-enabled via `pyproject.toml` addopts; use `--cov-report=xml:coverage.xml` to mirror CI)
+   If you added new source code, you MUST also add unit tests for it in the same commit. Relying on E2E does not satisfy Codecov — E2E is local-only and unmeasured.
 2. Ensure the build succeeds for frontend changes: `npm run build`
 3. Do NOT commit generated files: `crates/megane-wasm/pkg/`, `dist/`, `target/`, `node_modules/`, `dev-preview/`
    Do NOT commit plan files: any file named `plan.md` or matching `*.plan.md` (these are local planning artifacts, not part of the codebase)

--- a/.claude/skills/pre-release/SKILL.md
+++ b/.claude/skills/pre-release/SKILL.md
@@ -122,6 +122,14 @@ uv run make test-all
 All of Python, TypeScript, Rust, E2E, notebook, and integration tests must
 pass.
 
+The release commit will run through CI on the way to `main`, and CI uploads
+to Codecov with `fail_ci_on_error: true` (`codecov.yml` patch target 70 %).
+The release diff is mostly version bumps + CHANGELOG, which Codecov ignores
+(`pyproject.toml`, `Cargo.toml`, `*.md`), so the gate normally passes
+trivially. If the release branch happens to also include source-code
+changes, run `make coverage-all` locally first — see CRITICAL RULE #8 in
+`CLAUDE.md` and the `testing` skill's "Coverage & Codecov" section.
+
 **E2E baseline drift.** Per `CLAUDE.md`, E2E is local-only and font /
 fontconfig differences across machines can cause baseline diffs. If E2E
 fails only with `full-page diff X.XX% > 2%` style errors (not timeouts or

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -40,6 +40,66 @@ python -m pytest
 Requires `maturin develop --release` to have been run first.
 Tests: `tests/python/`. Config: `pyproject.toml` under `[tool.pytest.ini_options]`.
 
+## Coverage & Codecov (merge gate)
+
+**Codecov is a hard merge gate — see CRITICAL RULE #8 in `CLAUDE.md`.** The
+three CI jobs that upload coverage all use `fail_ci_on_error: true`, and
+`codecov.yml` requires **patch coverage ≥ 70 %** on every PR (project
+coverage status is `off`, so only the diff matters — but the diff matters a
+lot).
+
+What this means in practice:
+- Every new function / branch / pipeline node / React component / parser
+  needs a unit test in the same PR. E2E does not count toward Codecov
+  because E2E is local-only and unmeasured.
+- A PR that adds 100 lines of TS but no `tests/ts/` updates will fail the
+  TS Codecov patch check, which fails CI, which blocks merge.
+- Adding a Rust parser without `#[test]` cases under that crate's `tests/`
+  module will fail the Rust patch check.
+
+### Local commands that match what CI uploads
+
+| Stack | Command | Output | CI job that consumes it |
+|---|---|---|---|
+| TypeScript | `npm test -- --coverage` | `coverage/ts/lcov.info` | `test-ts` |
+| Rust | `cargo llvm-cov --package megane-core --lcov --output-path lcov.info` | `lcov.info` | `test-rust` |
+| Python | `python -m pytest --cov-report=xml:coverage.xml` | `coverage.xml` | `test-python` |
+
+`cargo llvm-cov` requires `cargo install cargo-llvm-cov` once; the pytest
+`--cov` flag is already wired via `pyproject.toml` `addopts`.
+
+The convenience wrappers in the `Makefile` produce HTML reports under
+`coverage/{python,ts,rust}/index.html` for browsing, but they don't emit
+the lcov / xml files that match the CI uploads — use the table above when
+you want to predict the Codecov result:
+
+```sh
+make coverage-ts      # → coverage/ts/index.html
+make coverage         # → coverage/python/index.html
+make coverage-rust    # → coverage/rust/tarpaulin-report.html (needs cargo-tarpaulin)
+make coverage-all     # all three
+```
+
+### Patch coverage rules (`codecov.yml`)
+
+- Three flags are tracked separately: `python`, `typescript`, `rust`.
+  Each is filtered by path (`python/megane/`, `src/` + `vscode-megane/src/`
+  + `jupyterlab-megane/src/`, `crates/`).
+- `tests/`, `docs/`, `python/megane/static/**`, and `*.d.ts` are ignored.
+- The patch target is **70 % with 0 % threshold**, so a single uncovered
+  branch in a small diff can drop you below the line. When you change only
+  one file, run the matching coverage command and inspect the per-file
+  report before pushing.
+
+### Legitimate exceptions
+
+If a line genuinely cannot be covered (e.g. a defensive branch that's
+unreachable from public APIs, or platform-gated code that only runs in a
+specific host), document the gap in the PR description and prefer
+`#[cfg(...)]` / `/* c8 ignore next */` / `# pragma: no cover` over
+disabling the gate. Never set `fail_ci_on_error: false` or relax
+`codecov.yml` to make a PR pass.
+
 ## E2E Tests (cross-platform 3-layer suite)
 
 ### Playwright Test runner (current)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@
 5. **In plan mode, strictly follow the approved plan.** Do not skip steps, reorder them, or add unplanned work. If the plan needs changes, explain the reason and get approval before deviating.
 6. **All file formats should behave consistently across hosts.** When you add a parser or feature to one platform (standalone webapp, Jupyter widget, JupyterLab labextension, VSCode extension), register it on every host unless there is a host-specific reason not to. The single source of truth is `docs/docs/platform-support.md`; update its tables in the same PR. Host registration points: `crates/megane-wasm/src/lib.rs` (browser parsers), `src/components/nodes/LoadStructureNode.tsx` / `LoadTrajectoryNode.tsx` (standalone accept lists), `jupyterlab-megane/src/filetypes.ts`, `vscode-megane/package.json` `customEditors`. Walk the full checklist in the `add-format` skill — drift between hosts is the #1 source of "format X works in the webapp but not in VSCode/JupyterLab" bugs.
 7. **The Jupyter widget (anywidget `MolecularViewer`) does not mount the visual pipeline editor.** Pipeline data still flows in via `MolecularViewer.set_pipeline()` (`_pipeline_json` + `_node_snapshots_data`), but the in-cell `PipelineEditor` UI is intentionally not rendered — the host cell chrome cannot reliably lay it out. Do not re-introduce a `pipeline=True` opt-in or a `_pipeline_enabled` traitlet. Visual editing lives in the standalone webapp, JupyterLab labextension, and VSCode extension only.
+8. **Codecov is a hard merge gate — write tests for every new line you add.** The `test-rust`, `test-ts`, and `test-python` jobs in `.github/workflows/ci.yml` upload coverage to Codecov with `fail_ci_on_error: true`, and `codecov.yml` requires **patch coverage ≥ 70 %** on every PR (project coverage is off, only the diff is gated). New parsers, pipeline nodes, React components, Python API, and Rust modules MUST ship with unit tests in the same PR — relying on E2E does not count because E2E is local-only and unmeasured. Reproduce the gate locally before pushing: `npm test -- --coverage` (TS → `coverage/ts/lcov.info`), `cargo llvm-cov --package megane-core --lcov --output-path lcov.info` (Rust), `python -m pytest --cov-report=xml:coverage.xml` (Python). The `make coverage-all` target (or `make coverage-ts` / `coverage` / `coverage-rust`) wraps these. If you genuinely cannot cover a line (e.g. unreachable defensive branch) document why in the PR description rather than disabling the check. See the `testing` skill for details.
 
 ## Dev Environment Setup
 
@@ -56,8 +57,12 @@ Rust compiles to both PyO3 (Python) and WASM (browser) via a Cargo workspace wit
 | Command | What it does |
 |---|---|
 | `npm test` | TypeScript unit tests (vitest) |
+| `npm test -- --coverage` | vitest with V8 coverage → `coverage/ts/lcov.info` (matches Codecov upload) |
 | `cargo test -p megane-core` | Rust parser tests |
-| `python -m pytest` | Python tests (needs maturin develop first) |
+| `cargo llvm-cov --package megane-core --lcov --output-path lcov.info` | Rust coverage in the exact form CI uploads |
+| `python -m pytest` | Python tests (needs maturin develop first); pytest config already enables `--cov` |
+| `python -m pytest --cov-report=xml:coverage.xml` | Python coverage in the exact form CI uploads |
+| `make coverage-all` | Run all three coverage targets locally before pushing |
 | `npm run test:all` | vitest + full Playwright suite |
 | `make test-all` | Python + TypeScript + Rust + active Playwright projects + notebooks + integration |
 


### PR DESCRIPTION
Codecov patch coverage (>= 70%) is enforced in CI via fail_ci_on_error
on the test-rust, test-ts, and test-python jobs, but neither CLAUDE.md
nor the commit/testing/pre-release skills mentioned it. Most PRs were
landing without authors knowing what the gate requires or how to
reproduce it locally.

- CLAUDE.md: add CRITICAL RULE #8 calling out Codecov as a merge gate,
  and extend the Test command table with the per-stack coverage
  invocations CI uses (npm test --coverage, cargo llvm-cov, pytest
  --cov-report=xml).
- testing skill: add a 'Coverage & Codecov (merge gate)' section with
  the local commands that match each CI upload, the make wrappers,
  patch-coverage rules from codecov.yml, and guidance on legitimate
  exceptions.
- commit skill: 'Before Committing' now requires running tests with
  coverage and adding unit tests for new source code in the same
  commit.
- pre-release skill: Phase 3 notes that the release diff is mostly
  Codecov-ignored bumps, but flags the gate when source code is
  bundled into a release branch.