### PR TITLE
feat(python): add load_dcd, load_netcdf, load_lammpstrj to Python parsers API

### DIFF
--- a/docs/docs/platform-support.md
+++ b/docs/docs/platform-support.md
@@ -42,10 +42,10 @@ Legend:
 | Format | Extensions | Standalone | Jupyter widget | JupyterLab | VSCode | Python |
 |---|---|:---:|:---:|:---:|:---:|:---:|
 | XTC | `.xtc` | ✓ | API | ✓¹ | ✓¹ | ✓ |
-| DCD | `.dcd` | ✓ | API | ✓¹ | ✓¹ | API |
+| DCD | `.dcd` | ✓ | API | ✓¹ | ✓¹ | ✓ |
 | ASE trajectory | `.traj` | ✓ | API | ✓ | ✓ | ✓ |
-| LAMMPS dump | `.lammpstrj`, `.dump` | ✓ | API | ✓¹ | ✓¹ | API |
-| AMBER NetCDF | `.nc` | ✓ | API | ✓¹ | ✓¹ | API |
+| LAMMPS dump | `.lammpstrj`, `.dump` | ✓ | API | ✓¹ | ✓¹ | ✓ |
+| AMBER NetCDF | `.nc` | ✓ | API | ✓¹ | ✓¹ | ✓ |
 
 ¹ Trajectory-only formats need a topology already loaded. Opening a `.xtc` /
 `.dcd` / `.lammpstrj` / `.dump` / `.nc` directly surfaces an actionable error; recover by
@@ -88,7 +88,7 @@ How data gets into the viewer on each platform:
 | **Jupyter widget** | Python only — no in-cell file picker | `MolecularViewer.load(pdb_path, xtc=, traj=)` (deprecated) or `MolecularViewer.set_pipeline(Pipeline)` (recommended) |
 | **JupyterLab** | Click a registered file type in the file browser | Internally reads `context.model` (`jupyterlab-megane/src/MeganeDocWidget.tsx`) |
 | **VSCode** | Open a registered file from the explorer; extension host posts `loadFile` / `loadPipeline` to the webview | `postMessage({ type: "loadFile", … })` (`vscode-megane/webview/main.tsx`) |
-| **Python** | `from megane.parsers import …` | `load_pdb`, `load_cif`, `load_lammps_data`, `load_traj`, `load_trajectory` (XTC), `load_xyz_trajectory`, and the `parse_*` PyO3 functions |
+| **Python** | `from megane.parsers import …` | `load_pdb`, `load_cif`, `load_lammps_data`, `load_traj`, `load_trajectory` (XTC), `load_xyz_trajectory`, `load_dcd`, `load_netcdf`, `load_lammpstrj`, and the `parse_*` PyO3 functions |
 
 ## Known gaps
 

--- a/python/megane/parsers/__init__.py
+++ b/python/megane/parsers/__init__.py
@@ -1,7 +1,19 @@
 from megane.parsers.cif import load_cif
+from megane.parsers.dcd import load_dcd
 from megane.parsers.lammps_data import load_lammps_data
+from megane.parsers.lammpstrj import load_lammpstrj
+from megane.parsers.netcdf import load_netcdf
 from megane.parsers.pdb import load_pdb
 from megane.parsers.traj import load_traj
 from megane.parsers.xtc import load_trajectory
 
-__all__ = ["load_cif", "load_lammps_data", "load_pdb", "load_traj", "load_trajectory"]
+__all__ = [
+    "load_cif",
+    "load_dcd",
+    "load_lammps_data",
+    "load_lammpstrj",
+    "load_netcdf",
+    "load_pdb",
+    "load_traj",
+    "load_trajectory",
+]

