### PR TITLE
docs: add AMBER NetCDF format and fix missing format entries

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -109,6 +109,7 @@ For multiple independent viewers per page (e.g. embedding in MDX docs), use
 | DCD | `.dcd` | CHARMM/NAMD binary trajectory |
 | ASE .traj | `.traj` | ASE trajectory (ULM binary format) |
 | LAMMPS dump | `.lammpstrj`, `.dump` | LAMMPS dump trajectory |
+| AMBER NetCDF | `.nc` | AMBER compressed trajectory (NetCDF format) |
 
 Not every host opens every extension from its native file picker — see
 [Platform Support](./platform-support) for the per-host matrix.

--- a/docs/docs/guide/pipeline/index.md
+++ b/docs/docs/guide/pipeline/index.md
@@ -29,7 +29,7 @@ The generator creates the appropriate LoadStructure, AddBond, Filter, Modify, an
 
 ## VSCode Extension Auto-Setup
 
-When you open a supported molecular file (`.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf`, `.cif`, `.data`, `.lammps`, `.traj`, `.xtc`, `.lammpstrj`, `.dump`) in the megane VSCode extension, it automatically creates a default pipeline consisting of `LoadStructure → AddBond → Viewport`. This gives you an immediate 3D view of the structure with bonds, without needing to build a pipeline manually. You can then modify the auto-generated pipeline in the editor as needed.
+When you open a supported molecular file (`.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf`, `.mol2`, `.cif`, `.data`, `.lammps`, `.traj`, `.xtc`, `.dcd`, `.lammpstrj`, `.dump`, `.nc`) in the megane VSCode extension, it automatically creates a default pipeline consisting of `LoadStructure → AddBond → Viewport`. This gives you an immediate 3D view of the structure with bonds, without needing to build a pipeline manually. You can then modify the auto-generated pipeline in the editor as needed.
 
 ## Getting Started
 
@@ -59,7 +59,7 @@ Use the **Templates** dropdown to load pre-built pipelines:
 | Node | Description | Inputs | Outputs |
 |------|-------------|--------|---------|
 | **Load Structure** | Load a molecular structure file (PDB, GRO, XYZ, MOL, SDF, MOL2, CIF, LAMMPS data, ASE `.traj`) | — | particle, trajectory, cell |
-| **Load Trajectory** | Load a separate trajectory file (XTC, LAMMPS `.lammpstrj` / `.dump`) | particle | trajectory |
+| **Load Trajectory** | Load a separate trajectory file (XTC, DCD, LAMMPS `.lammpstrj` / `.dump`, AMBER NetCDF `.nc`) | particle | trajectory |
 | **Streaming** | WebSocket-based real-time data delivery (only available on the standalone `megane serve` host) | — | particle, bond, trajectory, cell |
 | **Load Vector** | Load per-atom vector data from a file | — | vector |
 
@@ -97,7 +97,7 @@ Use the **Templates** dropdown to load pre-built pipelines:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| File path | string | Path to a trajectory file. Supported: `.xtc`, `.lammpstrj` / `.dump` |
+| File path | string | Path to a trajectory file. Supported: `.xtc`, `.dcd`, `.lammpstrj` / `.dump`, `.nc` |
 
 Requires a connection from a LoadStructure node. Frames are loaded lazily when `frame_index` changes.
 

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 ## What can megane do?
 
 - **Render 1M+ atoms at 60 fps** in the browser using billboard impostor rendering
-- **Load 12 file formats**: PDB, GRO, XYZ, MOL, SDF, MOL2, CIF, LAMMPS data, XTC, DCD, ASE `.traj`, LAMMPS dump
+- **Load 13 file formats**: PDB, GRO, XYZ, MOL, SDF, MOL2, CIF, LAMMPS data, XTC, DCD, ASE `.traj`, LAMMPS dump, AMBER NetCDF
 - **Stream XTC trajectories from the `megane serve` CLI** over WebSocket — scrub multi-GB files without loading every frame into memory (browser/Jupyter without the CLI load full trajectories)
 - **Build visual pipelines** with a drag-and-drop node editor, or write them as Python/TypeScript code
 - **Integrate with Plotly**, MDX/Next.js, ipywidgets, and any framework via the framework-agnostic renderer
@@ -39,8 +39,10 @@ For a side-by-side comparison of which formats and UI features each environment 
 | Crystallographic Information File | `.cif` |
 | LAMMPS data | `.data`, `.lammps` |
 | GROMACS trajectory | `.xtc` |
+| CHARMM/NAMD DCD trajectory | `.dcd` |
 | ASE trajectory | `.traj` |
 | LAMMPS dump | `.lammpstrj`, `.dump` |
