### PR TITLE
feat(jupyterlab): wire frame_change callback and show frame counter in status bar

### DIFF
--- a/docs/docs/platform-support.md
+++ b/docs/docs/platform-support.md
@@ -63,7 +63,7 @@ Sources of truth: `crates/megane-wasm/src/lib.rs` (browser parsers), `crates/meg
 | Trajectory timeline / scrubbing | ✓ | ✓ | ✓ | ✓ | n/a |
 | WebSocket trajectory streaming | ✓ | — | — | — | n/a |
 | Multi-layer rendering | ✓ | ✓ (via pipeline) | ✓ | ✓ | n/a |
-| `frame_change` callback | ✓ (React prop) | ✓ (Python event) | — | ✓ (status bar) | n/a |
+| `frame_change` callback | ✓ (React prop) | ✓ (Python event) | ✓ (status bar) | ✓ (status bar) | n/a |
 | `selection_change` / `measurement` events | — | ✓ | — | — | n/a |
 | Programmatic frame seek (`frame_index = N`) | ✓ | ✓ | — | — | n/a |
 
@@ -94,4 +94,4 @@ These are formats or features that the parser layer supports but a given platfor
 - **Jupyter widget has no in-cell file picker or drag-and-drop.** This is intentional — the widget is Python-driven. Use `set_pipeline()` with a `Pipeline` to load any supported format.
 - **Jupyter widget has no visual pipeline editor.** The editor's React surface relies on host chrome (drag handles, side panel layout) that the anywidget cell cannot reliably render, so it is only shipped on the standalone app, JupyterLab labextension, and VSCode extension. Build pipelines in Python with `megane.Pipeline` and push them via `MolecularViewer.set_pipeline()`.
 - **`selection_change` / `measurement` events are widget-only.** Other platforms do not emit these to a host. The standalone React component does expose `onFrameChange` (see UI features table).
-- **`frame_change` callback is not yet wired for JupyterLab.** The JupyterLab DocWidget has no Python kernel connection, so there is no callback surface to fire. The VSCode extension surfaces it as a status-bar frame counter.
+- **`frame_change` callback for JupyterLab is surfaced as a status-bar frame counter.** The JupyterLab DocWidget has no Python kernel connection, so there is no Python callback surface. Instead, when `IStatusBar` is available, the current frame index is shown in the JupyterLab status bar (right side). The `subscribeFrameChange` method on `MeganeReactView` can also be used by other JupyterLab extensions to react to frame changes.

--- a/jupyterlab-megane/package.json
+++ b/jupyterlab-megane/package.json
@@ -28,6 +28,7 @@
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/docregistry": "^4.0.0",
     "@jupyterlab/services": "^7.0.0",
+    "@jupyterlab/statusbar": "^4.0.0",
     "@jupyterlab/ui-components": "^4.0.0",
     "@lumino/widgets": "^2.0.0",
     "react": "^18.2.0",

--- a/jupyterlab-megane/src/MeganeDocWidget.tsx
+++ b/jupyterlab-megane/src/MeganeDocWidget.tsx
@@ -14,6 +14,7 @@ import "@megane/styles/megane.css";
 import { ensureWasmUrl } from "./wasmLoader";
 import { STRUCTURE_FILETYPES_BINARY } from "./filetypes";
 import { TRAJECTORY_ONLY_EXTENSIONS } from "./trajectoryUtils";
+import { createFrameSubscription } from "./frameSubscription";
 
 const BINARY_EXTENSIONS = new Set(
   STRUCTURE_FILETYPES_BINARY.flatMap((f) => f.extensions ?? []),
@@ -31,6 +32,7 @@ type ActivationSubscribe = (cb: () => void) => () => void;
 interface DocBodyProps {
   context: DocumentRegistry.Context;
   subscribeActivation: ActivationSubscribe;
+  onFrameChange?: (frame: number) => void;
 }
 
 type LoadState = "loading" | "ready" | { error: string };
@@ -52,7 +54,7 @@ function ThemeSync() {
   return null;
 }
 
-function DocBody({ context, subscribeActivation }: DocBodyProps): JSX.Element {
+function DocBody({ context, subscribeActivation, onFrameChange }: DocBodyProps): JSX.Element {
   const local = useMeganeLocal();
   const [state, setState] = useState<LoadState>("loading");
   useTour({ host: "jupyterlab" });
@@ -200,6 +202,7 @@ function DocBody({ context, subscribeActivation }: DocBodyProps): JSX.Element {
         onVectorSourceChange={(s: string) => local.setVectorSource(s as "none" | "file" | "demo")}
         onLoadVectorFile={(f: File) => local.loadVectorFile(f)}
         onLoadDemoVectors={() => local.loadDemoVectors()}
+        onFrameChange={onFrameChange}
       />
     </div>
   );
@@ -207,6 +210,14 @@ function DocBody({ context, subscribeActivation }: DocBodyProps): JSX.Element {
 
 export class MeganeReactView extends ReactWidget {
   private readonly listeners = new Set<() => void>();
+  private readonly _frameSub = createFrameSubscription();
+
+  /** Subscribe to trajectory frame-change events emitted by the viewer. */
+  readonly subscribeFrameChange = this._frameSub.subscribe.bind(this._frameSub);
+
+  private readonly _handleFrameChange = (frame: number): void => {
+    this._frameSub.emit(frame);
+  };
 
   constructor(private readonly context: DocumentRegistry.Context) {
     super();
@@ -233,6 +244,12 @@ export class MeganeReactView extends ReactWidget {
   };
 
   protected render(): JSX.Element {
-    return <DocBody context={this.context} subscribeActivation={this.subscribeActivation} />;
+    return (
+      <DocBody
+        context={this.context}
+        subscribeActivation={this.subscribeActivation}
+        onFrameChange={this._handleFrameChange}
+      />
+    );
   }
 }

--- a/jupyterlab-megane/src/frameStatusBar.ts
+++ b/jupyterlab-megane/src/frameStatusBar.ts
@@ -1,0 +1,34 @@
+import { Widget } from "@lumino/widgets";
+import type { IStatusBar } from "@jupyterlab/statusbar";
+import type { WidgetTracker } from "@jupyterlab/apputils";
+import type { IDocumentWidget } from "@jupyterlab/docregistry";
+import type { MeganeReactView } from "./MeganeDocWidget";
+
+export function setupFrameStatusBar(
+  tracker: WidgetTracker<IDocumentWidget<MeganeReactView>>,
+  statusBar: IStatusBar,
+): void {
+  const item = new Widget();
+  item.addClass("jp-megane-frame-status");
+  item.node.textContent = "";
+
+  let currentUnsub: (() => void) | null = null;
+
+  tracker.currentChanged.connect((_tracker, widget) => {
+    currentUnsub?.();
+    currentUnsub = null;
+    item.node.textContent = "";
+    if (widget) {
+      currentUnsub = widget.content.subscribeFrameChange((frame) => {
+        item.node.textContent = `Frame ${frame}`;
+      });
+    }
+  });
+
+  statusBar.registerStatusItem("megane:frame-counter", {
+    item,
+    align: "right",
+    rank: 100,
+    isActive: () => tracker.currentWidget !== null,
+  });
+}

--- a/jupyterlab-megane/src/frameSubscription.ts
+++ b/jupyterlab-megane/src/frameSubscription.ts
@@ -1,0 +1,27 @@
+type FrameListener = (frame: number) => void;
+
+export interface FrameSubscription {
+  subscribe(listener: FrameListener): () => void;
+  emit(frame: number): void;
+}
+
+export function createFrameSubscription(): FrameSubscription {
+  const listeners = new Set<FrameListener>();
+  return {
+    subscribe(listener: FrameListener): () => void {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    emit(frame: number): void {
+      for (const cb of listeners) {
+        try {
+          cb(frame);
+        } catch {
+          // swallow listener errors so one bad listener doesn't block others
+        }
+      }
+    },
+  };
+}

--- a/jupyterlab-megane/src/index.ts
+++ b/jupyterlab-megane/src/index.ts
@@ -5,8 +5,10 @@ import {
 } from "@jupyterlab/application";
 import { WidgetTracker } from "@jupyterlab/apputils";
 import type { IDocumentWidget } from "@jupyterlab/docregistry";
+import { IStatusBar } from "@jupyterlab/statusbar";
 import { exposeAppForTests } from "./testHook";
 import { MeganeDocFactory, MeganePipelineDocFactory } from "./factory";
+import { setupFrameStatusBar } from "./frameStatusBar";
 import type { MeganeReactView } from "./MeganeDocWidget";
 import type { MeganePipelineReactView } from "./MeganePipelineDocWidget";
 import {
@@ -31,7 +33,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
     "Open molecular structure files (PDB, GRO, XYZ, MOL, SDF, CIF, LAMMPS data, ASE traj) and trajectories (XTC, DCD, LAMMPS dump) and megane pipelines",
   autoStart: true,
   requires: [ILayoutRestorer],
-  activate: (app: JupyterFrontEnd, restorer: ILayoutRestorer) => {
+  optional: [IStatusBar],
+  activate: (app: JupyterFrontEnd, restorer: ILayoutRestorer, statusBar: IStatusBar | null) => {
     exposeAppForTests(app);
 
     for (const ft of [...STRUCTURE_FILETYPES_TEXT, ...STRUCTURE_FILETYPES_BINARY]) {
@@ -123,6 +126,10 @@ const plugin: JupyterFrontEndPlugin<void> = {
       }),
       name: (widget) => widget.context.path,
     });
+
+    if (statusBar) {
+      setupFrameStatusBar(tracker, statusBar);
+    }
   },
 };
 

--- a/tests/ts/__stubs__/jupyterlab-statusbar.ts
+++ b/tests/ts/__stubs__/jupyterlab-statusbar.ts
@@ -1,0 +1,10 @@
+// Test-only stub for `@jupyterlab/statusbar`.
+// Provides the IStatusBar token shape so index.ts resolves at transform time.
+// vi.mock() supplies behavior where needed.
+
+export class IStatusBar {
+  registerStatusItem(_id: string, _options: object): void {
+    void _id;
+    void _options;
+  }
+}

--- a/tests/ts/__stubs__/lumino-widgets.ts
+++ b/tests/ts/__stubs__/lumino-widgets.ts
@@ -1,0 +1,14 @@
+// Test-only stub for `@lumino/widgets`.
+// Provides minimal Widget shape so jupyterlab-megane/src/frameStatusBar.ts
+// resolves at transform time. Tests can use vi.mock() to override behavior.
+
+export class Widget {
+  node: HTMLElement;
+  constructor() {
+    this.node = document.createElement("div");
+  }
+  addClass(_className: string): void {
+    void _className;
+  }
+  dispose(): void {}
+}

--- a/tests/ts/jupyterlab/frameStatusBar.test.ts
+++ b/tests/ts/jupyterlab/frameStatusBar.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// @lumino/widgets is resolved via the stub alias in vitest.config.ts
+import { setupFrameStatusBar } from "../../../jupyterlab-megane/src/frameStatusBar";
+
+type CurrentChangedHandler = (
+  tracker: unknown,
+  widget: { content: { subscribeFrameChange: (cb: (f: number) => void) => () => void } } | null,
+) => void;
+
+function makeTracker(currentWidget: unknown = null) {
+  let handler: CurrentChangedHandler | null = null;
+  return {
+    currentWidget,
+    currentChanged: {
+      connect: vi.fn((h: CurrentChangedHandler) => {
+        handler = h;
+      }),
+    },
+    fireCurrentChanged(
+      widget: { content: { subscribeFrameChange: (cb: (f: number) => void) => () => void } } | null,
+    ) {
+      handler?.(this, widget);
+    },
+  };
+}
+
+function makeStatusBar() {
+  return { registerStatusItem: vi.fn() };
+}
+
+function registeredItem(
+  statusBar: ReturnType<typeof makeStatusBar>,
+): { node: { textContent: string } } {
+  return statusBar.registerStatusItem.mock.calls[0][1].item as {
+    node: { textContent: string };
+  };
+}
+
+describe("setupFrameStatusBar", () => {
+  let tracker: ReturnType<typeof makeTracker>;
+  let statusBar: ReturnType<typeof makeStatusBar>;
+
+  beforeEach(() => {
+    tracker = makeTracker();
+    statusBar = makeStatusBar();
+  });
+
+  it("registers a status item with the correct id and alignment", () => {
+    setupFrameStatusBar(tracker as never, statusBar as never);
+
+    expect(statusBar.registerStatusItem).toHaveBeenCalledWith(
+      "megane:frame-counter",
+      expect.objectContaining({ align: "right", rank: 100 }),
+    );
+  });
+
+  it("connects to tracker.currentChanged", () => {
+    setupFrameStatusBar(tracker as never, statusBar as never);
+    expect(tracker.currentChanged.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts with empty status item text", () => {
+    setupFrameStatusBar(tracker as never, statusBar as never);
+    const item = registeredItem(statusBar);
+    expect(item.node.textContent).toBe("");
+  });
+
+  it("subscribes to the widget's frame changes when a widget becomes active", () => {
+    setupFrameStatusBar(tracker as never, statusBar as never);
+
+    const unsub = vi.fn();
+    const mockWidget = {
+      content: {
+        subscribeFrameChange: vi.fn(() => unsub),
+      },
+    };
+
+    tracker.fireCurrentChanged(mockWidget);
+    expect(mockWidget.content.subscribeFrameChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates item text content when frame changes", () => {
+    setupFrameStatusBar(tracker as never, statusBar as never);
+
+    let frameCb: ((f: number) => void) | null = null;
+    const mockWidget = {
+      content: {
+        subscribeFrameChange: vi.fn((cb: (f: number) => void) => {
+          frameCb = cb;
+          return vi.fn();
+        }),
+      },
+    };
+
+    tracker.fireCurrentChanged(mockWidget);
+    frameCb!(99);
+
+    const item = registeredItem(statusBar);
+    expect(item.node.textContent).toBe("Frame 99");
+  });
+
+  it("clears item text and unsubscribes when widget is deactivated", () => {
+    setupFrameStatusBar(tracker as never, statusBar as never);
+
+    let frameCb: ((f: number) => void) | null = null;
+    const unsub = vi.fn();
+    const mockWidget = {
+      content: {
+        subscribeFrameChange: vi.fn((cb: (f: number) => void) => {
+          frameCb = cb;
+          return unsub;
+        }),
+      },
+    };
+
+    tracker.fireCurrentChanged(mockWidget);
+    frameCb!(5);
+
+    const item = registeredItem(statusBar);
+    expect(item.node.textContent).toBe("Frame 5");
+
+    tracker.fireCurrentChanged(null);
+    expect(unsub).toHaveBeenCalledTimes(1);
+    expect(item.node.textContent).toBe("");
+  });
+
+  it("unsubscribes from previous widget when a new widget becomes active", () => {
+    setupFrameStatusBar(tracker as never, statusBar as never);
+
+    const unsub1 = vi.fn();
+    const widget1 = {
+      content: { subscribeFrameChange: vi.fn(() => unsub1) },
+    };
+    const unsub2 = vi.fn();
+    const widget2 = {
+      content: { subscribeFrameChange: vi.fn(() => unsub2) },
+    };
+
+    tracker.fireCurrentChanged(widget1);
+    tracker.fireCurrentChanged(widget2);
+
+    expect(unsub1).toHaveBeenCalledTimes(1);
+    expect(unsub2).not.toHaveBeenCalled();
+  });
+
+  it("isActive returns true when tracker has a current widget", () => {
+    const trackerWithWidget = makeTracker({ content: {} });
+    setupFrameStatusBar(trackerWithWidget as never, statusBar as never);
+
+    const options = statusBar.registerStatusItem.mock.calls[0][1] as {
+      isActive: () => boolean;
+    };
+    expect(options.isActive()).toBe(true);
+  });
+
+  it("isActive returns false when tracker has no current widget", () => {
+    setupFrameStatusBar(tracker as never, statusBar as never);
+
+    const options = statusBar.registerStatusItem.mock.calls[0][1] as {
+      isActive: () => boolean;
+    };
+    expect(options.isActive()).toBe(false);
+  });
+});

--- a/tests/ts/jupyterlab/frameSubscription.test.ts
+++ b/tests/ts/jupyterlab/frameSubscription.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from "vitest";
+import { createFrameSubscription } from "../../../jupyterlab-megane/src/frameSubscription";
+
+describe("createFrameSubscription", () => {
+  it("calls listener when emit is called", () => {
+    const sub = createFrameSubscription();
+    const received: number[] = [];
+    sub.subscribe((f) => received.push(f));
+    sub.emit(42);
+    expect(received).toEqual([42]);
+  });
+
+  it("calls listener multiple times", () => {
+    const sub = createFrameSubscription();
+    const received: number[] = [];
+    sub.subscribe((f) => received.push(f));
+    sub.emit(1);
+    sub.emit(2);
+    sub.emit(3);
+    expect(received).toEqual([1, 2, 3]);
+  });
+
+  it("unsubscribes correctly", () => {
+    const sub = createFrameSubscription();
+    const received: number[] = [];
+    const unsub = sub.subscribe((f) => received.push(f));
+    sub.emit(1);
+    unsub();
+    sub.emit(2);
+    expect(received).toEqual([1]);
+  });
+
+  it("unsubscribing is idempotent", () => {
+    const sub = createFrameSubscription();
+    const received: number[] = [];
+    const unsub = sub.subscribe((f) => received.push(f));
+    unsub();
+    unsub();
+    sub.emit(99);
+    expect(received).toEqual([]);
+  });
+
+  it("notifies multiple listeners independently", () => {
+    const sub = createFrameSubscription();
+    const a: number[] = [];
+    const b: number[] = [];
+    sub.subscribe((f) => a.push(f));
+    sub.subscribe((f) => b.push(f));
+    sub.emit(7);
+    expect(a).toEqual([7]);
+    expect(b).toEqual([7]);
+  });
+
+  it("removing one listener does not affect others", () => {
+    const sub = createFrameSubscription();
+    const a: number[] = [];
+    const b: number[] = [];
+    const unsubA = sub.subscribe((f) => a.push(f));
+    sub.subscribe((f) => b.push(f));
+    unsubA();
+    sub.emit(5);
+    expect(a).toEqual([]);
+    expect(b).toEqual([5]);
+  });
+
+  it("swallows listener errors and continues calling remaining listeners", () => {
+    const sub = createFrameSubscription();
+    const received: number[] = [];
+    sub.subscribe(() => {
+      throw new Error("oops");
+    });
+    sub.subscribe((f) => received.push(f));
+    expect(() => sub.emit(1)).not.toThrow();
+    expect(received).toEqual([1]);
+  });
+
+  it("handles emit with no listeners without throwing", () => {
+    const sub = createFrameSubscription();
+    expect(() => sub.emit(0)).not.toThrow();
+  });
+
+  it("returns a function from subscribe", () => {
+    const sub = createFrameSubscription();
+    const unsub = sub.subscribe(vi.fn());
+    expect(typeof unsub).toBe("function");
+  });
+});

--- a/tests/ts/jupyterlab/plugin-statusbar.test.ts
+++ b/tests/ts/jupyterlab/plugin-statusbar.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../jupyterlab-megane/src/testHook", () => ({
+  exposeAppForTests: vi.fn(),
+}));
+
+vi.mock("../../../jupyterlab-megane/src/factory", () => {
+  const MockFactory = class {
+    widgetCreated = { connect: vi.fn() };
+    constructor(_opts: unknown) {
+      void _opts;
+    }
+  };
+  return { MeganeDocFactory: MockFactory, MeganePipelineDocFactory: MockFactory };
+});
+
+vi.mock("../../../jupyterlab-megane/src/MeganeDocWidget", () => ({}));
+vi.mock("../../../jupyterlab-megane/src/MeganePipelineDocWidget", () => ({}));
+
+vi.mock("../../../jupyterlab-megane/src/frameStatusBar", () => ({
+  setupFrameStatusBar: vi.fn(),
+}));
+
+vi.mock("@jupyterlab/apputils", () => ({
+  WidgetTracker: class {
+    constructor(_opts: unknown) {
+      void _opts;
+    }
+    add = vi.fn().mockResolvedValue(undefined);
+    save = vi.fn().mockResolvedValue(undefined);
+    currentWidget = null;
+  },
+}));
+
+import plugin from "../../../jupyterlab-megane/src/index";
+import { setupFrameStatusBar } from "../../../jupyterlab-megane/src/frameStatusBar";
+
+const mockApp = {
+  docRegistry: {
+    addFileType: vi.fn(),
+    addWidgetFactory: vi.fn(),
+  },
+  serviceManager: { contents: {} },
+};
+
+const mockRestorer = {
+  restore: vi.fn().mockResolvedValue(undefined),
+};
+
+describe("megane JupyterLab plugin – IStatusBar optional integration", () => {
+  beforeEach(() => {
+    vi.mocked(setupFrameStatusBar).mockClear();
+    vi.mocked(mockApp.docRegistry.addFileType).mockClear();
+    vi.mocked(mockApp.docRegistry.addWidgetFactory).mockClear();
+    vi.mocked(mockRestorer.restore).mockClear();
+  });
+
+  it("calls setupFrameStatusBar when IStatusBar is provided", () => {
+    const fakeStatusBar = { registerStatusItem: vi.fn() };
+    plugin.activate(mockApp as never, mockRestorer as never, fakeStatusBar as never);
+
+    expect(setupFrameStatusBar).toHaveBeenCalledTimes(1);
+    expect(setupFrameStatusBar).toHaveBeenCalledWith(
+      expect.anything(),
+      fakeStatusBar,
+    );
+  });
+
+  it("skips setupFrameStatusBar when statusBar is null", () => {
+    plugin.activate(mockApp as never, mockRestorer as never, null as never);
+    expect(setupFrameStatusBar).not.toHaveBeenCalled();
+  });
+
+  it("always registers file types and factories regardless of statusBar", () => {
+    plugin.activate(mockApp as never, mockRestorer as never, null as never);
+    expect(mockApp.docRegistry.addFileType).toHaveBeenCalled();
+    expect(mockApp.docRegistry.addWidgetFactory).toHaveBeenCalled();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,6 +29,16 @@ export default defineConfig({
         __dirname,
         "tests/ts/__stubs__/jupyterlab-services.ts",
       ),
+      "@jupyterlab/statusbar": path.resolve(
+        __dirname,
+        "tests/ts/__stubs__/jupyterlab-statusbar.ts",
+      ),
+      // `@lumino/widgets` is a peer dep of jupyterlab-megane but is not in the
+      // root node_modules. The stub satisfies import resolution at test time.
+      "@lumino/widgets": path.resolve(
+        __dirname,
+        "tests/ts/__stubs__/lumino-widgets.ts",
+      ),
       // `vscode` is injected by the VS Code extension host at runtime and is
       // not present in any node_modules. Tests mock it via vi.mock(); the stub
       // only needs to satisfy resolution.


### PR DESCRIPTION
## Summary

Closes one of the remaining platform-support gaps tracked in #377: the JupyterLab DocWidget now surfaces the `frame_change` event as a status-bar frame counter, matching what the VSCode extension already does.

- **`frameSubscription.ts`** — pure-TS pub/sub helper that bridges the React `onFrameChange` callback to the Lumino widget boundary without importing `@lumino/signaling`.
- **`frameStatusBar.ts`** — subscribes to `tracker.currentChanged` and `widget.content.subscribeFrameChange`; writes `Frame N` into a Lumino `Widget` registered with `IStatusBar` (right-aligned, rank 100). Clears and unsubscribes when the active document changes.
- **`MeganeDocWidget.tsx`** — adds `onFrameChange` prop to `DocBody`, passes it to `MeganeViewer`, exposes `subscribeFrameChange` on `MeganeReactView`.
- **`index.ts`** — declares `optional: [IStatusBar]`; calls `setupFrameStatusBar(tracker, statusBar)` when the service is present (no-op when absent, so the extension still works in minimal JupyterLab environments).
- **`jupyterlab-megane/package.json`** — adds `@jupyterlab/statusbar ^4.0.0` as a direct dependency.
- **`vitest.config.ts`** — adds `@jupyterlab/statusbar` and `@lumino/widgets` stub aliases so the new tests resolve cleanly.
- **`docs/docs/platform-support.md`** — updates the `frame_change` row to ✓ for JupyterLab; revises the Known gaps entry.

## Tests

21 new unit tests added (all passing):

- `frameSubscription.test.ts` × 9 — subscribe, emit, multi-listener, unsubscribe, error-swallow, edge cases.
- `frameStatusBar.test.ts` × 9 — registerStatusItem id/alignment, connect to tracker, text updates, unsubscribe on deactivation, widget switching, isActive.
- `plugin-statusbar.test.ts` × 3 — activate calls `setupFrameStatusBar` when `statusBar` is provided, skips it when null, always registers file types.

## Test plan

- [x] `npm test -- --run` — 728 passing (5 pre-existing wasmLoader failures due to WASM not built locally; CI builds WASM first)
- [x] All 21 new tests green
- [x] No regressions in existing JupyterLab tests

https://claude.ai/code/session_01DiTbU2UKMA2iwdHcxuc5gF