--- a/python/megane/parsers/dcd.py
+++ b/python/megane/parsers/dcd.py
@@ -1,0 +1,50 @@
+"""DCD trajectory reader backed by shared Rust megane-core via PyO3."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from megane import megane_parser
+from megane.parsers.common import InMemoryTrajectory
+
+__all__ = ["load_dcd"]
+
+logger = logging.getLogger(__name__)
+
+
+def load_dcd(path: str) -> InMemoryTrajectory:
+    """Load a DCD trajectory file (CHARMM/NAMD/X-PLOR format).
+
+    DCD files contain only coordinate frames — topology (elements, bonds)
+    must be supplied separately (e.g. via a PSF or PDB file). Use the
+    ``LoadStructure`` + ``LoadTrajectory`` pipeline pair to combine them.
+
+    Args:
+        path: Path to .dcd file.
+
+    Returns:
+        InMemoryTrajectory with frame-by-frame access.
+    """
+    logger.debug("Loading DCD trajectory: %s", path)
+
+    with open(path, "rb") as f:
+        data = f.read()
+
+    result = megane_parser.parse_dcd(data)
+
+    n_atoms = result.n_atoms
+    n_frames = result.n_frames
+    frames = np.asarray(result.frame_positions, dtype=np.float32).reshape(n_frames, n_atoms, 3)
+    box_matrix = np.asarray(result.box_matrix, dtype=np.float32)
+
+    logger.info("Loaded DCD trajectory: %d frames, %d atoms", n_frames, n_atoms)
+
+    return InMemoryTrajectory(
+        _frames=frames,
+        n_frames=n_frames,
+        n_atoms=n_atoms,
+        timestep_ps=result.timestep_ps,
+        box=box_matrix,
+    )

--- a/python/megane/parsers/netcdf.py
+++ b/python/megane/parsers/netcdf.py
@@ -1,0 +1,50 @@
+"""AMBER NetCDF trajectory reader backed by shared Rust megane-core via PyO3."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from megane import megane_parser
+from megane.parsers.common import InMemoryTrajectory
+
+__all__ = ["load_netcdf"]
+
+logger = logging.getLogger(__name__)
+
+
+def load_netcdf(path: str) -> InMemoryTrajectory:
+    """Load an AMBER NetCDF trajectory file (.nc).
+
+    NetCDF files contain only coordinate frames — topology (elements, bonds)
+    must be supplied separately (e.g. via a PDB or AMBER prmtop file). Use
+    the ``LoadStructure`` + ``LoadTrajectory`` pipeline pair to combine them.
+
+    Args:
+        path: Path to .nc file.
+
+    Returns:
+        InMemoryTrajectory with frame-by-frame access.
+    """
+    logger.debug("Loading AMBER NetCDF trajectory: %s", path)
+
+    with open(path, "rb") as f:
+        data = f.read()
+
+    result = megane_parser.parse_netcdf(data)
+
+    n_atoms = result.n_atoms
+    n_frames = result.n_frames
+    frames = np.asarray(result.frame_positions, dtype=np.float32).reshape(n_frames, n_atoms, 3)
+    box_matrix = np.asarray(result.box_matrix, dtype=np.float32)
+
+    logger.info("Loaded AMBER NetCDF trajectory: %d frames, %d atoms", n_frames, n_atoms)
+
+    return InMemoryTrajectory(
+        _frames=frames,
+        n_frames=n_frames,
+        n_atoms=n_atoms,
+        timestep_ps=result.timestep_ps,
+        box=box_matrix,
+    )

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -112,7 +112,10 @@ class LoadStructure(PipelineNode):
 
 
 class LoadTrajectory(PipelineNode):
-    """Load an external trajectory file (XTC, ASE .traj, or multi-frame XYZ).
+    """Load an external trajectory file.
+
+    Supported formats: XTC, DCD, AMBER NetCDF (.nc), ASE .traj,
+    LAMMPS dump (.lammpstrj / .dump), and multi-frame XYZ.
 
     Requires connection from a ``LoadStructure`` node via
     ``pipe.add_edge(s.out.particle, t.inp.particle)``.
@@ -120,8 +123,11 @@ class LoadTrajectory(PipelineNode):
 
     Args:
         xtc: Path to XTC trajectory file.
+        dcd: Path to DCD trajectory file (CHARMM/NAMD/X-PLOR).
+        nc: Path to AMBER NetCDF trajectory file.
         traj: Path to ASE .traj file.
         xyz: Path to multi-frame XYZ file.
+        lammpstrj: Path to LAMMPS dump trajectory (.lammpstrj / .dump).
 
     Ports:
         inp.particle — atom topology source
@@ -136,13 +142,19 @@ class LoadTrajectory(PipelineNode):
         self,
         *,
         xtc: str | None = None,
+        dcd: str | None = None,
+        nc: str | None = None,
         traj: str | None = None,
         xyz: str | None = None,
+        lammpstrj: str | None = None,
     ) -> None:
         super().__init__()
         self.xtc = xtc
+        self.dcd = dcd
+        self.nc = nc
         self.traj = traj
         self.xyz = xyz
+        self.lammpstrj = lammpstrj
 
 
 class Streaming(PipelineNode):
@@ -624,8 +636,11 @@ class Pipeline:
             ext = pathlib.Path(fname).suffix.lower()
             return LoadTrajectory(
                 xtc=fname if ext == ".xtc" else None,
+                dcd=fname if ext == ".dcd" else None,
+                nc=fname if ext == ".nc" else None,
                 traj=fname if ext == ".traj" else None,
                 xyz=fname if ext == ".xyz" else None,
+                lammpstrj=fname if ext in (".lammpstrj", ".dump") else None,
             )
         elif ntype == "filter":
             return Filter(query=nd.get("query", "all"), bond_query=nd.get("bond_query", ""))
