### PR TITLE
docs: fix outdated MOL2/CIF note and missing parsers in architecture diagram

### DIFF
--- a/docs/docs/dev/architecture.md
+++ b/docs/docs/dev/architecture.md
@@ -30,7 +30,7 @@ Instead of mesh-based spheres (32+ triangles each), atoms are rendered as **scre
 ┌─────────────────────────────────────────────────────────────┐
 │  Rust / WASM Parsers  (crates/megane-wasm/)                 │
 │  PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, LAMMPS data,            │
-│  XTC, ASE .traj, .lammpstrj/.dump                           │
+│  XTC, DCD, AMBER NetCDF, ASE .traj, .lammpstrj/.dump        │
 │  → Snapshot { positions, elements, bonds, box }             │
 └────────────────────────────┬────────────────────────────────┘
                              │  wasm-bindgen FFI

--- a/docs/docs/guide/pipeline/python.md
+++ b/docs/docs/guide/pipeline/python.md
@@ -81,17 +81,7 @@ LoadStructure(path: str)
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `path` | `str` | File path. Auto-detected by extension. Supported: `.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf` (routed through the MOL parser), `.data`, `.lammps`, `.traj` (ASE binary). |
-
-> **Note — MOL2 and CIF in Python pipelines.** The Rust/PyO3 layer ships
-> `parse_mol2` and `parse_cif`, but the Python `LoadStructure` extension
-> dispatcher (`_load_structure_file()` in `python/megane/pipeline.py`) does not
-> route those two extensions yet, so `LoadStructure("foo.mol2")` /
-> `LoadStructure("foo.cif")` will raise an unsupported-format error. Until the
-> dispatcher is wired up, parse them directly with
-> `from megane import megane_parser; megane_parser.parse_mol2(text)` or open
-> the file in the standalone web app, JupyterLab, or VSCode where MOL2/CIF
-> are fully supported.
+| `path` | `str` | File path. Auto-detected by extension. Supported: `.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf` (routed through the MOL parser), `.mol2`, `.cif`, `.data`, `.lammps`, `.traj` (ASE binary). |
 
 **Ports:** `out.particle`, `out.traj`, `out.cell`
 


### PR DESCRIPTION
## Summary

- **Remove incorrect MOL2/CIF limitation note** from the Python pipeline guide. The note claimed that `LoadStructure("foo.mol2")` / `LoadStructure("foo.cif")` would raise an error, but `_load_structure_file()` in `python/megane/pipeline.py` already dispatches `.mol2` → `megane_parser.parse_mol2` and `.cif` → `megane_parser.parse_cif`. The note was written before the dispatcher was wired up and was never removed.
- **Update `LoadStructure` parameter description** to include `.mol2` and `.cif` in the supported extension list (`docs/docs/guide/pipeline/python.md`).
- **Add DCD and AMBER NetCDF to the WASM parser diagram** in `docs/docs/dev/architecture.md`. Both `parse_dcd_file` and `parse_netcdf_file` exist in `crates/megane-wasm/src/lib.rs` but were omitted from the ASCII diagram.

## Test plan

- [ ] Documentation-only changes — no code logic altered.
- [ ] Verified `_load_structure_file()` in `python/megane/pipeline.py` dispatches `.mol2` (line 470) and `.cif` (line 471).
- [ ] Verified `parse_dcd_file` and `parse_netcdf_file` exist in `crates/megane-wasm/src/lib.rs`.

https://claude.ai/code/session_01L72fB9Uy9Y3mhj4PeZ8tnL