### PR TITLE
fix(pipeline-editor): surface silent Share button failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ wheel-share/data/share/jupyter/labextensions/megane-jupyterlab/
 jupyterlab-megane/lib/
 jupyterlab-megane/node_modules/
 jupyterlab-megane/tsconfig.tsbuildinfo
+tsconfig.tsbuildinfo
+dist-node/
 .ipynb_checkpoints/
 docs/node_modules
 docs/.docusaurus/

--- a/src/components/PipelineEditor.tsx
+++ b/src/components/PipelineEditor.tsx
@@ -381,6 +381,36 @@ const shareBtnStyle: React.CSSProperties = {
   color: "#059669",
 };
 
+const shareFeedbackBase: React.CSSProperties = {
+  display: "inline-block",
+  fontSize: 12,
+  fontWeight: 600,
+  padding: "4px 10px",
+  borderRadius: 4,
+  lineHeight: 1.2,
+};
+
+const SHARE_FEEDBACK_STYLES: Record<"success" | "warning" | "error", React.CSSProperties> = {
+  success: {
+    ...shareFeedbackBase,
+    background: "rgba(16, 185, 129, 0.12)",
+    border: "1px solid rgba(16, 185, 129, 0.35)",
+    color: "#047857",
+  },
+  warning: {
+    ...shareFeedbackBase,
+    background: "rgba(220, 38, 38, 0.12)",
+    border: "1px solid rgba(220, 38, 38, 0.35)",
+    color: "#b91c1c",
+  },
+  error: {
+    ...shareFeedbackBase,
+    background: "rgba(220, 38, 38, 0.12)",
+    border: "1px solid rgba(220, 38, 38, 0.35)",
+    color: "#b91c1c",
+  },
+};
+
 const guideBtnStyle: React.CSSProperties = {
   ...textBtnBase,
   background: "rgba(100, 116, 139, 0.08)",
@@ -521,7 +551,10 @@ function PipelineEditorInner({
   const [showAddMenu, setShowAddMenu] = useState(false);
   const [showTemplateMenu, setShowTemplateMenu] = useState(false);
   const [showRenderModal, setShowRenderModal] = useState(false);
-  const [shareFeedback, setShareFeedback] = useState<string | null>(null);
+  const [shareFeedback, setShareFeedback] = useState<{
+    message: string;
+    tone: "success" | "warning" | "error";
+  } | null>(null);
   const [panelWidth, setPanelWidth] = useState(DEFAULT_WIDTH);
   const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
   const flowContainerRef = useRef<HTMLDivElement | null>(null);
@@ -678,10 +711,21 @@ function PipelineEditorInner({
   );
 
   const handleShare = useCallback(async () => {
-    const serialized = usePipelineStore.getState().serialize();
-    const outcome = await shareCurrentPipeline(serialized);
-    setShareFeedback(outcome.message);
-    setTimeout(() => setShareFeedback(null), outcome.clearAfterMs);
+    try {
+      const serialized = usePipelineStore.getState().serialize();
+      const outcome = await shareCurrentPipeline(serialized);
+      const tone: "success" | "warning" | "error" = outcome.tooLong
+        ? "warning"
+        : outcome.copyFailed
+          ? "error"
+          : "success";
+      setShareFeedback({ message: outcome.message, tone });
+      setTimeout(() => setShareFeedback(null), outcome.clearAfterMs);
+    } catch (err) {
+      console.error("Share failed:", err);
+      setShareFeedback({ message: "Share failed — see console", tone: "error" });
+      setTimeout(() => setShareFeedback(null), 5000);
+    }
   }, []);
 
   const memoizedNodeTypes = useMemo(() => nodeTypes, []);
@@ -811,16 +855,16 @@ function PipelineEditorInner({
         </button>
       </div>
       {shareFeedback && (
-        <div
-          style={{
-            fontSize: 10,
-            color: shareFeedback.startsWith("Pipeline too") ? "#dc2626" : "#059669",
-            padding: "2px 0 0 68px",
-          }}
-          role="status"
-          aria-live="polite"
-        >
-          {shareFeedback}
+        <div style={{ padding: "2px 0 0 68px" }}>
+          <span
+            data-testid="pipeline-editor-share-feedback"
+            data-tone={shareFeedback.tone}
+            style={SHARE_FEEDBACK_STYLES[shareFeedback.tone]}
+            role="status"
+            aria-live="polite"
+          >
+            {shareFeedback.message}
+          </span>
         </div>
       )}
 

--- a/src/pipeline/shareLink.ts
+++ b/src/pipeline/shareLink.ts
@@ -18,7 +18,7 @@ const COPIED_MESSAGE = "Link copied to clipboard!";
 const COPY_FAILED_MESSAGE = "Copy failed — see console for the link";
 
 const COPIED_TOAST_MS = 3000;
-const TOO_LONG_TOAST_MS = 4000;
+const TOO_LONG_TOAST_MS = 5000;
 
 // ── byte ↔ base64url ────────────────────────────────────────────────────────
 

--- a/tests/ts/components/PipelineEditor.test.tsx
+++ b/tests/ts/components/PipelineEditor.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
 
 // Mock heavy children that depend on Three.js / WebGL / WASM so the editor
 // chrome (toolbar, theme button, dropdowns) renders cleanly under jsdom.
@@ -37,6 +37,17 @@ vi.mock("@/tour/MeganeTour", () => ({
 vi.mock("@/renderer/RenderCapture", () => ({
   downloadBlob: vi.fn(),
 }));
+
+const shareCurrentPipelineMock = vi.fn();
+vi.mock("@/pipeline/shareLink", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/pipeline/shareLink")>("@/pipeline/shareLink");
+  return {
+    ...actual,
+    shareCurrentPipeline: (...args: Parameters<typeof actual.shareCurrentPipeline>) =>
+      shareCurrentPipelineMock(...args),
+  };
+});
 
 import { PipelineEditor } from "@/components/PipelineEditor";
 import { useThemeStore } from "@/stores/useThemeStore";
@@ -87,5 +98,81 @@ describe("PipelineEditor — collapsed state", () => {
     render(<PipelineEditor collapsed={true} onToggleCollapse={() => {}} />);
     expect(screen.queryByTestId("pipeline-editor-theme")).toBeNull();
     expect(screen.getByTestId("panel-pipeline-toggle")).toBeTruthy();
+  });
+});
+
+describe("PipelineEditor — Share button feedback", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    shareCurrentPipelineMock.mockReset();
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("shows the success pill when shareCurrentPipeline resolves with copied", async () => {
+    shareCurrentPipelineMock.mockResolvedValue({
+      message: "Link copied to clipboard!",
+      clearAfterMs: 3000,
+      url: "http://example.test/#pipeline=abc",
+      tooLong: false,
+      copyFailed: false,
+    });
+
+    render(<PipelineEditor collapsed={false} onToggleCollapse={() => {}} />);
+    fireEvent.click(screen.getByTestId("pipeline-editor-share"));
+
+    const feedback = await screen.findByTestId("pipeline-editor-share-feedback");
+    expect(feedback.textContent).toContain("Link copied to clipboard!");
+    expect(feedback.getAttribute("data-tone")).toBe("success");
+  });
+
+  it("shows the warning pill when the pipeline is too long", async () => {
+    shareCurrentPipelineMock.mockResolvedValue({
+      message: "Pipeline too large for a share link — use Export instead",
+      clearAfterMs: 5000,
+      url: "http://example.test/#pipeline=zzz",
+      tooLong: true,
+      copyFailed: false,
+    });
+
+    render(<PipelineEditor collapsed={false} onToggleCollapse={() => {}} />);
+    fireEvent.click(screen.getByTestId("pipeline-editor-share"));
+
+    const feedback = await screen.findByTestId("pipeline-editor-share-feedback");
+    expect(feedback.getAttribute("data-tone")).toBe("warning");
+  });
+
+  it("shows the error pill when clipboard write fails", async () => {
+    shareCurrentPipelineMock.mockResolvedValue({
+      message: "Copy failed — see console for the link",
+      clearAfterMs: 3000,
+      url: "http://example.test/#pipeline=abc",
+      tooLong: false,
+      copyFailed: true,
+    });
+
+    render(<PipelineEditor collapsed={false} onToggleCollapse={() => {}} />);
+    fireEvent.click(screen.getByTestId("pipeline-editor-share"));
+
+    const feedback = await screen.findByTestId("pipeline-editor-share-feedback");
+    expect(feedback.getAttribute("data-tone")).toBe("error");
+  });
+
+  it("surfaces silent rejections as a visible error pill (regression for the void-handler bug)", async () => {
+    shareCurrentPipelineMock.mockRejectedValue(new Error("boom"));
+
+    render(<PipelineEditor collapsed={false} onToggleCollapse={() => {}} />);
+    fireEvent.click(screen.getByTestId("pipeline-editor-share"));
+
+    const feedback = await screen.findByTestId("pipeline-editor-share-feedback");
+    expect(feedback.textContent).toContain("Share failed");
+    expect(feedback.getAttribute("data-tone")).toBe("error");
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/tests/ts/pipeline/shareLink.test.ts
+++ b/tests/ts/pipeline/shareLink.test.ts
@@ -288,7 +288,7 @@ describe("shareCurrentPipeline", () => {
     expect(outcome.tooLong).toBe(true);
     expect(outcome.copyFailed).toBe(false);
     expect(outcome.message).toBe("Pipeline too large for a share link — use Export instead");
-    expect(outcome.clearAfterMs).toBe(4000);
+    expect(outcome.clearAfterMs).toBe(5000);
     expect(writeText).not.toHaveBeenCalled();
     expect(replaceStateSpy).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

A user reported the Pipeline Editor's Share button "does nothing" on click. Two real problems combined to produce that perception:

1. **Silent failures.** The button used `onClick={() => void handleShare()}`, which discards the returned promise. Anything thrown by `serialize()`, `buildShareUrl()` (e.g. a `CompressionStream` hang or unexpected throw), or the outer `shareCurrentPipeline()` chain disappeared with no toast and no console error. Only `navigator.clipboard.writeText` and `history.replaceState` were inside an inner try/catch.
2. **Easy-to-miss success feedback.** The success toast was 10px, no background, 3 s, sandwiched between toolbar rows. Clipboard write and hash mirror are themselves invisible browser-level effects, so a user not watching the URL bar genuinely saw no change.

## Changes

- `src/components/PipelineEditor.tsx`
  - Wrap `handleShare` in `try/catch`; on rejection, log via `console.error` and show a red "Share failed — see console" pill.
  - Track the toast variant via `{ message, tone }` instead of pattern-matching the message string. Tone is selected from `outcome.tooLong` / `outcome.copyFailed` returned by `shareCurrentPipeline`.
  - Restyle the toast as a 12px bold pill with colored background and border (green for success, red for warning/error). Add `data-testid="pipeline-editor-share-feedback"` and `data-tone` for tests.
- `src/pipeline/shareLink.ts` — bump `TOO_LONG_TOAST_MS` from 4 s to 5 s so the warning doesn't disappear before the user looks.
- `tests/ts/components/PipelineEditor.test.tsx` — four new component tests covering the success, too-long, copy-failed, and silent-rejection paths (CRITICAL RULE #8 patch coverage).
- `tests/ts/pipeline/shareLink.test.ts` — update the `clearAfterMs` expectation to 5000 ms.
- `.gitignore` — add `tsconfig.tsbuildinfo` and `dist-node/` so local tsc-build artifacts aren't tracked.

## Out of scope

- Switching `deflate()` to the `Response(stream).arrayBuffer()` pattern. The current pattern works in modern browsers, and the new try/catch will now surface a concrete error if it ever does hang on a real user.
- Adding a Share button to other hosts. By CRITICAL RULE #7 the Jupyter widget intentionally does not mount the visual PipelineEditor.

## Test plan

- [x] `npx vitest run` — 813/813 pass (4 new tests in `PipelineEditor.test.tsx`).
- [x] `npm run lint` — no new errors/warnings from this diff (only pre-existing warnings remain).
- [x] `npm run format:check` and `npx prettier --check tests/ts/...` — clean.
- [x] `npx tsc --noEmit -p tsconfig.json` — clean.
- [ ] Manual smoke (`npm run build:wasm && npm run dev`):
  - Click Share → green pill "Link copied to clipboard!" visible for ~3 s, URL hash updates to `#pipeline=…`, clipboard contains the URL.
  - DevTools override `navigator.clipboard.writeText` to throw → red "Copy failed" pill.
  - DevTools override `usePipelineStore.getState().serialize` to throw → red "Share failed — see console" pill + `console.error` (was silent before).

https://claude.ai/code/session_014d5WWKFpvTvPDVpbWjCvQg

---
_Generated by [Claude Code](https://claude.ai/code/session_014d5WWKFpvTvPDVpbWjCvQg)_