@@ -784,7 +799,7 @@ class Pipeline:
             base["hasTrajectory"] = False
             base["hasCell"] = has_cell
         elif isinstance(node, LoadTrajectory):
-            base["fileName"] = node.xtc or node.traj or node.xyz
+            base["fileName"] = node.xtc or node.dcd or node.nc or node.traj or node.xyz or node.lammpstrj
         elif isinstance(node, Streaming):
             base["connected"] = False
         elif isinstance(node, Filter):
@@ -862,6 +877,21 @@ class Pipeline:
             from megane.parsers.xtc import load_trajectory
 
             trajectory = load_trajectory(source.path, node.xtc)
+            self._trajectories[node._id] = trajectory
+        elif node.dcd is not None:
+            from megane.parsers.dcd import load_dcd
+
+            trajectory = load_dcd(node.dcd)
+            self._trajectories[node._id] = trajectory
+        elif node.nc is not None:
+            from megane.parsers.netcdf import load_netcdf
+
+            trajectory = load_netcdf(node.nc)
+            self._trajectories[node._id] = trajectory
+        elif node.lammpstrj is not None:
+            from megane.parsers.lammpstrj import load_lammpstrj
+
+            trajectory = load_lammpstrj(node.lammpstrj)
             self._trajectories[node._id] = trajectory
         elif node.traj is not None:
             from megane.parsers.traj import load_traj

--- a/tests/python/test_dcd_reader.py
+++ b/tests/python/test_dcd_reader.py
@@ -1,0 +1,61 @@
+"""Tests for the high-level DCD trajectory reader (load_dcd)."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from megane.parsers.dcd import load_dcd
+from megane.parsers import load_dcd as load_dcd_toplevel
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+
+
+def test_load_dcd_returns_in_memory_trajectory():
+    traj = load_dcd(str(FIXTURES / "water.dcd"))
+    assert traj.n_atoms == 3
+    assert traj.n_frames == 5
+
+
+def test_load_dcd_exported_from_parsers():
+    """load_dcd is accessible from megane.parsers."""
+    traj = load_dcd_toplevel(str(FIXTURES / "water.dcd"))
+    assert traj.n_frames == 5
+
+
+def test_load_dcd_frame_shape():
+    traj = load_dcd(str(FIXTURES / "water.dcd"))
+    frame = traj.get_frame(0)
+    assert frame.shape == (3, 3)
+    assert frame.dtype == np.float32
+
+
+def test_load_dcd_timestep_positive():
+    traj = load_dcd(str(FIXTURES / "water.dcd"))
+    assert traj.timestep_ps > 0
+
+
+def test_load_dcd_box_matrix():
+    traj = load_dcd(str(FIXTURES / "water.dcd"))
+    assert traj.box.shape == (3, 3)
+    np.testing.assert_allclose(traj.box[0, 0], 10.0, atol=1e-2)
+    np.testing.assert_allclose(traj.box[1, 1], 10.0, atol=1e-2)
+    np.testing.assert_allclose(traj.box[2, 2], 10.0, atol=1e-2)
+
+
+def test_load_dcd_frames_differ():
+    traj = load_dcd(str(FIXTURES / "water.dcd"))
+    frame0 = traj.get_frame(0)
+    frame1 = traj.get_frame(1)
+    assert not np.allclose(frame0, frame1, atol=1e-3)
+
+
+def test_load_dcd_get_frame_out_of_range():
+    traj = load_dcd(str(FIXTURES / "water.dcd"))
+    with pytest.raises(ValueError):
+        traj.get_frame(100)
+
+
+def test_load_dcd_missing_file():
+    with pytest.raises((FileNotFoundError, OSError)):
+        load_dcd("/nonexistent/path/traj.dcd")

--- a/tests/python/test_netcdf_reader.py
+++ b/tests/python/test_netcdf_reader.py
@@ -1,0 +1,61 @@
+"""Tests for the high-level AMBER NetCDF trajectory reader (load_netcdf)."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from megane.parsers.netcdf import load_netcdf
+from megane.parsers import load_netcdf as load_netcdf_toplevel
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+
+
+def test_load_netcdf_returns_in_memory_trajectory():
+    traj = load_netcdf(str(FIXTURES / "water.nc"))
+    assert traj.n_atoms == 3
+    assert traj.n_frames == 5
+
+
+def test_load_netcdf_exported_from_parsers():
+    """load_netcdf is accessible from megane.parsers."""
+    traj = load_netcdf_toplevel(str(FIXTURES / "water.nc"))
+    assert traj.n_frames == 5
+
+
+def test_load_netcdf_frame_shape():
+    traj = load_netcdf(str(FIXTURES / "water.nc"))
+    frame = traj.get_frame(0)
+    assert frame.shape == (3, 3)
+    assert frame.dtype == np.float32
+
+
+def test_load_netcdf_timestep():
+    traj = load_netcdf(str(FIXTURES / "water.nc"))
+    assert traj.timestep_ps >= 0
+
+
+def test_load_netcdf_box_matrix():
+    traj = load_netcdf(str(FIXTURES / "water.nc"))
+    assert traj.box.shape == (3, 3)
+    np.testing.assert_allclose(traj.box[0, 0], 10.0, atol=1e-2)
+    np.testing.assert_allclose(traj.box[1, 1], 10.0, atol=1e-2)
+    np.testing.assert_allclose(traj.box[2, 2], 10.0, atol=1e-2)
+
+
+def test_load_netcdf_frames_differ():
+    traj = load_netcdf(str(FIXTURES / "water.nc"))
+    frame0 = traj.get_frame(0)
+    frame4 = traj.get_frame(4)
+    assert not np.allclose(frame0, frame4, atol=1e-3)
+
+
+def test_load_netcdf_get_frame_out_of_range():
+    traj = load_netcdf(str(FIXTURES / "water.nc"))
+    with pytest.raises(ValueError):
+        traj.get_frame(100)
+
+
+def test_load_netcdf_missing_file():
+    with pytest.raises((FileNotFoundError, OSError)):
+        load_netcdf("/nonexistent/path/traj.nc")

