### PR TITLE
feat: expose onSelectionChange and onMeasurementChange props on MeganeViewer

### DIFF
--- a/docs/docs/platform-support.md
+++ b/docs/docs/platform-support.md
@@ -66,7 +66,7 @@ Sources of truth: `crates/megane-wasm/src/lib.rs` (browser parsers), `crates/meg
 | Multi-layer rendering | ✓ | ✓ (via pipeline) | ✓ | ✓ | n/a |
 | Solvent-accessible surface (SAS) | ✓ | ✓ (via pipeline) | ✓ | ✓ | n/a |
 | `frame_change` callback | ✓ (React prop) | ✓ (Python event) | ✓ (status bar) | ✓ (status bar) | n/a |
-| `selection_change` / `measurement` events | — | ✓ | — | — | n/a |
+| `selection_change` / `measurement` events | ✓ (React props) | ✓ | — | — | n/a |
 | Programmatic frame seek (`frame_index = N`) | ✓ | ✓ | — | — | n/a |
 
 Notes:
@@ -75,6 +75,7 @@ Notes:
 - The Jupyter widget intentionally does not mount the visual pipeline editor — pipelines are built in Python (`megane.Pipeline`) and pushed via `MolecularViewer.set_pipeline()`. Use the standalone app, JupyterLab labextension, or VSCode extension to edit pipelines visually.
 - The standalone app is the only platform with `megane serve` WebSocket streaming; other platforms load full trajectories into memory.
 - The standalone React `MeganeViewer` exposes an `onFrameChange?: (frame: number) => void` prop that fires on every trajectory frame transition — useful for keeping a host Plotly figure in sync.
+- The standalone React `MeganeViewer` also exposes `onSelectionChange?: (selection: SelectionState) => void` (fires on every atom selection change; data: `{ atoms: number[] }`) and `onMeasurementChange?: (measurement: Measurement | null) => void` (fires when a distance/angle/dihedral measurement is computed or cleared) — both mirror the Jupyter widget's `selection_change` and `measurement` events.
 
 ## Load methods / APIs
 
@@ -95,5 +96,5 @@ These are formats or features that the parser layer supports but a given platfor
 - **Trajectory-only opens require a topology first.** On VSCode and JupyterLab, opening a `.xtc` / `.dcd` / `.lammpstrj` / `.dump` / `.nc` file before any structure is loaded surfaces a friendly error. The recommended flow is to open the structure first, or to use the pipeline editor (always mounted on these hosts) to wire a Load Structure node.
 - **Jupyter widget has no in-cell file picker or drag-and-drop.** This is intentional — the widget is Python-driven. Use `set_pipeline()` with a `Pipeline` to load any supported format.
 - **Jupyter widget has no visual pipeline editor.** The editor's React surface relies on host chrome (drag handles, side panel layout) that the anywidget cell cannot reliably render, so it is only shipped on the standalone app, JupyterLab labextension, and VSCode extension. Build pipelines in Python with `megane.Pipeline` and push them via `MolecularViewer.set_pipeline()`.
-- **`selection_change` / `measurement` events are widget-only.** Other platforms do not emit these to a host. The standalone React component does expose `onFrameChange` (see UI features table).
+- **`selection_change` / `measurement` events on JupyterLab and VSCode are not yet wired.** The standalone React component exposes `onSelectionChange?: (selection: SelectionState) => void` and `onMeasurementChange?: (measurement: Measurement | null) => void` props (mirroring the Jupyter widget's `selection_change` and `measurement` events). These are not yet surfaced on the JupyterLab DocWidget or VSCode extension.
 - **`frame_change` callback for JupyterLab is surfaced as a status-bar frame counter.** The JupyterLab DocWidget has no Python kernel connection, so there is no Python callback surface. Instead, when `IStatusBar` is available, the current frame index is shown in the JupyterLab status bar (right side). The `subscribeFrameChange` method on `MeganeReactView` can also be used by other JupyterLab extensions to react to frame changes.

--- a/src/components/MeganeViewer.tsx
+++ b/src/components/MeganeViewer.tsx
@@ -23,7 +23,14 @@ import { useViewStateStore } from "../stores/useViewStateStore";
 import { applyViewportState, applyVectorsForFrame } from "../pipeline/apply";
 import { useAtomSelection } from "../hooks/useAtomSelection";
 import { useNodeLoadHandlers } from "../hooks/useNodeLoadHandlers";
-import type { HoverInfo, BondSource, LabelSource, VectorSource, SelectionState, Measurement } from "../types";
+import type {
+  HoverInfo,
+  BondSource,
+  LabelSource,
+  VectorSource,
+  SelectionState,
+  Measurement,
+} from "../types";
 import type { ViewportState, AddBondParams } from "../pipeline/types";
 import { useThemeStore, themeToHex } from "../stores/useThemeStore";
 

--- a/src/components/MeganeViewer.tsx
+++ b/src/components/MeganeViewer.tsx
@@ -23,7 +23,7 @@ import { useViewStateStore } from "../stores/useViewStateStore";
 import { applyViewportState, applyVectorsForFrame } from "../pipeline/apply";
 import { useAtomSelection } from "../hooks/useAtomSelection";
 import { useNodeLoadHandlers } from "../hooks/useNodeLoadHandlers";
-import type { HoverInfo, BondSource, LabelSource, VectorSource } from "../types";
+import type { HoverInfo, BondSource, LabelSource, VectorSource, SelectionState, Measurement } from "../types";
 import type { ViewportState, AddBondParams } from "../pipeline/types";
 import { useThemeStore, themeToHex } from "../stores/useThemeStore";
 
@@ -48,6 +48,19 @@ interface MeganeViewerProps {
    * keyed on the same frame index.
    */
   onFrameChange?: (frame: number) => void;
+  /**
+   * Fired whenever the atom selection changes (right-click to toggle, clear).
+   * Mirrors the Jupyter widget's `selection_change` event — useful for keeping
+   * a host Plotly figure or table highlighted in sync with the 3D selection.
+   * Data: `{ atoms: number[] }` — 0-based atom indices (max 4).
+   */
+  onSelectionChange?: (selection: SelectionState) => void;
+  /**
+   * Fired whenever the active measurement changes (distance, angle, dihedral)
+   * or is cleared. Mirrors the Jupyter widget's `measurement` event.
+   * Data: `{ atoms, type, value, label }` or `null` when selection is cleared.
+   */
+  onMeasurementChange?: (measurement: Measurement | null) => void;
   width?: string | number;
   height?: string | number;
   /** Host context tag for E2E tests: "webapp" | "jupyterlab-doc" | "vscode". Defaults to "webapp". */
@@ -81,6 +94,8 @@ export function MeganeViewer({
   onLoadVectorFile: _onLoadVectorFile,
   onLoadDemoVectors: _onLoadDemoVectors,
   onFrameChange,
+  onSelectionChange,
+  onMeasurementChange,
   width = "100%",
   height = "100%",
   testContext = "webapp",
@@ -99,7 +114,7 @@ export function MeganeViewer({
 
   // Shared atom selection & measurement
   const { selection, measurement, handleAtomRightClick, handleClearSelection, handleFrameUpdated } =
-    useAtomSelection(rendererRef);
+    useAtomSelection(rendererRef, onMeasurementChange, onSelectionChange);
 
   useEffect(() => {
     pipelineCollapsedRef.current = pipelineCollapsed;

--- a/src/hooks/useAtomSelection.ts
+++ b/src/hooks/useAtomSelection.ts
@@ -19,11 +19,19 @@ export interface AtomSelectionState {
 export function useAtomSelection(
   rendererRef: React.MutableRefObject<MoleculeRenderer | null>,
   onMeasurementChange?: (measurement: Measurement | null) => void,
+  onSelectionChange?: (selection: SelectionState) => void,
 ): AtomSelectionState {
   const [selection, setSelection] = useState<SelectionState>({ atoms: [] });
   const [measurement, setMeasurement] = useState<Measurement | null>(null);
   const onMeasurementChangeRef = useRef(onMeasurementChange);
   onMeasurementChangeRef.current = onMeasurementChange;
+  const onSelectionChangeRef = useRef(onSelectionChange);
+  onSelectionChangeRef.current = onSelectionChange;
+
+  const updateSelection = useCallback((s: SelectionState) => {
+    setSelection(s);
+    onSelectionChangeRef.current?.(s);
+  }, []);
 
   const updateMeasurement = useCallback((m: Measurement | null) => {
     setMeasurement(m);
@@ -34,17 +42,17 @@ export function useAtomSelection(
     (atomIndex: number) => {
       if (!rendererRef.current) return;
       const newSelection = rendererRef.current.toggleAtomSelection(atomIndex);
-      setSelection(newSelection);
+      updateSelection(newSelection);
       updateMeasurement(rendererRef.current.getMeasurement());
     },
-    [rendererRef, updateMeasurement],
+    [rendererRef, updateSelection, updateMeasurement],
   );
 
   const handleClearSelection = useCallback(() => {
     rendererRef.current?.clearSelection();
-    setSelection({ atoms: [] });
+    updateSelection({ atoms: [] });
     updateMeasurement(null);
-  }, [rendererRef, updateMeasurement]);
+  }, [rendererRef, updateSelection, updateMeasurement]);
 
   const handleFrameUpdated = useCallback(() => {
     if (!rendererRef.current) return;
@@ -57,15 +65,15 @@ export function useAtomSelection(
       if (!rendererRef.current) return;
       if (atoms.length === 0) {
         rendererRef.current.clearSelection();
-        setSelection({ atoms: [] });
+        updateSelection({ atoms: [] });
         updateMeasurement(null);
       } else {
         const newSelection = rendererRef.current.setSelection(atoms);
-        setSelection(newSelection);
+        updateSelection(newSelection);
         updateMeasurement(rendererRef.current.getMeasurement());
       }
     },
-    [rendererRef, updateMeasurement],
+    [rendererRef, updateSelection, updateMeasurement],
   );
 
   return {

--- a/tests/ts/components/MeganeViewer.selectionEvents.test.tsx
+++ b/tests/ts/components/MeganeViewer.selectionEvents.test.tsx
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, act, cleanup } from "@testing-library/react";
+import type { SelectionState, Measurement } from "@/types";
+
+vi.mock("@/components/Viewport", () => ({ Viewport: vi.fn(() => null) }));
+vi.mock("@/components/Tooltip", () => ({ Tooltip: vi.fn(() => null) }));
+vi.mock("@/components/MeasurementPanel", () => ({ MeasurementPanel: vi.fn(() => null) }));
+vi.mock("@/components/Timeline", () => ({ Timeline: vi.fn(() => null) }));
+vi.mock("@/components/PipelineEditor", () => ({ PipelineEditor: vi.fn(() => null) }));
+vi.mock("@/parsers/inferBondsJS", () => ({
+  inferBondsVdwJS: vi.fn(() => new Uint32Array(0)),
+}));
+vi.mock("@/pipeline/executors/addBond", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/pipeline/executors/addBond")>();
+  return { ...actual, processPbcBonds: vi.fn() };
+});
+
+import { MeganeViewer } from "@/components/MeganeViewer";
+import { Viewport } from "@/components/Viewport";
+import { MeasurementPanel } from "@/components/MeasurementPanel";
+
+const mockViewport = vi.mocked(Viewport);
+const mockMeasurementPanel = vi.mocked(MeasurementPanel);
+
+/**
+ * Build a fake MoleculeRenderer with configurable selection/measurement
+ * responses. All other methods are no-op stubs via Proxy.
+ */
+function makeFakeRenderer(opts: {
+  toggleResult?: SelectionState;
+  measurementResult?: Measurement | null;
+  clearResult?: SelectionState;
+  setSelectionResult?: SelectionState;
+}) {
+  const toggleAtomSelection = vi.fn(() => opts.toggleResult ?? { atoms: [] });
+  const getMeasurement = vi.fn(() => opts.measurementResult ?? null);
+  const clearSelection = vi.fn();
+  const setSelection = vi.fn(() => opts.setSelectionResult ?? { atoms: [] });
+
+  const renderer = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === "toggleAtomSelection") return toggleAtomSelection;
+        if (prop === "getMeasurement") return getMeasurement;
+        if (prop === "clearSelection") return clearSelection;
+        if (prop === "setSelection") return setSelection;
+        return vi.fn();
+      },
+    },
+  );
+
+  return { renderer, toggleAtomSelection, getMeasurement, clearSelection, setSelection };
+}
+
+function mountAndWireRenderer(
+  onSelectionChange?: (s: SelectionState) => void,
+  onMeasurementChange?: (m: Measurement | null) => void,
+  rendererOpts: Parameters<typeof makeFakeRenderer>[0] = {},
+) {
+  render(
+    <MeganeViewer
+      onUploadStructure={() => {}}
+      onSelectionChange={onSelectionChange}
+      onMeasurementChange={onMeasurementChange}
+    />,
+  );
+
+  const viewportProps = mockViewport.mock.calls[0][0];
+  const { renderer, ...spies } = makeFakeRenderer(rendererOpts);
+
+  act(() => {
+    viewportProps.onRendererReady?.(renderer as never);
+  });
+
+  return { viewportProps, spies };
+}
+
+describe("MeganeViewer.onSelectionChange", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("fires with the new atom list on right-click selection", () => {
+    const onSelectionChange = vi.fn();
+    const selected: SelectionState = { atoms: [3] };
+
+    const { viewportProps } = mountAndWireRenderer(onSelectionChange, undefined, {
+      toggleResult: selected,
+    });
+
+    act(() => {
+      viewportProps.onAtomRightClick(3);
+    });
+
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+    expect(onSelectionChange).toHaveBeenCalledWith(selected);
+  });
+
+  it("fires with empty atoms when selection is cleared", () => {
+    const onSelectionChange = vi.fn();
+    const { viewportProps } = mountAndWireRenderer(onSelectionChange, undefined, {
+      toggleResult: { atoms: [5] },
+    });
+
+    act(() => {
+      viewportProps.onAtomRightClick(5);
+    });
+    onSelectionChange.mockClear();
+
+    // Simulate clear from MeasurementPanel's onClear
+    const panelProps = mockMeasurementPanel.mock.lastCall?.[0];
+    act(() => {
+      panelProps?.onClear();
+    });
+
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+    expect(onSelectionChange).toHaveBeenCalledWith({ atoms: [] });
+  });
+
+  it("fires for multi-atom selection (angle)", () => {
+    const onSelectionChange = vi.fn();
+    const { viewportProps } = mountAndWireRenderer(onSelectionChange, undefined, {
+      toggleResult: { atoms: [1, 2] },
+    });
+
+    act(() => {
+      viewportProps.onAtomRightClick(2);
+    });
+
+    expect(onSelectionChange).toHaveBeenCalledWith({ atoms: [1, 2] });
+  });
+
+  it("does not throw when onSelectionChange is not provided", () => {
+    const { viewportProps } = mountAndWireRenderer(undefined, undefined, {
+      toggleResult: { atoms: [0] },
+    });
+
+    expect(() => {
+      act(() => {
+        viewportProps.onAtomRightClick(0);
+      });
+    }).not.toThrow();
+  });
+});
+
+describe("MeganeViewer.onMeasurementChange", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("fires with distance measurement when two atoms are selected", () => {
+    const onMeasurementChange = vi.fn();
+    const measurement: Measurement = {
+      atoms: [0, 1],
+      type: "distance",
+      value: 1.5,
+      label: "1.500 Å",
+    };
+
+    const { viewportProps } = mountAndWireRenderer(undefined, onMeasurementChange, {
+      toggleResult: { atoms: [0, 1] },
+      measurementResult: measurement,
+    });
+
+    act(() => {
+      viewportProps.onAtomRightClick(1);
+    });
+
+    expect(onMeasurementChange).toHaveBeenCalledTimes(1);
+    expect(onMeasurementChange).toHaveBeenCalledWith(measurement);
+  });
+
+  it("fires with null when selection is cleared", () => {
+    const onMeasurementChange = vi.fn();
+    const { viewportProps } = mountAndWireRenderer(undefined, onMeasurementChange, {
+      toggleResult: { atoms: [0, 1] },
+      measurementResult: {
+        atoms: [0, 1],
+        type: "distance",
+        value: 2.0,
+        label: "2.000 Å",
+      },
+    });
+
+    act(() => {
+      viewportProps.onAtomRightClick(1);
+    });
+    onMeasurementChange.mockClear();
+
+    const panelProps = mockMeasurementPanel.mock.lastCall?.[0];
+    act(() => {
+      panelProps?.onClear();
+    });
+
+    expect(onMeasurementChange).toHaveBeenCalledWith(null);
+  });
+
+  it("fires with null when no measurement is available (single atom)", () => {
+    const onMeasurementChange = vi.fn();
+
+    const { viewportProps } = mountAndWireRenderer(undefined, onMeasurementChange, {
+      toggleResult: { atoms: [7] },
+      measurementResult: null,
+    });
+
+    act(() => {
+      viewportProps.onAtomRightClick(7);
+    });
+
+    expect(onMeasurementChange).toHaveBeenCalledWith(null);
+  });
+
+  it("does not throw when onMeasurementChange is not provided", () => {
+    const { viewportProps } = mountAndWireRenderer(undefined, undefined, {
+      measurementResult: {
+        atoms: [0, 1],
+        type: "distance",
+        value: 1.0,
+        label: "1.000 Å",
+      },
+    });
+
+    expect(() => {
+      act(() => {
+        viewportProps.onAtomRightClick(1);
+      });
+    }).not.toThrow();
+  });
+
+  it("fires both onSelectionChange and onMeasurementChange on the same interaction", () => {
+    const onSelectionChange = vi.fn();
+    const onMeasurementChange = vi.fn();
+    const measurement: Measurement = {
+      atoms: [2, 3, 4],
+      type: "angle",
+      value: 109.5,
+      label: "109.5°",
+    };
+
+    const { viewportProps } = mountAndWireRenderer(onSelectionChange, onMeasurementChange, {
+      toggleResult: { atoms: [2, 3, 4] },
+      measurementResult: measurement,
+    });
+
+    act(() => {
+      viewportProps.onAtomRightClick(4);
+    });
+
+    expect(onSelectionChange).toHaveBeenCalledWith({ atoms: [2, 3, 4] });
+    expect(onMeasurementChange).toHaveBeenCalledWith(measurement);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `onSelectionChange?: (selection: SelectionState) => void` prop to `MeganeViewer` — fires on every atom selection toggle or clear with `{ atoms: number[] }` (0-based indices, max 4)
- Add `onMeasurementChange?: (measurement: Measurement | null) => void` prop to `MeganeViewer` — fires when a distance/angle/dihedral is computed or cleared
- Thread both callbacks through `useAtomSelection` via a new `updateSelection` helper (matching the existing `updateMeasurement` ref-backed pattern)
- Update `docs/docs/platform-support.md` UI features table and Known Gaps note to reflect standalone now supports these events

These props mirror the Jupyter widget's `selection_change` and `measurement` events, enabling Plotly (and other host-app) integration directly from the standalone React component.

Closes part of #377 (platform-support gaps — Plotly / selection_change / measurement events).

## Test plan

- [x] 9 new unit tests in `tests/ts/components/MeganeViewer.selectionEvents.test.tsx`:
  - `onSelectionChange` fires with correct atom list on right-click
  - `onSelectionChange` fires with empty atoms on clear
  - `onSelectionChange` fires for multi-atom selection
  - No throw when `onSelectionChange` is omitted
  - `onMeasurementChange` fires with distance measurement (2 atoms)
  - `onMeasurementChange` fires with `null` on clear
  - `onMeasurementChange` fires with `null` when only 1 atom selected
  - No throw when `onMeasurementChange` is omitted
  - Both callbacks fire together on the same interaction
- [x] All 1015 existing TypeScript tests continue to pass
- [x] `useAtomSelection.ts` patch coverage: 88.88% (well above 70% Codecov gate)

https://claude.ai/code/session_01UHuq3qeu85uGAbQqNacyT6