### PR TITLE
feat(widget): add in-cell drag-and-drop / file picker for Jupyter widget

### DIFF
--- a/docs/docs/platform-support.md
+++ b/docs/docs/platform-support.md
@@ -58,19 +58,21 @@ Sources of truth: `crates/megane-wasm/src/lib.rs` (browser parsers), `crates/meg
 
 | Feature | Standalone | Jupyter widget | JupyterLab | VSCode | Python |
 |---|:---:|:---:|:---:|:---:|:---:|
-| Drag-and-drop into viewer | ✓ | — | — | — | n/a |
-| Built-in file picker | ✓ | — | host | host | n/a |
+| Drag-and-drop into viewer | ✓ | ✓¹ | — | — | n/a |
+| Built-in file picker | ✓ | ✓¹ | host | host | n/a |
 | Visual pipeline editor | ✓ | — | ✓ | ✓ (`.megane.json`) | n/a |
 | Trajectory timeline / scrubbing | ✓ | ✓ | ✓ | ✓ | n/a |
 | WebSocket trajectory streaming | ✓ | — | — | — | n/a |
 | Multi-layer rendering | ✓ | ✓ (via pipeline) | ✓ | ✓ | n/a |
 | `frame_change` callback | ✓ (React prop) | ✓ (Python event) | ✓ (status bar) | ✓ (status bar) | n/a |
 | `selection_change` / `measurement` events | — | ✓ | — | — | n/a |
+| `file_load` event (in-widget picker) | — | ✓ | — | — | n/a |
 | Programmatic frame seek (`frame_index = N`) | ✓ | ✓ | — | — | n/a |
 
 Notes:
 
 - **host** means the parent app provides the file picker (the JupyterLab file browser, the VS Code explorer); megane itself does not render one.
+- ¹ The Jupyter widget shows an in-cell drag-drop overlay and file-input button when no structure has been loaded via the Python API. Supported formats match `LoadStructure` (PDB, GRO, XYZ, MOL/SDF, CIF, LAMMPS data, ASE .traj). Separate trajectory files (XTC, DCD) still require the Python API.
 - The Jupyter widget intentionally does not mount the visual pipeline editor — pipelines are built in Python (`megane.Pipeline`) and pushed via `MolecularViewer.set_pipeline()`. Use the standalone app, JupyterLab labextension, or VSCode extension to edit pipelines visually.
 - The standalone app is the only platform with `megane serve` WebSocket streaming; other platforms load full trajectories into memory.
 - The standalone React `MeganeViewer` exposes an `onFrameChange?: (frame: number) => void` prop that fires on every trajectory frame transition — useful for keeping a host Plotly figure in sync.
@@ -82,7 +84,7 @@ How data gets into the viewer on each platform:
 | Platform | Primary load path | API surface |
 |---|---|---|
 | **Standalone** | Drag-and-drop, file dialog, `megane serve <file>`, WebSocket | `parseStructureFile(file)` (TypeScript), pipeline node `LoadStructure` / `LoadTrajectory` |
-| **Jupyter widget** | Python only — no in-cell file picker | `MolecularViewer.load(pdb_path, xtc=, traj=)` (deprecated) or `MolecularViewer.set_pipeline(Pipeline)` (recommended) |
+| **Jupyter widget** | Python API, or in-cell drag-drop / file picker (structure files only) | `MolecularViewer.load(pdb_path, xtc=, traj=)` (deprecated) or `MolecularViewer.set_pipeline(Pipeline)` (recommended); `on_event("file_load", cb)` to react to picker loads |
 | **JupyterLab** | Click a registered file type in the file browser | Internally reads `context.model` (`jupyterlab-megane/src/MeganeDocWidget.tsx`) |
 | **VSCode** | Open a registered file from the explorer; extension host posts `loadFile` / `loadPipeline` to the webview | `postMessage({ type: "loadFile", … })` (`vscode-megane/webview/main.tsx`) |
 | **Python** | `from megane.parsers import …` | `load_pdb`, `load_cif`, `load_lammps_data`, `load_traj`, `load_trajectory` (XTC), `load_xyz_trajectory`, and the `parse_*` PyO3 functions |
@@ -92,7 +94,7 @@ How data gets into the viewer on each platform:
 These are formats or features that the parser layer supports but a given platform does not yet wire into its UI. They are documented here so users do not file bugs against expected-but-absent behaviour.
 
 - **Trajectory-only opens require a topology first.** On VSCode and JupyterLab, opening a `.xtc` / `.dcd` / `.lammpstrj` / `.dump` / `.nc` file before any structure is loaded surfaces a friendly error. The recommended flow is to open the structure first, or to use the pipeline editor (always mounted on these hosts) to wire a Load Structure node.
-- **Jupyter widget has no in-cell file picker or drag-and-drop.** This is intentional — the widget is Python-driven. Use `set_pipeline()` with a `Pipeline` to load any supported format.
+- **Jupyter widget file picker supports structure formats only.** Separate trajectory files (XTC, DCD, AMBER NetCDF, LAMMPS dump) require the Python API (`set_pipeline()` or `load()`). The in-cell picker only appears when no structure has been loaded via Python.
 - **Jupyter widget has no visual pipeline editor.** The editor's React surface relies on host chrome (drag handles, side panel layout) that the anywidget cell cannot reliably render, so it is only shipped on the standalone app, JupyterLab labextension, and VSCode extension. Build pipelines in Python with `megane.Pipeline` and push them via `MolecularViewer.set_pipeline()`.
 - **`selection_change` / `measurement` events are widget-only.** Other platforms do not emit these to a host. The standalone React component does expose `onFrameChange` (see UI features table).
 - **`frame_change` callback for JupyterLab is surfaced as a status-bar frame counter.** The JupyterLab DocWidget has no Python kernel connection, so there is no Python callback surface. Instead, when `IStatusBar` is available, the current frame index is shown in the JupyterLab status bar (right side). The `subscribeFrameChange` method on `MeganeReactView` can also be used by other JupyterLab extensions to react to frame changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,4 +152,5 @@ replace = '"version": "{new_version}"'
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",
+    "pytest-cov>=7.0.0",
 ]

--- a/python/megane/widget.py
+++ b/python/megane/widget.py
@@ -80,6 +80,10 @@ class MolecularViewer(anywidget.AnyWidget):
         value_trait=traitlets.Bytes(),
     ).tag(sync=True)
 
+    # File picker: JS sets this to the file name when the user loads a
+    # structure via the in-widget drag-drop / file-input overlay.
+    _uploaded_file_name = traitlets.Unicode("").tag(sync=True)
+
     # Internal (not synced)
     _structure = None
     _trajectory = None
@@ -212,6 +216,13 @@ class MolecularViewer(anywidget.AnyWidget):
             },
         )
 
+    @traitlets.observe("_uploaded_file_name")
+    def _on_file_name_change(self, change: dict) -> None:
+        """Fire file_load event when the user loads a file via the in-widget picker."""
+        name = change["new"]
+        if name:
+            self._fire_event("file_load", {"file_name": name})
+
     @traitlets.observe("_measurement_json")
     def _on_measurement_change(self, change: dict) -> None:
         """Fire measurement event when JS sends measurement data."""
@@ -264,6 +275,8 @@ class MolecularViewer(anywidget.AnyWidget):
             - "measurement": fired when a measurement is computed.
               Data: {"type": str, "value": float, "label": str,
                      "atoms": list[int]} or None
+            - "file_load": fired when the user loads a file via the in-widget
+              file picker. Data: {"file_name": str}
 
         Args:
             event_name: Name of the event.

--- a/src/components/WidgetViewer.tsx
+++ b/src/components/WidgetViewer.tsx
@@ -25,6 +25,21 @@ import type { ViewportState, AddBondParams } from "../pipeline/types";
 import type { Snapshot, Frame, Measurement, HoverInfo } from "../types";
 import { useThemeStore, themeToHex } from "../stores/useThemeStore";
 
+/** Accepted structure file extensions (no WASM required). */
+export const WIDGET_STRUCTURE_ACCEPT = ".pdb,.gro,.xyz,.mol,.sdf,.mol2,.cif,.data,.lammps,.traj";
+export const WIDGET_STRUCTURE_EXTS = [
+  ".pdb",
+  ".gro",
+  ".xyz",
+  ".mol",
+  ".sdf",
+  ".mol2",
+  ".cif",
+  ".data",
+  ".lammps",
+  ".traj",
+];
+
 interface WidgetViewerProps {
   snapshot: Snapshot | null;
   frame: Frame | null;
@@ -40,6 +55,14 @@ interface WidgetViewerProps {
   initialCameraState?: MeganeCameraState | null;
   /** Called when camera state changes (after user interaction ends). */
   onCameraStateChange?: (state: MeganeCameraState) => void;
+  /**
+   * Called when the user selects or drops a structure file via the in-widget
+   * picker. The parent (widget.ts) is responsible for parsing and updating the
+   * snapshot; this async hook should resolve on success or reject with an Error
+   * message on failure. When provided, an empty-state overlay with drag-drop
+   * support is shown until the first structure is loaded.
+   */
+  onFilePick?: (file: File) => Promise<void>;
   // Optional pipeline store override. Each Jupyter widget mount creates its
   // own private store so multiple MolecularViewers in the same notebook do
   // not share state. Tests pass their own store to inspect internal state.
@@ -70,6 +93,7 @@ export function WidgetViewer({
   nodeSnapshotsData,
   initialCameraState,
   onCameraStateChange,
+  onFilePick,
   pipelineStore: pipelineStoreProp,
 }: WidgetViewerProps) {
   // Each WidgetViewer instance owns a private pipeline store. The webapp
@@ -92,6 +116,14 @@ export function WidgetViewer({
   onCameraStateChangeRef.current = onCameraStateChange;
   const initialCameraStateRef = useRef(initialCameraState);
 
+  // File picker state
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [isLoadingFile, setIsLoadingFile] = useState(false);
+  const [fileLoadError, setFileLoadError] = useState<string | null>(null);
+  const onFilePickRef = useRef(onFilePick);
+  onFilePickRef.current = onFilePick;
+
   const {
     selection,
     measurement,
@@ -100,6 +132,54 @@ export function WidgetViewer({
     handleFrameUpdated,
     setExternalSelection,
   } = useAtomSelection(rendererRef, onMeasurementChange);
+
+  // File picker handlers
+  const handleFileSelect = useCallback(async (file: File) => {
+    if (!onFilePickRef.current) return;
+    const lower = file.name.toLowerCase();
+    if (!WIDGET_STRUCTURE_EXTS.some((ext) => lower.endsWith(ext))) {
+      setFileLoadError(`Unsupported format: ${file.name}`);
+      return;
+    }
+    setFileLoadError(null);
+    setIsLoadingFile(true);
+    try {
+      await onFilePickRef.current(file);
+    } catch (e) {
+      setFileLoadError(e instanceof Error ? e.message : "Failed to load file");
+    } finally {
+      setIsLoadingFile(false);
+    }
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragOver(false);
+      const file = Array.from(e.dataTransfer.files)[0];
+      if (file) handleFileSelect(file);
+    },
+    [handleFileSelect],
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+  }, []);
+
+  const handleFileInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) handleFileSelect(file);
+      e.target.value = "";
+    },
+    [handleFileSelect],
+  );
 
   // Keep a ref so handleRendererReady can apply the initial selection
   const selectedAtomsRef = useRef(selectedAtoms);
@@ -358,6 +438,59 @@ export function WidgetViewer({
         elements={effectiveSnapshot?.elements ?? null}
         onClear={handleClearSelection}
       />
+
+      {onFilePick && !effectiveSnapshot && !pipelineJson && (
+        <div
+          data-testid="widget-file-picker"
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "8px",
+            background: isDragOver ? "rgba(99,102,241,0.08)" : "transparent",
+            border: `2px dashed ${isDragOver ? "#6366f1" : "#9ca3af"}`,
+            borderRadius: "8px",
+            cursor: "pointer",
+            pointerEvents: isLoadingFile ? "none" : "auto",
+          }}
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          {isLoadingFile ? (
+            <span style={{ opacity: 0.6, fontSize: "0.875rem" }}>Loading...</span>
+          ) : (
+            <>
+              <span style={{ opacity: 0.5, fontSize: "0.875rem", textAlign: "center" }}>
+                Drop a structure file here, or click to browse
+              </span>
+              <span style={{ opacity: 0.35, fontSize: "0.75rem" }}>
+                PDB, GRO, XYZ, MOL/SDF, CIF, LAMMPS, ASE .traj
+              </span>
+              {fileLoadError && (
+                <span
+                  data-testid="widget-file-error"
+                  style={{ color: "#ef4444", fontSize: "0.75rem" }}
+                >
+                  {fileLoadError}
+                </span>
+              )}
+            </>
+          )}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept={WIDGET_STRUCTURE_ACCEPT}
+            style={{ display: "none" }}
+            onChange={handleFileInputChange}
+            data-testid="widget-file-input"
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -21,6 +21,20 @@ import {
 } from "./protocol/protocol";
 import type { Snapshot, Frame, Measurement } from "./types";
 import type { MeganeCameraState } from "./renderer/MoleculeRenderer";
+// Accepted structure extensions — mirrors WIDGET_STRUCTURE_EXTS in WidgetViewer.tsx.
+// Kept here as a plain constant so the WASM module is never imported statically.
+const WIDGET_STRUCTURE_EXTS = [
+  ".pdb",
+  ".gro",
+  ".xyz",
+  ".mol",
+  ".sdf",
+  ".mol2",
+  ".cif",
+  ".data",
+  ".lammps",
+  ".traj",
+];
 
 interface AnyWidgetModel {
   get(key: string): unknown;
@@ -55,6 +69,11 @@ function render({ model, el }: { model: AnyWidgetModel; el: HTMLElement }) {
   let currentFrame: Frame | null = null;
   let disposed = false;
 
+  // Client-side trajectory loaded via the in-widget file picker.
+  // Seeking is handled locally without a Python round-trip.
+  let localFrames: Frame[] = [];
+  let localFrameIndex: number = 0;
+
   function parseSnapshot(): Snapshot | null {
     const data = model.get("_snapshot_data") as DataView | null;
     if (!data || data.byteLength === 0) return null;
@@ -80,6 +99,17 @@ function render({ model, el }: { model: AnyWidgetModel; el: HTMLElement }) {
   }
 
   function handleSeek(frame: number) {
+    if (localFrames.length > 0) {
+      // Local trajectory from file picker — seek without Python round-trip.
+      const total = localFrames.length + 1; // +1: frame 0 uses snapshot positions
+      const target = frame === -1 ? (localFrameIndex + 1) % total : frame;
+      localFrameIndex = target;
+      // Frame 0 → snapshot positions (currentFrame = null); subsequent frames
+      // → the corresponding localFrames entry.
+      currentFrame = target === 0 ? null : localFrames[target - 1];
+      renderApp();
+      return;
+    }
     const totalFrames = (model.get("total_frames") as number) || 0;
     if (frame === -1) {
       // "next frame" signal from playback
@@ -90,6 +120,25 @@ function render({ model, el }: { model: AnyWidgetModel; el: HTMLElement }) {
       model.set("frame_index", frame);
     }
     model.save_changes();
+  }
+
+  async function handleFilePick(file: File): Promise<void> {
+    const lower = file.name.toLowerCase();
+    if (!WIDGET_STRUCTURE_EXTS.some((ext) => lower.endsWith(ext))) {
+      throw new Error(`Unsupported format: ${file.name}`);
+    }
+    // Dynamic import so the WASM bundle is only fetched when the user actually
+    // picks a file, keeping the widget startup cost unchanged.
+    const { parseStructureFile } = await import("./parsers/structure");
+    const result = await parseStructureFile(file);
+    currentSnapshot = result.snapshot;
+    currentFrame = null;
+    localFrames = result.frames;
+    localFrameIndex = 0;
+    // Notify Python so it can fire the "file_load" event.
+    model.set("_uploaded_file_name", file.name);
+    model.save_changes();
+    renderApp();
   }
 
   function handleMeasurementChange(measurement: Measurement | null) {
@@ -124,8 +173,10 @@ function render({ model, el }: { model: AnyWidgetModel; el: HTMLElement }) {
 
   function renderApp() {
     if (!root || disposed) return;
-    const frameIndex = (model.get("frame_index") as number) || 0;
-    const totalFrames = (model.get("total_frames") as number) || 0;
+    const frameIndex =
+      localFrames.length > 0 ? localFrameIndex : (model.get("frame_index") as number) || 0;
+    const totalFrames =
+      localFrames.length > 0 ? localFrames.length + 1 : (model.get("total_frames") as number) || 0;
     const selectedAtoms = (model.get("selected_atoms") as number[]) || [];
     const pipelineJson = (model.get("_pipeline_json") as string) || "";
     const nodeSnapshotsData = (model.get("_node_snapshots_data") as Record<string, DataView>) || {};
@@ -144,6 +195,7 @@ function render({ model, el }: { model: AnyWidgetModel; el: HTMLElement }) {
         onPipelineChange: handlePipelineChange,
         initialCameraState: getInitialCameraState(),
         onCameraStateChange: handleCameraStateChange,
+        onFilePick: handleFilePick,
       }),
     );
   }

--- a/tests/python/test_widget.py
+++ b/tests/python/test_widget.py
@@ -115,3 +115,59 @@ def test_deprecated_load_warns():
     assert len(w) == 1
     assert issubclass(w[0].category, DeprecationWarning)
     assert "set_pipeline" in str(w[0].message)
+
+
+# ── File picker traitlet tests ────────────────────────────────────────────────
+
+
+def test_uploaded_file_name_default():
+    """_uploaded_file_name starts as empty string."""
+    v = MolecularViewer()
+    assert v._uploaded_file_name == ""
+
+
+def test_uploaded_file_name_is_synced():
+    """_uploaded_file_name is in get_state() (sync=True)."""
+    v = MolecularViewer()
+    state = v.get_state()
+    assert "_uploaded_file_name" in state
+
+
+def test_file_load_event_fired_on_name_change():
+    """Setting _uploaded_file_name fires the 'file_load' event with the name."""
+    v = MolecularViewer()
+    received = []
+    v.on_event("file_load", lambda data: received.append(data))
+
+    v._uploaded_file_name = "protein.pdb"
+
+    assert len(received) == 1
+    assert received[0] == {"file_name": "protein.pdb"}
+
+
+def test_file_load_event_not_fired_for_empty_name():
+    """Setting _uploaded_file_name to '' does not fire the event."""
+    v = MolecularViewer()
+    received = []
+    v.on_event("file_load", lambda data: received.append(data))
+
+    # Simulate a round-trip reset (JS clears the field after loading)
+    v._uploaded_file_name = "protein.pdb"
+    v._uploaded_file_name = ""
+
+    # Only the non-empty set should trigger the event.
+    assert len(received) == 1
+
+
+def test_file_load_event_multiple_files():
+    """Each non-empty _uploaded_file_name change triggers a separate event."""
+    v = MolecularViewer()
+    received = []
+    v.on_event("file_load", lambda data: received.append(data))
+
+    v._uploaded_file_name = "mol_a.pdb"
+    v._uploaded_file_name = "mol_b.gro"
+
+    assert len(received) == 2
+    assert received[0] == {"file_name": "mol_a.pdb"}
+    assert received[1] == {"file_name": "mol_b.gro"}

--- a/tests/ts/__stubs__/megane-wasm-bg-wasm.ts
+++ b/tests/ts/__stubs__/megane-wasm-bg-wasm.ts
@@ -1,0 +1,9 @@
+/**
+ * Stub for crates/megane-wasm/pkg/megane_wasm_bg.wasm — used by vitest so
+ * wasmLoader.ts can be imported without the WASM binary being built.
+ *
+ * wasmLoader.ts tries to import this asset URL (via webpack asset/resource)
+ * and falls back to the JupyterLab PageConfig URL when the import fails.
+ * Throwing here lets vitest exercise that catch branch without a real binary.
+ */
+throw new Error("WASM binary not available in test environment — mock or stub wasmLoader instead.");

--- a/tests/ts/__stubs__/megane-wasm-pkg.ts
+++ b/tests/ts/__stubs__/megane-wasm-pkg.ts
@@ -1,0 +1,34 @@
+/**
+ * Stub for crates/megane-wasm/pkg — used by vitest so the test suite can
+ * resolve the WASM package path without a built WASM binary.
+ *
+ * All actual tests that call WASM functions mock @/parsers/structure (or
+ * @/parsers/xtc etc.) via vi.mock, so these stubs are never invoked.  They
+ * exist only to satisfy Vite's import-analysis resolution at the transform
+ * stage so that the 19 test files blocked by "Failed to resolve
+ * 'crates/megane-wasm/pkg'" can be collected.
+ */
+
+const stub = () => {
+  throw new Error("WASM not built — mock @/parsers/structure in your test.");
+};
+
+export const parse_pdb = stub;
+export const parse_gro = stub;
+export const parse_xyz = stub;
+export const parse_mol = stub;
+export const parse_mol2 = stub;
+export const parse_cif = stub;
+export const parse_lammps_data = stub;
+export const parse_traj = stub;
+export const parse_xtc = stub;
+export const parse_dcd = stub;
+export const parse_netcdf = stub;
+export const parse_lammpstrj = stub;
+export const infer_bonds_vdw = stub;
+export const parse_top_bonds = stub;
+export const parse_pdb_bonds = stub;
+export const extract_labels = stub;
+
+// The default export is the WASM init function.
+export default async (_url?: string | URL | undefined): Promise<void> => {};

--- a/tests/ts/components/WidgetViewerFilePicker.test.tsx
+++ b/tests/ts/components/WidgetViewerFilePicker.test.tsx
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, act, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import type { Snapshot } from "@/types";
+
+// Mock heavy components to avoid WebGL/canvas in jsdom
+vi.mock("@/components/Viewport", () => ({ Viewport: vi.fn(() => null) }));
+vi.mock("@/components/Tooltip", () => ({ Tooltip: vi.fn(() => null) }));
+vi.mock("@/components/MeasurementPanel", () => ({ MeasurementPanel: vi.fn(() => null) }));
+vi.mock("@/parsers/inferBondsJS", () => ({ inferBondsVdwJS: vi.fn(() => new Uint32Array(0)) }));
+vi.mock("@/pipeline/executors/addBond", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/pipeline/executors/addBond")>();
+  return {
+    ...actual,
+    processPbcBonds: vi.fn((bondIndices: Uint32Array, bondOrders: Uint8Array | null) => ({
+      bondIndices,
+      bondOrders,
+      nBonds: bondIndices.length / 2,
+      positions: null,
+      elements: null,
+      nAtoms: 0,
+    })),
+  };
+});
+
+import { WidgetViewer } from "@/components/WidgetViewer";
+
+function makeSnapshot(): Snapshot {
+  return {
+    nAtoms: 2,
+    nBonds: 0,
+    nFileBonds: 0,
+    positions: new Float32Array([0, 0, 0, 1, 0, 0]),
+    elements: new Uint8Array([1, 8]),
+    bonds: new Uint32Array(0),
+    bondOrders: null,
+    box: null,
+  };
+}
+
+const defaultProps = {
+  snapshot: null,
+  frame: null,
+  currentFrame: 0,
+  totalFrames: 0,
+  onSeek: vi.fn(),
+};
+
+describe("WidgetViewer — file picker overlay", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("shows file picker overlay when onFilePick is set and no snapshot is loaded", () => {
+    const { getByTestId } = render(
+      <WidgetViewer {...defaultProps} onFilePick={vi.fn()} />,
+    );
+    expect(getByTestId("widget-file-picker")).toBeDefined();
+  });
+
+  it("does not show file picker overlay when onFilePick is not provided", () => {
+    const { queryByTestId } = render(<WidgetViewer {...defaultProps} />);
+    expect(queryByTestId("widget-file-picker")).toBeNull();
+  });
+
+  it("hides file picker overlay when a snapshot is provided", () => {
+    const { queryByTestId } = render(
+      <WidgetViewer {...defaultProps} snapshot={makeSnapshot()} onFilePick={vi.fn()} />,
+    );
+    expect(queryByTestId("widget-file-picker")).toBeNull();
+  });
+
+  it("hides file picker overlay when pipelineJson is present", () => {
+    const { queryByTestId } = render(
+      <WidgetViewer
+        {...defaultProps}
+        pipelineJson='{"version":3,"nodes":[],"edges":[]}'
+        onFilePick={vi.fn()}
+      />,
+    );
+    expect(queryByTestId("widget-file-picker")).toBeNull();
+  });
+
+  it("calls onFilePick when a supported file is dropped", async () => {
+    const onFilePick = vi.fn().mockResolvedValue(undefined);
+    const { getByTestId } = render(
+      <WidgetViewer {...defaultProps} onFilePick={onFilePick} />,
+    );
+
+    const picker = getByTestId("widget-file-picker");
+    const file = new File(["ATOM  1  CA  ALA"], "test.pdb", { type: "chemical/x-pdb" });
+
+    await act(async () => {
+      fireEvent.drop(picker, { dataTransfer: { files: [file] } });
+    });
+
+    expect(onFilePick).toHaveBeenCalledWith(file);
+  });
+
+  it("calls onFilePick when a file is selected via the hidden input", async () => {
+    const onFilePick = vi.fn().mockResolvedValue(undefined);
+    const { getByTestId } = render(
+      <WidgetViewer {...defaultProps} onFilePick={onFilePick} />,
+    );
+
+    const input = getByTestId("widget-file-input") as HTMLInputElement;
+    const file = new File([""], "protein.gro", { type: "" });
+    Object.defineProperty(input, "files", { value: [file], writable: false });
+
+    await act(async () => {
+      fireEvent.change(input);
+    });
+
+    expect(onFilePick).toHaveBeenCalledWith(file);
+  });
+
+  it("shows error message when an unsupported file is dropped", async () => {
+    const onFilePick = vi.fn();
+    const { getByTestId } = render(
+      <WidgetViewer {...defaultProps} onFilePick={onFilePick} />,
+    );
+
+    const picker = getByTestId("widget-file-picker");
+    const file = new File([""], "trajectory.mp4", { type: "video/mp4" });
+
+    await act(async () => {
+      fireEvent.drop(picker, { dataTransfer: { files: [file] } });
+    });
+
+    expect(onFilePick).not.toHaveBeenCalled();
+    expect(getByTestId("widget-file-error")).toBeDefined();
+  });
+
+  it("shows error message when onFilePick rejects", async () => {
+    const onFilePick = vi.fn().mockRejectedValue(new Error("Parse failed"));
+    const { getByTestId } = render(
+      <WidgetViewer {...defaultProps} onFilePick={onFilePick} />,
+    );
+
+    const picker = getByTestId("widget-file-picker");
+    const file = new File([""], "bad.pdb", { type: "" });
+
+    await act(async () => {
+      fireEvent.drop(picker, { dataTransfer: { files: [file] } });
+    });
+
+    await waitFor(() => {
+      expect(getByTestId("widget-file-error").textContent).toBe("Parse failed");
+    });
+  });
+
+  it("accepts all supported structure file extensions", async () => {
+    const exts = [".pdb", ".gro", ".xyz", ".mol", ".sdf", ".mol2", ".cif", ".data", ".lammps", ".traj"];
+
+    for (const ext of exts) {
+      const onFilePick = vi.fn().mockResolvedValue(undefined);
+      const { getByTestId, unmount } = render(
+        <WidgetViewer {...defaultProps} onFilePick={onFilePick} />,
+      );
+
+      const picker = getByTestId("widget-file-picker");
+      const file = new File([""], `molecule${ext}`, { type: "" });
+
+      await act(async () => {
+        fireEvent.drop(picker, { dataTransfer: { files: [file] } });
+      });
+
+      expect(onFilePick).toHaveBeenCalledWith(file);
+      unmount();
+      vi.clearAllMocks();
+    }
+  });
+
+  it("does not call onFilePick when no files are in the drop event", async () => {
+    const onFilePick = vi.fn();
+    const { getByTestId } = render(
+      <WidgetViewer {...defaultProps} onFilePick={onFilePick} />,
+    );
+
+    const picker = getByTestId("widget-file-picker");
+    await act(async () => {
+      fireEvent.drop(picker, { dataTransfer: { files: [] } });
+    });
+
+    expect(onFilePick).not.toHaveBeenCalled();
+  });
+
+  it("sets isDragOver styling when dragging over the picker and clears it on drag leave", () => {
+    const { getByTestId } = render(
+      <WidgetViewer {...defaultProps} onFilePick={vi.fn()} />,
+    );
+
+    const picker = getByTestId("widget-file-picker");
+
+    act(() => {
+      fireEvent.dragOver(picker);
+    });
+    // jsdom normalises hex colours to rgb(); check for either form.
+    const borderAfterOver = (picker as HTMLElement).style.border;
+    expect(
+      borderAfterOver.includes("#6366f1") || borderAfterOver.includes("rgb(99, 102, 241)"),
+    ).toBe(true);
+
+    act(() => {
+      fireEvent.dragLeave(picker);
+    });
+    const borderAfterLeave = (picker as HTMLElement).style.border;
+    expect(
+      borderAfterLeave.includes("#9ca3af") || borderAfterLeave.includes("rgb(156, 163, 175)"),
+    ).toBe(true);
+  });
+
+  it("contains a file input with the correct accept attribute", () => {
+    const { getByTestId } = render(
+      <WidgetViewer {...defaultProps} onFilePick={vi.fn()} />,
+    );
+
+    const input = getByTestId("widget-file-input") as HTMLInputElement;
+    expect(input.accept).toBe(".pdb,.gro,.xyz,.mol,.sdf,.mol2,.cif,.data,.lammps,.traj");
+    expect(input.type).toBe("file");
+  });
+});

--- a/tests/ts/widget.test.ts
+++ b/tests/ts/widget.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Snapshot, Frame } from "@/types";
 
 /**
  * Tests for src/widget.ts — the anywidget render entry point.
@@ -36,6 +37,13 @@ vi.mock("react-dom/client", () => ({
 vi.mock("@/perf", () => ({
   perfMark: vi.fn(),
   perfMeasure: vi.fn(),
+}));
+
+// Stub the WASM-backed structure parser so handleFilePick can be exercised
+// without a real WASM build. Tests configure the return value per-case.
+const mockParseStructureFile = vi.fn();
+vi.mock("@/parsers/structure", () => ({
+  parseStructureFile: mockParseStructureFile,
 }));
 
 // Stub protocol decoders so parseSnapshot/parseFrame return null in tests
@@ -272,5 +280,133 @@ describe("widget.ts — render", () => {
     const el = makeContainer();
     const cleanup = widgetEntry.render({ model: model as never, el }) as () => void;
     expect(() => cleanup()).not.toThrow();
+  });
+
+  // ── handleFilePick ────────────────────────────────────────────────────────
+
+  it("handleFilePick parses the file and notifies Python with the file name", async () => {
+    const mockSnapshot = { atoms: [] } as unknown as Snapshot;
+    const mockFrames = [{ positions: new Float32Array([1, 2, 3]) }] as unknown as Frame[];
+    mockParseStructureFile.mockResolvedValueOnce({
+      snapshot: mockSnapshot,
+      frames: mockFrames,
+    });
+
+    const model = makeMockModel();
+    const el = makeContainer();
+    widgetEntry.render({ model: model as never, el });
+
+    const last = renderedElements[renderedElements.length - 1];
+    const onFilePick = last.props.onFilePick as (file: File) => Promise<void>;
+    const file = new File([""], "protein.pdb");
+    await onFilePick(file);
+
+    expect(mockParseStructureFile).toHaveBeenCalledWith(file);
+    expect(model.set).toHaveBeenCalledWith("_uploaded_file_name", "protein.pdb");
+    expect(model.save_changes).toHaveBeenCalled();
+  });
+
+  it("handleFilePick re-renders with snapshot from parsed file", async () => {
+    const mockSnapshot = { atoms: [{ x: 1, y: 2, z: 3 }] } as unknown as Snapshot;
+    mockParseStructureFile.mockResolvedValueOnce({ snapshot: mockSnapshot, frames: [] });
+
+    const model = makeMockModel();
+    const el = makeContainer();
+    widgetEntry.render({ model: model as never, el });
+
+    const { onFilePick } = renderedElements[renderedElements.length - 1].props;
+    await (onFilePick as (f: File) => Promise<void>)(new File([""], "mol.gro"));
+
+    const afterLoad = renderedElements[renderedElements.length - 1];
+    expect(afterLoad.props.snapshot).toBe(mockSnapshot);
+    expect(afterLoad.props.frame).toBeNull();
+  });
+
+  it("handleFilePick throws for unsupported file extensions", async () => {
+    const model = makeMockModel();
+    const el = makeContainer();
+    widgetEntry.render({ model: model as never, el });
+
+    const { onFilePick } = renderedElements[renderedElements.length - 1].props;
+    await expect(
+      (onFilePick as (f: File) => Promise<void>)(new File([""], "video.mp4")),
+    ).rejects.toThrow("Unsupported format: video.mp4");
+  });
+
+  // ── local-frame trajectory (after handleFilePick) ─────────────────────────
+
+  it("handleSeek uses local frames after file pick (no Python round-trip)", async () => {
+    const frames = [
+      { positions: new Float32Array([1]) },
+      { positions: new Float32Array([2]) },
+    ] as unknown as Frame[];
+    mockParseStructureFile.mockResolvedValueOnce({ snapshot: {} as Snapshot, frames });
+
+    const model = makeMockModel();
+    const el = makeContainer();
+    widgetEntry.render({ model: model as never, el });
+
+    await (renderedElements[renderedElements.length - 1].props.onFilePick as (f: File) => Promise<void>)(
+      new File([""], "mol.pdb"),
+    );
+
+    // After load, localFrameIndex=0 (snapshot frame). Seek to frame 2.
+    const onSeek = renderedElements[renderedElements.length - 1].props.onSeek as (f: number) => void;
+    onSeek(2);
+
+    // model.set("frame_index") must NOT be called — seeking is local.
+    expect(model.set).not.toHaveBeenCalledWith("frame_index", expect.anything());
+
+    // renderApp reflects localFrameIndex=2, totalFrames=3 (frames.length+1).
+    const after = renderedElements[renderedElements.length - 1];
+    expect(after.props.currentFrame).toBe(2);
+    expect(after.props.totalFrames).toBe(3);
+  });
+
+  it("handleSeek -1 advances local frame index with wrap-around", async () => {
+    const frames = [
+      { positions: new Float32Array([1]) },
+      { positions: new Float32Array([2]) },
+    ] as unknown as Frame[];
+    mockParseStructureFile.mockResolvedValueOnce({ snapshot: {} as Snapshot, frames });
+
+    const model = makeMockModel();
+    const el = makeContainer();
+    widgetEntry.render({ model: model as never, el });
+
+    await (renderedElements[renderedElements.length - 1].props.onFilePick as (f: File) => Promise<void>)(
+      new File([""], "mol.pdb"),
+    );
+
+    const onSeek = renderedElements[renderedElements.length - 1].props.onSeek as (f: number) => void;
+    // localFrameIndex=0, total=3; -1 → 1
+    onSeek(-1);
+    expect(renderedElements[renderedElements.length - 1].props.currentFrame).toBe(1);
+
+    // -1 again → 2
+    onSeek(-1);
+    expect(renderedElements[renderedElements.length - 1].props.currentFrame).toBe(2);
+
+    // -1 again wraps → 0
+    onSeek(-1);
+    expect(renderedElements[renderedElements.length - 1].props.currentFrame).toBe(0);
+  });
+
+  it("handleSeek frame 0 after local load sets currentFrame to null (snapshot positions)", async () => {
+    const frames = [{ positions: new Float32Array([1]) }] as unknown as Frame[];
+    mockParseStructureFile.mockResolvedValueOnce({ snapshot: {} as Snapshot, frames });
+
+    const model = makeMockModel();
+    const el = makeContainer();
+    widgetEntry.render({ model: model as never, el });
+
+    await (renderedElements[renderedElements.length - 1].props.onFilePick as (f: File) => Promise<void>)(
+      new File([""], "mol.pdb"),
+    );
+
+    const onSeek = renderedElements[renderedElements.length - 1].props.onSeek as (f: number) => void;
+    onSeek(1); // advance to frame 1
+    onSeek(0); // back to frame 0 (snapshot)
+    expect(renderedElements[renderedElements.length - 1].props.frame).toBeNull();
   });
 });

--- a/uv.lock
+++ b/uv.lock
@@ -1788,6 +1788,7 @@ traj = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
@@ -1813,7 +1814,10 @@ requires-dist = [
 provides-extras = ["traj", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.2" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+]
 
 [[package]]
 name = "mistune"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,47 +3,99 @@ import path from "path";
 
 export default defineConfig({
   resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "src"),
+    alias: [
+      { find: "@", replacement: path.resolve(__dirname, "src") },
       // The `@jupyterlab/*` packages live in jupyterlab-megane/package.json,
       // not the root, so vitest's import-analysis can't resolve bare specifiers
       // referenced by `jupyterlab-megane/src/`. Tests mock these via vi.mock();
       // the stubs only need to satisfy resolution, not provide behavior.
-      "@jupyterlab/application": path.resolve(
-        __dirname,
-        "tests/ts/__stubs__/jupyterlab-application.ts",
-      ),
-      "@jupyterlab/apputils": path.resolve(
-        __dirname,
-        "tests/ts/__stubs__/jupyterlab-apputils.ts",
-      ),
-      "@jupyterlab/coreutils": path.resolve(
-        __dirname,
-        "tests/ts/__stubs__/jupyterlab-coreutils.ts",
-      ),
-      "@jupyterlab/docregistry": path.resolve(
-        __dirname,
-        "tests/ts/__stubs__/jupyterlab-docregistry.ts",
-      ),
-      "@jupyterlab/services": path.resolve(
-        __dirname,
-        "tests/ts/__stubs__/jupyterlab-services.ts",
-      ),
-      "@jupyterlab/statusbar": path.resolve(
-        __dirname,
-        "tests/ts/__stubs__/jupyterlab-statusbar.ts",
-      ),
+      {
+        find: "@jupyterlab/application",
+        replacement: path.resolve(
+          __dirname,
+          "tests/ts/__stubs__/jupyterlab-application.ts",
+        ),
+      },
+      {
+        find: "@jupyterlab/apputils",
+        replacement: path.resolve(
+          __dirname,
+          "tests/ts/__stubs__/jupyterlab-apputils.ts",
+        ),
+      },
+      {
+        find: "@jupyterlab/coreutils",
+        replacement: path.resolve(
+          __dirname,
+          "tests/ts/__stubs__/jupyterlab-coreutils.ts",
+        ),
+      },
+      {
+        find: "@jupyterlab/docregistry",
+        replacement: path.resolve(
+          __dirname,
+          "tests/ts/__stubs__/jupyterlab-docregistry.ts",
+        ),
+      },
+      {
+        find: "@jupyterlab/services",
+        replacement: path.resolve(
+          __dirname,
+          "tests/ts/__stubs__/jupyterlab-services.ts",
+        ),
+      },
+      {
+        find: "@jupyterlab/statusbar",
+        replacement: path.resolve(
+          __dirname,
+          "tests/ts/__stubs__/jupyterlab-statusbar.ts",
+        ),
+      },
       // `@lumino/widgets` is a peer dep of jupyterlab-megane but is not in the
       // root node_modules. The stub satisfies import resolution at test time.
-      "@lumino/widgets": path.resolve(
-        __dirname,
-        "tests/ts/__stubs__/lumino-widgets.ts",
-      ),
+      {
+        find: "@lumino/widgets",
+        replacement: path.resolve(
+          __dirname,
+          "tests/ts/__stubs__/lumino-widgets.ts",
+        ),
+      },
       // `vscode` is injected by the VS Code extension host at runtime and is
       // not present in any node_modules. Tests mock it via vi.mock(); the stub
       // only needs to satisfy resolution.
-      vscode: path.resolve(__dirname, "tests/ts/__stubs__/vscode.ts"),
-    },
+      {
+        find: "vscode",
+        replacement: path.resolve(__dirname, "tests/ts/__stubs__/vscode.ts"),
+      },
+      // `crates/megane-wasm/pkg` does not exist until `npm run build:wasm` is
+      // run.  Two aliases handle different import shapes:
+      //
+      //  1. The .wasm binary asset (wasmLoader.ts tries to import it as a
+      //     webpack asset/resource URL).  The stub throws so that wasmLoader's
+      //     catch branch — tested by wasmLoader.test.ts — still fires.
+      //
+      //  2. The JS glue package index (parsers/structure.ts and friends import
+      //     the wasm-bindgen JS output). The stub exports no-op stubs for every
+      //     WASM function so that test collection succeeds without a real build.
+      //     Tests that actually invoke WASM functions mock @/parsers/structure.
+      //
+      // Both regexes match the full import specifier (anchored) so no stale
+      // prefix is left after String.prototype.replace(find, replacement).
+      {
+        find: /^.*\/crates\/megane-wasm\/pkg\/.*\.wasm$/,
+        replacement: path.resolve(
+          __dirname,
+          "tests/ts/__stubs__/megane-wasm-bg-wasm.ts",
+        ),
+      },
+      {
+        find: /^.*\/crates\/megane-wasm\/pkg(?:\/index)?$/,
+        replacement: path.resolve(
+          __dirname,
+          "tests/ts/__stubs__/megane-wasm-pkg.ts",
+        ),
+      },
+    ],
   },
   test: {
     environment: "jsdom",


### PR DESCRIPTION
## Summary

Implements the in-widget file picker described in issue #377. When no structure has been loaded via the Python API, a drag-and-drop overlay appears in the Jupyter widget cell, letting users open molecular structure files directly from the browser.

- **`src/components/WidgetViewer.tsx`**: renders a drag-and-drop overlay when `onFilePick` is provided and no snapshot/pipeline is active. Exports `WIDGET_STRUCTURE_ACCEPT` and `WIDGET_STRUCTURE_EXTS` constants (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, LAMMPS data, ASE `.traj`). No static WASM import — keeps test collection clean.
- **`src/widget.ts`**: adds `handleFilePick` that lazily loads the WASM parser via dynamic import (WASM bundle only fetched on first file pick, not on widget load). Adds local-frame trajectory state so client-side seeking works without a Python round-trip.
- **`python/megane/widget.py`**: adds `_uploaded_file_name` traitlet (`sync=True`) and a `@traitlets.observe` handler that fires the `file_load` Python event, enabling `viewer.on_event("file_load", callback)`.
- **`docs/docs/platform-support.md`**: updates drag-and-drop, file picker, and `file_load` event rows to reflect Jupyter widget support.
- **`vitest.config.ts` + `tests/ts/__stubs__/`**: two WASM stubs (JS glue index + `.wasm` binary) fix the pre-existing 19-file test collection failure caused by `crates/megane-wasm/pkg` not existing before `npm run build:wasm`. All 80 test files now collect and run cleanly (888 tests, up from 733).

## Test plan

- [x] `npm test` — 80/80 files, 888/888 tests pass (up from 733; fixed 18 pre-existing collection failures)
- [x] `uv run pytest tests/python/test_widget.py` — 14/14 pass (5 new tests)
- [x] `npm run lint` — 0 errors (24 pre-existing warnings unchanged)
- [x] `npm run format:check` — all files formatted
- [x] New TS tests (`WidgetViewerFilePicker.test.tsx`): overlay visibility, drop handling, file input, error display, drag styling, accept attribute (12 tests)
- [x] New Python tests: traitlet default, sync state, `file_load` event fired on non-empty name, not fired on empty string, multiple sequential loads

https://claude.ai/code/session_01EZimBwnopMX2UCJJqqAGG9

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZimBwnopMX2UCJJqqAGG9)_