--- a/tests/python/test_pipeline.py
+++ b/tests/python/test_pipeline.py
@@ -120,6 +120,21 @@ class TestNodeClasses:
         assert n.xtc == "traj.xtc"
         assert n._node_type == "load_trajectory"
 
+    def test_load_trajectory_dcd(self):
+        n = LoadTrajectory(dcd="run.dcd")
+        assert n.dcd == "run.dcd"
+        assert n.xtc is None
+
+    def test_load_trajectory_nc(self):
+        n = LoadTrajectory(nc="traj.nc")
+        assert n.nc == "traj.nc"
+        assert n.dcd is None
+
+    def test_load_trajectory_lammpstrj(self):
+        n = LoadTrajectory(lammpstrj="dump.lammpstrj")
+        assert n.lammpstrj == "dump.lammpstrj"
+        assert n.xtc is None
+
 
 class TestPortObjects:
     """NodePort and PortNamespace work correctly."""
@@ -540,6 +555,33 @@ class TestPipelineDataLoading:
         with pytest.raises(ValueError, match="Unsupported"):
             pipe.add_node(LoadStructure(str(dummy)))
 
+    def test_add_edge_loads_dcd_trajectory(self):
+        """Wiring LoadStructure → LoadTrajectory(dcd=...) populates _trajectories."""
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        t = pipe.add_node(LoadTrajectory(dcd=str(FIXTURES / "water.dcd")))
+        pipe.add_edge(s.out.particle, t.inp.particle)
+        assert t._id in pipe._trajectories
+        assert pipe._trajectories[t._id].n_frames == 5
+
+    def test_add_edge_loads_netcdf_trajectory(self):
+        """Wiring LoadStructure → LoadTrajectory(nc=...) populates _trajectories."""
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        t = pipe.add_node(LoadTrajectory(nc=str(FIXTURES / "water.nc")))
+        pipe.add_edge(s.out.particle, t.inp.particle)
+        assert t._id in pipe._trajectories
+        assert pipe._trajectories[t._id].n_frames == 5
+
+    def test_add_edge_loads_lammpstrj_trajectory(self):
+        """Wiring LoadStructure → LoadTrajectory(lammpstrj=...) populates _trajectories."""
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        t = pipe.add_node(LoadTrajectory(lammpstrj=str(FIXTURES / "water.lammpstrj")))
+        pipe.add_edge(s.out.particle, t.inp.particle)
+        assert t._id in pipe._trajectories
+        assert pipe._trajectories[t._id].n_frames == 3
+
 
 class TestPipelineDAG:
     """Pipeline supports DAG branching correctly."""
@@ -758,6 +800,40 @@ class TestPipelineJsonImport:
         vp_cfg = next(cfg for _, cfg in pipe2._nodes.values() if cfg["type"] == "viewport")
         assert vp_cfg["perspective"] is True
         assert vp_cfg["cellAxesVisible"] is False
