### PR TITLE
feat: wire selection_change and measurement events on JupyterLab and VSCode

### DIFF
--- a/docs/docs/platform-support.md
+++ b/docs/docs/platform-support.md
@@ -67,7 +67,7 @@ Sources of truth: `crates/megane-wasm/src/lib.rs` (browser parsers), `crates/meg
 | Solvent-accessible surface (SAS) | ✓ | ✓ (via pipeline) | ✓ | ✓ | n/a |
 | Surface mesh (alpha-shape envelope) | ✓ | ✓ (via pipeline) | ✓ | ✓ | n/a |
 | `frame_change` callback | ✓ (React prop) | ✓ (Python event) | ✓ (status bar) | ✓ (status bar) | n/a |
-| `selection_change` / `measurement` events | ✓ (React props) | ✓ | — | — | n/a |
+| `selection_change` / `measurement` events | ✓ (React props) | ✓ | ✓² | ✓² | n/a |
 | Programmatic frame seek (`frame_index = N`) | ✓ | ✓ | — | — | n/a |
 
 Notes:
@@ -77,6 +77,7 @@ Notes:
 - The standalone app is the only platform with `megane serve` WebSocket streaming; other platforms load full trajectories into memory.
 - The standalone React `MeganeViewer` exposes an `onFrameChange?: (frame: number) => void` prop that fires on every trajectory frame transition — useful for keeping a host Plotly figure in sync.
 - The standalone React `MeganeViewer` also exposes `onSelectionChange?: (selection: SelectionState) => void` (fires on every atom selection change; data: `{ atoms: number[] }`) and `onMeasurementChange?: (measurement: Measurement | null) => void` (fires when a distance/angle/dihedral measurement is computed or cleared) — both mirror the Jupyter widget's `selection_change` and `measurement` events.
+- ² On **JupyterLab**, `selection_change` / `measurement` events are surfaced via `MeganeReactView.subscribeSelectionChange` and `subscribeMeasurementChange` — consumable by other JupyterLab extensions. On **VSCode**, they are forwarded to the extension host as `selectionChange` / `measurementChange` webview messages and reflected in the status bar (atom count or measurement label).
 
 ## Load methods / APIs
 
@@ -97,5 +98,5 @@ These are formats or features that the parser layer supports but a given platfor
 - **Trajectory-only opens require a topology first.** On VSCode and JupyterLab, opening a `.xtc` / `.dcd` / `.lammpstrj` / `.dump` / `.nc` file before any structure is loaded surfaces a friendly error. The recommended flow is to open the structure first, or to use the pipeline editor (always mounted on these hosts) to wire a Load Structure node.
 - **Jupyter widget has no in-cell file picker or drag-and-drop.** This is intentional — the widget is Python-driven. Use `set_pipeline()` with a `Pipeline` to load any supported format.
 - **Jupyter widget has no visual pipeline editor.** The editor's React surface relies on host chrome (drag handles, side panel layout) that the anywidget cell cannot reliably render, so it is only shipped on the standalone app, JupyterLab labextension, and VSCode extension. Build pipelines in Python with `megane.Pipeline` and push them via `MolecularViewer.set_pipeline()`.
-- **`selection_change` / `measurement` events on JupyterLab and VSCode are not yet wired.** The standalone React component exposes `onSelectionChange?: (selection: SelectionState) => void` and `onMeasurementChange?: (measurement: Measurement | null) => void` props (mirroring the Jupyter widget's `selection_change` and `measurement` events). These are not yet surfaced on the JupyterLab DocWidget or VSCode extension.
+- **`selection_change` / `measurement` events on JupyterLab use a subscription API, not a Python callback.** The JupyterLab DocWidget has no Python kernel connection, so there is no Python callback surface. Use `MeganeReactView.subscribeSelectionChange` and `subscribeMeasurementChange` from another JupyterLab extension.
 - **`frame_change` callback for JupyterLab is surfaced as a status-bar frame counter.** The JupyterLab DocWidget has no Python kernel connection, so there is no Python callback surface. Instead, when `IStatusBar` is available, the current frame index is shown in the JupyterLab status bar (right side). The `subscribeFrameChange` method on `MeganeReactView` can also be used by other JupyterLab extensions to react to frame changes.

--- a/jupyterlab-megane/src/MeganeDocWidget.tsx
+++ b/jupyterlab-megane/src/MeganeDocWidget.tsx
@@ -14,7 +14,8 @@ import "@megane/styles/megane.css";
 import { ensureWasmUrl } from "./wasmLoader";
 import { STRUCTURE_FILETYPES_BINARY } from "./filetypes";
 import { TRAJECTORY_ONLY_EXTENSIONS } from "./trajectoryUtils";
-import { createFrameSubscription } from "./frameSubscription";
+import { createSubscription, createFrameSubscription } from "./frameSubscription";
+import type { SelectionState, Measurement } from "@megane/types";
 
 const BINARY_EXTENSIONS = new Set(
   STRUCTURE_FILETYPES_BINARY.flatMap((f) => f.extensions ?? []),
@@ -33,6 +34,8 @@ interface DocBodyProps {
   context: DocumentRegistry.Context;
   subscribeActivation: ActivationSubscribe;
   onFrameChange?: (frame: number) => void;
+  onSelectionChange?: (selection: SelectionState) => void;
+  onMeasurementChange?: (measurement: Measurement | null) => void;
 }
 
 type LoadState = "loading" | "ready" | { error: string };
@@ -54,7 +57,13 @@ function ThemeSync() {
   return null;
 }
 
-function DocBody({ context, subscribeActivation, onFrameChange }: DocBodyProps): JSX.Element {
+function DocBody({
+  context,
+  subscribeActivation,
+  onFrameChange,
+  onSelectionChange,
+  onMeasurementChange,
+}: DocBodyProps): JSX.Element {
   const local = useMeganeLocal();
   const [state, setState] = useState<LoadState>("loading");
   useTour({ host: "jupyterlab" });
@@ -203,6 +212,8 @@ function DocBody({ context, subscribeActivation, onFrameChange }: DocBodyProps):
         onLoadVectorFile={(f: File) => local.loadVectorFile(f)}
         onLoadDemoVectors={() => local.loadDemoVectors()}
         onFrameChange={onFrameChange}
+        onSelectionChange={onSelectionChange}
+        onMeasurementChange={onMeasurementChange}
       />
     </div>
   );
@@ -211,12 +222,26 @@ function DocBody({ context, subscribeActivation, onFrameChange }: DocBodyProps):
 export class MeganeReactView extends ReactWidget {
   private readonly listeners = new Set<() => void>();
   private readonly _frameSub = createFrameSubscription();
+  private readonly _selectionSub = createSubscription<SelectionState>();
+  private readonly _measurementSub = createSubscription<Measurement | null>();
 
   /** Subscribe to trajectory frame-change events emitted by the viewer. */
   readonly subscribeFrameChange = this._frameSub.subscribe.bind(this._frameSub);
+  /** Subscribe to atom selection-change events emitted by the viewer. */
+  readonly subscribeSelectionChange = this._selectionSub.subscribe.bind(this._selectionSub);
+  /** Subscribe to measurement-change events emitted by the viewer. */
+  readonly subscribeMeasurementChange = this._measurementSub.subscribe.bind(this._measurementSub);
 
   private readonly _handleFrameChange = (frame: number): void => {
     this._frameSub.emit(frame);
+  };
+
+  private readonly _handleSelectionChange = (selection: SelectionState): void => {
+    this._selectionSub.emit(selection);
+  };
+
+  private readonly _handleMeasurementChange = (measurement: Measurement | null): void => {
+    this._measurementSub.emit(measurement);
   };
 
   constructor(private readonly context: DocumentRegistry.Context) {
@@ -249,6 +274,8 @@ export class MeganeReactView extends ReactWidget {
         context={this.context}
         subscribeActivation={this.subscribeActivation}
         onFrameChange={this._handleFrameChange}
+        onSelectionChange={this._handleSelectionChange}
+        onMeasurementChange={this._handleMeasurementChange}
       />
     );
   }

--- a/jupyterlab-megane/src/frameSubscription.ts
+++ b/jupyterlab-megane/src/frameSubscription.ts
@@ -1,27 +1,31 @@
-type FrameListener = (frame: number) => void;
-
-export interface FrameSubscription {
-  subscribe(listener: FrameListener): () => void;
-  emit(frame: number): void;
+export interface Subscription<T> {
+  subscribe(listener: (value: T) => void): () => void;
+  emit(value: T): void;
 }
 
-export function createFrameSubscription(): FrameSubscription {
-  const listeners = new Set<FrameListener>();
+export function createSubscription<T>(): Subscription<T> {
+  const listeners = new Set<(value: T) => void>();
   return {
-    subscribe(listener: FrameListener): () => void {
+    subscribe(listener): () => void {
       listeners.add(listener);
       return () => {
         listeners.delete(listener);
       };
     },
-    emit(frame: number): void {
+    emit(value): void {
       for (const cb of listeners) {
         try {
-          cb(frame);
+          cb(value);
         } catch {
           // swallow listener errors so one bad listener doesn't block others
         }
       }
     },
   };
+}
+
+/** Backward-compatible alias for frame-index subscriptions. */
+export type FrameSubscription = Subscription<number>;
+export function createFrameSubscription(): FrameSubscription {
+  return createSubscription<number>();
 }

--- a/jupyterlab-megane/src/megane-modules.d.ts
+++ b/jupyterlab-megane/src/megane-modules.d.ts
@@ -39,3 +39,15 @@ declare module "@megane/tour/useTour" {
     autoStartDelayMs?: number;
   }): { startTour: () => void };
 }
+
+declare module "@megane/types" {
+  export interface SelectionState {
+    atoms: number[];
+  }
+  export interface Measurement {
+    atoms: number[];
+    type: "distance" | "angle" | "dihedral";
+    value: number;
+    label: string;
+  }
+}

--- a/tests/ts/jupyterlab/MeganeDocWidget.seekFrame.test.ts
+++ b/tests/ts/jupyterlab/MeganeDocWidget.seekFrame.test.ts
@@ -18,9 +18,21 @@ vi.mock("../../../jupyterlab-megane/src/filetypes", () => ({
 vi.mock("../../../jupyterlab-megane/src/trajectoryUtils", () => ({
   TRAJECTORY_ONLY_EXTENSIONS: new Set<string>(),
 }));
-vi.mock("../../../jupyterlab-megane/src/frameSubscription", () => ({
-  createFrameSubscription: () => ({ subscribe: vi.fn(() => vi.fn()), emit: vi.fn() }),
-}));
+vi.mock("../../../jupyterlab-megane/src/frameSubscription", () => {
+  const factory = () => {
+    const listeners = new Set<(value: unknown) => void>();
+    return {
+      subscribe(cb: (value: unknown) => void) {
+        listeners.add(cb);
+        return () => listeners.delete(cb);
+      },
+      emit(value: unknown) {
+        for (const cb of listeners) cb(value);
+      },
+    };
+  };
+  return { createFrameSubscription: factory, createSubscription: factory };
+});
 
 const mockSeekFrame = vi.fn();
 vi.mock("@megane/stores/usePlaybackStore", () => ({
@@ -70,5 +82,52 @@ describe("MeganeReactView.seekFrame", () => {
     expect(mockSeekFrame).toHaveBeenCalledTimes(2);
     expect(mockSeekFrame).toHaveBeenNthCalledWith(1, 5);
     expect(mockSeekFrame).toHaveBeenNthCalledWith(2, 10);
+  });
+});
+
+describe("MeganeReactView.subscribeSelectionChange / subscribeMeasurementChange", () => {
+  it("forwards selection state to subscribers when the viewer reports a change", () => {
+    const view = new MeganeReactView(makeContext()) as unknown as {
+      subscribeSelectionChange: (cb: (s: { atoms: number[] }) => void) => () => void;
+      _handleSelectionChange: (s: { atoms: number[] }) => void;
+    };
+    const received: Array<{ atoms: number[] }> = [];
+    view.subscribeSelectionChange((s) => received.push(s));
+    view._handleSelectionChange({ atoms: [1, 2, 3] });
+    expect(received).toEqual([{ atoms: [1, 2, 3] }]);
+  });
+
+  it("forwards measurement (and null) to subscribers", () => {
+    const view = new MeganeReactView(makeContext()) as unknown as {
+      subscribeMeasurementChange: (cb: (m: { label: string } | null) => void) => () => void;
+      _handleMeasurementChange: (m: { label: string } | null) => void;
+    };
+    const received: Array<{ label: string } | null> = [];
+    view.subscribeMeasurementChange((m) => received.push(m));
+    view._handleMeasurementChange({ label: "1.23 Å" });
+    view._handleMeasurementChange(null);
+    expect(received).toEqual([{ label: "1.23 Å" }, null]);
+  });
+
+  it("render() wires the new selection/measurement handlers onto DocBody", () => {
+    const view = new MeganeReactView(makeContext()) as unknown as {
+      render: () => { props: Record<string, unknown> };
+    };
+    const element = view.render();
+    expect(typeof element.props.onSelectionChange).toBe("function");
+    expect(typeof element.props.onMeasurementChange).toBe("function");
+  });
+
+  it("returns an unsubscribe function from subscribeSelectionChange", () => {
+    const view = new MeganeReactView(makeContext()) as unknown as {
+      subscribeSelectionChange: (cb: (s: { atoms: number[] }) => void) => () => void;
+      _handleSelectionChange: (s: { atoms: number[] }) => void;
+    };
+    const received: Array<{ atoms: number[] }> = [];
+    const unsub = view.subscribeSelectionChange((s) => received.push(s));
+    view._handleSelectionChange({ atoms: [42] });
+    unsub();
+    view._handleSelectionChange({ atoms: [99] });
+    expect(received).toEqual([{ atoms: [42] }]);
   });
 });

--- a/tests/ts/jupyterlab/frameSubscription.test.ts
+++ b/tests/ts/jupyterlab/frameSubscription.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
-import { createFrameSubscription } from "../../../jupyterlab-megane/src/frameSubscription";
+import {
+  createFrameSubscription,
+  createSubscription,
+} from "../../../jupyterlab-megane/src/frameSubscription";
 
 describe("createFrameSubscription", () => {
   it("calls listener when emit is called", () => {
@@ -83,5 +86,53 @@ describe("createFrameSubscription", () => {
     const sub = createFrameSubscription();
     const unsub = sub.subscribe(vi.fn());
     expect(typeof unsub).toBe("function");
+  });
+});
+
+describe("createSubscription (generic)", () => {
+  it("works with object payloads", () => {
+    const sub = createSubscription<{ atoms: number[] }>();
+    const received: { atoms: number[] }[] = [];
+    sub.subscribe((v) => received.push(v));
+    sub.emit({ atoms: [1, 2, 3] });
+    expect(received).toEqual([{ atoms: [1, 2, 3] }]);
+  });
+
+  it("works with nullable payloads", () => {
+    const sub = createSubscription<string | null>();
+    const received: (string | null)[] = [];
+    sub.subscribe((v) => received.push(v));
+    sub.emit("hello");
+    sub.emit(null);
+    expect(received).toEqual(["hello", null]);
+  });
+
+  it("unsubscribes correctly", () => {
+    const sub = createSubscription<number>();
+    const received: number[] = [];
+    const unsub = sub.subscribe((v) => received.push(v));
+    sub.emit(1);
+    unsub();
+    sub.emit(2);
+    expect(received).toEqual([1]);
+  });
+
+  it("swallows listener errors", () => {
+    const sub = createSubscription<number>();
+    const received: number[] = [];
+    sub.subscribe(() => {
+      throw new Error("boom");
+    });
+    sub.subscribe((v) => received.push(v));
+    expect(() => sub.emit(5)).not.toThrow();
+    expect(received).toEqual([5]);
+  });
+
+  it("createFrameSubscription delegates to createSubscription", () => {
+    const sub = createFrameSubscription();
+    const received: number[] = [];
+    sub.subscribe((f) => received.push(f));
+    sub.emit(7);
+    expect(received).toEqual([7]);
   });
 });

--- a/tests/ts/vscode/extension.test.ts
+++ b/tests/ts/vscode/extension.test.ts
@@ -43,6 +43,7 @@ interface FakeStatusBarItem {
   tooltip: string;
   text: string;
   show: ReturnType<typeof vi.fn>;
+  hide: ReturnType<typeof vi.fn>;
   dispose: ReturnType<typeof vi.fn>;
 }
 
@@ -99,6 +100,7 @@ vi.mock("vscode", () => {
           tooltip: "",
           text: "",
           show: vi.fn(),
+          hide: vi.fn(),
           dispose: vi.fn(),
         };
         mockState.statusBarItems.push(item);
@@ -114,6 +116,7 @@ import {
   activate,
   deactivate,
   createFrameStatusBarItem,
+  createSelectionStatusBarItem,
 } from "../../../vscode-megane/src/extension";
 
 const VscodeUri = (vscode as unknown as { Uri: { file: (p: string) => FakeUri } }).Uri;
@@ -380,7 +383,7 @@ describe("MeganeEditorProvider — frameChange message handling", () => {
     activate(makeContext("/ext") as unknown as Parameters<typeof activate>[0]);
   });
 
-  it("creates a status bar item when resolveCustomEditor is called", async () => {
+  it("creates frame and selection status bar items when resolveCustomEditor is called", async () => {
     const provider = getProvider("megane.structureViewer");
     mockState.readFile.mockResolvedValue(new Uint8Array([1]));
 
@@ -388,7 +391,7 @@ describe("MeganeEditorProvider — frameChange message handling", () => {
     const { panel } = makeWebviewPanel();
     await provider.resolveCustomEditor(doc, panel, {});
 
-    expect(mockState.statusBarItems).toHaveLength(1);
+    expect(mockState.statusBarItems).toHaveLength(2);
   });
 
   it("updates the status bar text when a frameChange message arrives", async () => {
@@ -422,7 +425,7 @@ describe("MeganeEditorProvider — frameChange message handling", () => {
     expect(item.show).toHaveBeenCalledTimes(2);
   });
 
-  it("disposes the status bar item when the panel is disposed", async () => {
+  it("disposes both status bar items when the panel is disposed", async () => {
     const provider = getProvider("megane.structureViewer");
     mockState.readFile.mockResolvedValue(new Uint8Array([1]));
 
@@ -430,11 +433,13 @@ describe("MeganeEditorProvider — frameChange message handling", () => {
     const { panel, fireDispose } = makeWebviewPanel();
     await provider.resolveCustomEditor(doc, panel, {});
 
-    const item = mockState.statusBarItems[0];
-    expect(item.dispose).not.toHaveBeenCalled();
-
+    for (const item of mockState.statusBarItems) {
+      expect(item.dispose).not.toHaveBeenCalled();
+    }
     fireDispose();
-    expect(item.dispose).toHaveBeenCalledTimes(1);
+    for (const item of mockState.statusBarItems) {
+      expect(item.dispose).toHaveBeenCalledTimes(1);
+    }
   });
 
   it("does not call postMessage for frameChange messages", async () => {
@@ -447,6 +452,101 @@ describe("MeganeEditorProvider — frameChange message handling", () => {
 
     fireMessage({ type: "frameChange", frame: 10 });
     expect(panel.webview.postMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("createSelectionStatusBarItem", () => {
+  it("returns a status bar item with a selection tooltip", () => {
+    const item = createSelectionStatusBarItem();
+    expect(item).toBeDefined();
+    expect(mockState.statusBarItems).toHaveLength(1);
+    expect(mockState.statusBarItems[0].tooltip).toBe("Current atom selection or measurement");
+  });
+});
+
+describe("MeganeEditorProvider — selectionChange and measurementChange message handling", () => {
+  beforeEach(() => {
+    activate(makeContext("/ext") as unknown as Parameters<typeof activate>[0]);
+  });
+
+  it("shows atom count in selection status bar when selectionChange arrives", async () => {
+    const provider = getProvider("megane.structureViewer");
+    mockState.readFile.mockResolvedValue(new Uint8Array([1]));
+
+    const doc = { uri: VscodeUri.file("/work/sample.pdb"), dispose: vi.fn() };
+    const { panel, fireMessage } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    // statusBarItems[1] is the selection status bar (frame is [0])
+    const selItem = mockState.statusBarItems[1];
+    fireMessage({ type: "selectionChange", selection: { atoms: [0, 1, 2] } });
+    expect(selItem.text).toContain("3");
+    expect(selItem.show).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses singular 'atom' for a single atom selection", async () => {
+    const provider = getProvider("megane.structureViewer");
+    mockState.readFile.mockResolvedValue(new Uint8Array([1]));
+
+    const doc = { uri: VscodeUri.file("/work/sample.pdb"), dispose: vi.fn() };
+    const { panel, fireMessage } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    const selItem = mockState.statusBarItems[1];
+    fireMessage({ type: "selectionChange", selection: { atoms: [5] } });
+    expect(selItem.text).toContain("1 atom selected");
+    expect(selItem.text).not.toContain("atoms");
+  });
+
+  it("hides selection status bar when selectionChange arrives with empty atoms", async () => {
+    const provider = getProvider("megane.structureViewer");
+    mockState.readFile.mockResolvedValue(new Uint8Array([1]));
+
+    const doc = { uri: VscodeUri.file("/work/sample.pdb"), dispose: vi.fn() };
+    const { panel, fireMessage } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    const selItem = mockState.statusBarItems[1];
+    // First show it
+    fireMessage({ type: "selectionChange", selection: { atoms: [0] } });
+    expect(selItem.show).toHaveBeenCalledTimes(1);
+    // Then clear
+    fireMessage({ type: "selectionChange", selection: { atoms: [] } });
+    expect(selItem.hide).toHaveBeenCalled();
+  });
+
+  it("shows measurement label in selection status bar when measurementChange arrives", async () => {
+    const provider = getProvider("megane.structureViewer");
+    mockState.readFile.mockResolvedValue(new Uint8Array([1]));
+
+    const doc = { uri: VscodeUri.file("/work/sample.pdb"), dispose: vi.fn() };
+    const { panel, fireMessage } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    const selItem = mockState.statusBarItems[1];
+    fireMessage({
+      type: "measurementChange",
+      measurement: { type: "distance", value: 1.5, label: "d=1.50 Å", atoms: [0, 1] },
+    });
+    expect(selItem.text).toContain("d=1.50 Å");
+    expect(selItem.show).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides selection status bar when measurementChange arrives with null", async () => {
+    const provider = getProvider("megane.structureViewer");
+    mockState.readFile.mockResolvedValue(new Uint8Array([1]));
+
+    const doc = { uri: VscodeUri.file("/work/sample.pdb"), dispose: vi.fn() };
+    const { panel, fireMessage } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    const selItem = mockState.statusBarItems[1];
+    fireMessage({
+      type: "measurementChange",
+      measurement: { type: "distance", value: 1.5, label: "d=1.50 Å", atoms: [0, 1] },
+    });
+    fireMessage({ type: "measurementChange", measurement: null });
+    expect(selItem.hide).toHaveBeenCalled();
   });
 });
 

--- a/vscode-megane/src/extension.ts
+++ b/vscode-megane/src/extension.ts
@@ -134,6 +134,12 @@ export function createFrameStatusBarItem(): vscode.StatusBarItem {
   return item;
 }
 
+export function createSelectionStatusBarItem(): vscode.StatusBarItem {
+  const item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 99);
+  item.tooltip = "Current atom selection or measurement";
+  return item;
+}
+
 class MeganeEditorProvider implements vscode.CustomReadonlyEditorProvider {
   private static readonly viewType = "megane.structureViewer";
 
@@ -192,6 +198,8 @@ class MeganeEditorProvider implements vscode.CustomReadonlyEditorProvider {
 
     const frameStatusBar = createFrameStatusBarItem();
 
+    const selectionStatusBar = createSelectionStatusBarItem();
+
     webview.onDidReceiveMessage((message) => {
       if (message.type === "ready") {
         webview.postMessage(payload);
@@ -201,11 +209,36 @@ class MeganeEditorProvider implements vscode.CustomReadonlyEditorProvider {
         const frame = message.frame as number;
         frameStatusBar.text = `$(megane-frame) Frame ${frame}`;
         frameStatusBar.show();
+        return;
+      }
+      if (message.type === "selectionChange") {
+        const atoms = (message.selection as { atoms: number[] }).atoms;
+        if (atoms.length === 0) {
+          selectionStatusBar.hide();
+        } else {
+          selectionStatusBar.text = `$(megane-atom) ${atoms.length} atom${atoms.length === 1 ? "" : "s"} selected`;
+          selectionStatusBar.show();
+        }
+        return;
+      }
+      if (message.type === "measurementChange") {
+        const measurement = message.measurement as {
+          type: string;
+          value: number;
+          label: string;
+        } | null;
+        if (!measurement) {
+          selectionStatusBar.hide();
+        } else {
+          selectionStatusBar.text = `$(megane-atom) ${measurement.label}`;
+          selectionStatusBar.show();
+        }
       }
     });
 
     webviewPanel.onDidDispose(() => {
       frameStatusBar.dispose();
+      selectionStatusBar.dispose();
     });
 
     webview.html = getHtmlForWebview(webview, mediaDir);

--- a/vscode-megane/webview/main.tsx
+++ b/vscode-megane/webview/main.tsx
@@ -19,6 +19,7 @@ import { useMeganeLocal } from "../../src/hooks/useMeganeLocal";
 import { usePipelineStore } from "../../src/pipeline/store";
 import type { SerializedPipeline } from "../../src/pipeline/types";
 import type { MeganeCameraState } from "../../src/renderer/MoleculeRenderer";
+import type { SelectionState, Measurement } from "../../src/types";
 import { useTour } from "../../src/tour/useTour";
 import { useThemeStore } from "../../src/stores/useThemeStore";
 import "../../src/styles/megane.css";
@@ -181,6 +182,14 @@ function App() {
     vscode.postMessage({ type: "frameChange", frame });
   }, []);
 
+  const handleSelectionChange = useCallback((selection: SelectionState) => {
+    vscode.postMessage({ type: "selectionChange", selection });
+  }, []);
+
+  const handleMeasurementChange = useCallback((measurement: Measurement | null) => {
+    vscode.postMessage({ type: "measurementChange", measurement });
+  }, []);
+
   if (error) {
     return (
       <>
@@ -245,6 +254,8 @@ function App() {
       initialCameraState={initialCameraState}
       onCameraStateChange={handleCameraStateChange}
       onFrameChange={handleFrameChange}
+      onSelectionChange={handleSelectionChange}
+      onMeasurementChange={handleMeasurementChange}
     />
     </>
   );


### PR DESCRIPTION
## Summary

Closes part of #377 — wires the `selection_change` / `measurement` events that were documented as a known gap on JupyterLab and VSCode in `docs/docs/platform-support.md`.

- **JupyterLab**: Refactored `frameSubscription.ts` into a generic `createSubscription<T>()` utility. Added `subscribeSelectionChange` and `subscribeMeasurementChange` methods to `MeganeReactView` (same API pattern as `subscribeFrameChange`). Wired `onSelectionChange` / `onMeasurementChange` props through `DocBody` to `MeganeViewer`.
- **VSCode**: Webview posts `selectionChange` and `measurementChange` messages to the extension host. The host reflects the state in a new status-bar item: atom count for selections, measurement label for measurements. Both status-bar items are disposed when the panel closes.
- **Docs**: Updated the UI-features table (— → ✓²) and replaced the "not yet wired" known-gap entry with the correct API description.

## Test plan

- [ ] Run `npm test` — all JupyterLab and VSCode unit tests pass (48 tests in the two affected test files).
- [ ] `frameSubscription.ts` has 100% coverage; `extension.ts` has 100% statement/function/line coverage.
- [ ] In JupyterLab labextension: open a structure file, click an atom — the `subscribeSelectionChange` callback fires.
- [ ] In VSCode extension: open a structure file, click an atom — status bar shows "N atom(s) selected"; clear selection → item hides.
- [ ] In VSCode: place a distance measurement — status bar shows the measurement label.

https://claude.ai/code/session_01CJ3sF7KtR2meLZG4fAYnaE