+| AMBER NetCDF trajectory | `.nc` |
 
 Per-host coverage (which formats each platform's UI can open vs. parser-only access) is enumerated in [Platform Support](./platform-support).
 

--- a/docs/docs/platform-support.md
+++ b/docs/docs/platform-support.md
@@ -42,12 +42,13 @@ Legend:
 | Format | Extensions | Standalone | Jupyter widget | JupyterLab | VSCode | Python |
 |---|---|:---:|:---:|:---:|:---:|:---:|
 | XTC | `.xtc` | ✓ | API | ✓¹ | ✓¹ | ✓ |
-| DCD | `.dcd` | ✓ | API | ✓¹ | ✓¹ | ✓ |
+| DCD | `.dcd` | ✓ | API | ✓¹ | ✓¹ | API |
 | ASE trajectory | `.traj` | ✓ | API | ✓ | ✓ | ✓ |
-| LAMMPS dump | `.lammpstrj`, `.dump` | ✓ | API | ✓¹ | ✓¹ | ✓ |
+| LAMMPS dump | `.lammpstrj`, `.dump` | ✓ | API | ✓¹ | ✓¹ | API |
+| AMBER NetCDF | `.nc` | ✓ | API | ✓¹ | ✓¹ | API |
 
 ¹ Trajectory-only formats need a topology already loaded. Opening a `.xtc` /
-`.dcd` / `.lammpstrj` / `.dump` directly surfaces an actionable error; recover by
+`.dcd` / `.lammpstrj` / `.dump` / `.nc` directly surfaces an actionable error; recover by
 opening a structure file (PDB, GRO, …) first or by wiring a Load Structure
 node in the always-mounted pipeline editor.
 
@@ -84,13 +85,13 @@ How data gets into the viewer on each platform:
 | **Jupyter widget** | Python only — no in-cell file picker | `MolecularViewer.load(pdb_path, xtc=, traj=)` (deprecated) or `MolecularViewer.set_pipeline(Pipeline)` (recommended) |
 | **JupyterLab** | Click a registered file type in the file browser | Internally reads `context.model` (`jupyterlab-megane/src/MeganeDocWidget.tsx`) |
 | **VSCode** | Open a registered file from the explorer; extension host posts `loadFile` / `loadPipeline` to the webview | `postMessage({ type: "loadFile", … })` (`vscode-megane/webview/main.tsx`) |
-| **Python** | `from megane.parsers import …` | `load_pdb`, `load_cif`, `load_lammps_data`, `load_traj`, `load_trajectory` (XTC), and the `parse_*` PyO3 functions |
+| **Python** | `from megane.parsers import …` | `load_pdb`, `load_cif`, `load_lammps_data`, `load_traj`, `load_trajectory` (XTC), `load_xyz_trajectory`, and the `parse_*` PyO3 functions |
 
 ## Known gaps
 
 These are formats or features that the parser layer supports but a given platform does not yet wire into its UI. They are documented here so users do not file bugs against expected-but-absent behaviour.
 
-- **Trajectory-only opens require a topology first.** On VSCode and JupyterLab, opening a `.xtc` / `.dcd` / `.lammpstrj` / `.dump` file before any structure is loaded surfaces a friendly error. The recommended flow is to open the structure first, or to use the pipeline editor (always mounted on these hosts) to wire a Load Structure node.
+- **Trajectory-only opens require a topology first.** On VSCode and JupyterLab, opening a `.xtc` / `.dcd` / `.lammpstrj` / `.dump` / `.nc` file before any structure is loaded surfaces a friendly error. The recommended flow is to open the structure first, or to use the pipeline editor (always mounted on these hosts) to wire a Load Structure node.
 - **Jupyter widget has no in-cell file picker or drag-and-drop.** This is intentional — the widget is Python-driven. Use `set_pipeline()` with a `Pipeline` to load any supported format.
 - **Jupyter widget has no visual pipeline editor.** The editor's React surface relies on host chrome (drag handles, side panel layout) that the anywidget cell cannot reliably render, so it is only shipped on the standalone app, JupyterLab labextension, and VSCode extension. Build pipelines in Python with `megane.Pipeline` and push them via `MolecularViewer.set_pipeline()`.
 - **`selection_change` / `measurement` events are widget-only.** Other platforms do not emit these to a host. The standalone React component does expose `onFrameChange` (see UI features table).


### PR DESCRIPTION
## Summary

- **Add AMBER NetCDF (`.nc`) to all format tables** — the format was fully implemented in WASM, JupyterLab labextension, VSCode extension, and the standalone web app but never documented in any user-facing page.
- **Add missing DCD row** to the `introduction.md` supported formats table (it was mentioned in the bullet list but omitted from the table below it).
- **Fix Python support level** for DCD and LAMMPS dump in `platform-support.md` — downgraded from ✓ to API since neither `load_dcd` nor `load_lammpstrj` are in `__all__`; only the low-level `parse_*` PyO3 functions are available.
- **Add `load_xyz_trajectory`** to the Python API list in `platform-support.md` (it is exported in `__all__` but was missing from the docs).
- **Update Load Trajectory descriptions** in `guide/pipeline/index.md` to include DCD and AMBER NetCDF alongside XTC and LAMMPS dump.
- **Expand VSCode Extension Auto-Setup file list** to include `.mol2`, `.dcd`, and `.nc` which are registered in `vscode-megane/package.json` `customEditors` but were absent from the doc.

## Files changed

| File | What changed |
|---|---|
| `docs/docs/introduction.md` | Format count 12→13, add DCD and NetCDF to table |
| `docs/docs/getting-started.md` | Add AMBER NetCDF row to format table |
| `docs/docs/platform-support.md` | Add NetCDF trajectory row; fix DCD/LAMMPS-dump Python ✓→API; add `load_xyz_trajectory`; extend footnote and Known-gaps list |
| `docs/docs/guide/pipeline/index.md` | Load Trajectory node: add DCD/NetCDF; VSCode auto-setup file list |

## Test plan

- [ ] Read each changed doc and verify all format names, extensions, and platform columns are consistent with the source-of-truth files (`crates/megane-wasm/src/lib.rs`, `crates/megane-python/src/lib.rs`, `src/components/nodes/LoadTrajectoryNode.tsx`, `jupyterlab-megane/src/filetypes.ts`, `vscode-megane/package.json`, `python/megane/__init__.py`)
- [ ] Documentation-only change: no code coverage impact

https://claude.ai/code/session_01VfZ8LnBmrPPvrKvt9Q1rBa