+
+    def test_load_trajectory_dcd_round_trip(self):
+        """LoadTrajectory with .dcd survives to_dict → from_dict."""
+        pipe = Pipeline()
+        t = pipe.add_node(LoadTrajectory(dcd="run.dcd"))
+        traj_cfg = next(cfg for _, cfg in pipe._nodes.values() if cfg["type"] == "load_trajectory")
+        assert traj_cfg["fileName"] == "run.dcd"
+        pipe2 = Pipeline.from_dict(pipe.to_dict())
+        node2: LoadTrajectory = next(n for n, _ in pipe2._nodes.values() if isinstance(n, LoadTrajectory))
+        assert node2.dcd == "run.dcd"
+
+    def test_load_trajectory_nc_round_trip(self):
+        """LoadTrajectory with .nc survives to_dict → from_dict."""
+        pipe = Pipeline()
+        pipe.add_node(LoadTrajectory(nc="traj.nc"))
+        pipe2 = Pipeline.from_dict(pipe.to_dict())
+        node2: LoadTrajectory = next(n for n, _ in pipe2._nodes.values() if isinstance(n, LoadTrajectory))
+        assert node2.nc == "traj.nc"
+
+    def test_load_trajectory_lammpstrj_round_trip(self):
+        """LoadTrajectory with .lammpstrj survives to_dict → from_dict."""
+        pipe = Pipeline()
+        pipe.add_node(LoadTrajectory(lammpstrj="dump.lammpstrj"))
+        pipe2 = Pipeline.from_dict(pipe.to_dict())
+        node2: LoadTrajectory = next(n for n, _ in pipe2._nodes.values() if isinstance(n, LoadTrajectory))
+        assert node2.lammpstrj == "dump.lammpstrj"
+
+    def test_load_trajectory_dump_extension_round_trip(self):
+        """LoadTrajectory with .dump extension survives to_dict → from_dict."""
+        pipe = Pipeline()
+        pipe.add_node(LoadTrajectory(lammpstrj="output.dump"))
+        pipe2 = Pipeline.from_dict(pipe.to_dict())
+        node2: LoadTrajectory = next(n for n, _ in pipe2._nodes.values() if isinstance(n, LoadTrajectory))
+        assert node2.lammpstrj == "output.dump"
 
 
 class TestPipelineJsonImportErrors:


### PR DESCRIPTION
## Summary

Closes part of #377 — promotes DCD, AMBER NetCDF, and LAMMPS dump from `API` to `✓` in the Python column of `docs/docs/platform-support.md`.

Previously these trajectory formats were accessible only via the raw `megane_parser.parse_dcd` / `parse_netcdf` / `parse_lammpstrj` PyO3 functions. This PR adds high-level Python wrappers consistent with the existing `load_trajectory` (XTC) and `load_traj` (ASE) API.

### New parser modules

- `python/megane/parsers/dcd.py` — `load_dcd(path) → InMemoryTrajectory` (backed by `megane_parser.parse_dcd`)
- `python/megane/parsers/netcdf.py` — `load_netcdf(path) → InMemoryTrajectory` (backed by `megane_parser.parse_netcdf`)
- `python/megane/parsers/__init__.py` — now exports `load_dcd`, `load_netcdf`, `load_lammpstrj` (the last was already in `lammpstrj.py` but not re-exported)

### Pipeline support

- `LoadTrajectory` gains `dcd`, `nc`, and `lammpstrj` keyword parameters
- `_serialize_node`, `_load_trajectory_data`, and `_build_node_from_dict` handle `.dcd`, `.nc`, `.lammpstrj`, and `.dump` extensions

### Docs

- `docs/docs/platform-support.md`: DCD / LAMMPS dump / AMBER NetCDF Python column: `API` → `✓`
- Load methods table: adds `load_dcd`, `load_netcdf`, `load_lammpstrj` to the Python API list

## Test plan

- [x] `uv run python -m pytest tests/python/test_dcd_reader.py tests/python/test_netcdf_reader.py tests/python/test_pipeline.py` — 147 tests pass
- [x] `dcd.py` and `netcdf.py` each hit 100% line coverage
- [x] `pipeline.py` new branches (dcd/nc/lammpstrj in `_load_trajectory_data`) covered by integration tests that wire `LoadStructure → LoadTrajectory` with real fixture files
- [x] Round-trip tests confirm `.dcd`, `.nc`, `.lammpstrj`, `.dump` extensions survive `to_dict()` → `from_dict()`

https://claude.ai/code/session_01JMXBgyNvfRnzQvV7kpFWKf