### PR TITLE
feat(python): add load_gro, load_mol, load_sdf, load_mol2 structure parsers

### DIFF
--- a/docs/docs/platform-support.md
+++ b/docs/docs/platform-support.md
@@ -88,7 +88,7 @@ How data gets into the viewer on each platform:
 | **Jupyter widget** | Python only — no in-cell file picker | `MolecularViewer.load(pdb_path, xtc=, traj=)` (deprecated) or `MolecularViewer.set_pipeline(Pipeline)` (recommended) |
 | **JupyterLab** | Click a registered file type in the file browser | Internally reads `context.model` (`jupyterlab-megane/src/MeganeDocWidget.tsx`) |
 | **VSCode** | Open a registered file from the explorer; extension host posts `loadFile` / `loadPipeline` to the webview | `postMessage({ type: "loadFile", … })` (`vscode-megane/webview/main.tsx`) |
-| **Python** | `from megane.parsers import …` | `load_pdb`, `load_cif`, `load_lammps_data`, `load_traj`, `load_trajectory` (XTC), `load_xyz_trajectory`, and the `parse_*` PyO3 functions |
+| **Python** | `from megane.parsers import …` | `load_pdb`, `load_gro`, `load_mol`, `load_sdf`, `load_mol2`, `load_cif`, `load_lammps_data`, `load_traj`, `load_trajectory` (XTC), `load_xyz_trajectory`, and the `parse_*` PyO3 functions |
 
 ## Known gaps
 

--- a/python/megane/parsers/__init__.py
+++ b/python/megane/parsers/__init__.py
@@ -1,7 +1,22 @@
 from megane.parsers.cif import load_cif
+from megane.parsers.gro import load_gro
 from megane.parsers.lammps_data import load_lammps_data
+from megane.parsers.mol import load_mol, load_sdf
+from megane.parsers.mol2 import load_mol2
 from megane.parsers.pdb import load_pdb
 from megane.parsers.traj import load_traj
 from megane.parsers.xtc import load_trajectory
+from megane.parsers.xyz import load_xyz_trajectory
 
-__all__ = ["load_cif", "load_lammps_data", "load_pdb", "load_traj", "load_trajectory"]
+__all__ = [
+    "load_cif",
+    "load_gro",
+    "load_lammps_data",
+    "load_mol",
+    "load_mol2",
+    "load_pdb",
+    "load_sdf",
+    "load_traj",
+    "load_trajectory",
+    "load_xyz_trajectory",
+]

--- a/python/megane/parsers/gro.py
+++ b/python/megane/parsers/gro.py
@@ -1,0 +1,40 @@
+"""GROMACS GRO structure reader backed by shared Rust megane-core via PyO3."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from megane import megane_parser
+from megane.parsers.pdb import Structure
+
+__all__ = ["load_gro"]
+
+logger = logging.getLogger(__name__)
+
+
+def load_gro(path: str) -> Structure:
+    """Load a GROMACS GRO file using the shared Rust parser (megane-core).
+
+    Args:
+        path: Path to the .gro file.
+
+    Returns:
+        Parsed Structure with positions in Angstroms.
+    """
+    logger.debug("Loading GRO file: %s", path)
+    with open(path) as f:
+        text = f.read()
+
+    result = megane_parser.parse_gro(text)
+    logger.info("Loaded GRO: %d atoms, %d bonds", result.n_atoms, len(result.bonds))
+
+    return Structure(
+        n_atoms=result.n_atoms,
+        positions=np.asarray(result.positions, dtype=np.float32),
+        elements=np.asarray(result.elements, dtype=np.uint8),
+        bonds=np.asarray(result.bonds, dtype=np.uint32),
+        bond_orders=np.asarray(result.bond_orders, dtype=np.uint8),
+        box=np.asarray(result.box_matrix, dtype=np.float32),
+    )

--- a/python/megane/parsers/mol.py
+++ b/python/megane/parsers/mol.py
@@ -1,0 +1,65 @@
+"""MOL/SDF structure reader backed by shared Rust megane-core via PyO3."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from megane import megane_parser
+from megane.parsers.pdb import Structure
+
+__all__ = ["load_mol", "load_sdf"]
+
+logger = logging.getLogger(__name__)
+
+
+def _load_mol_text(text: str) -> Structure:
+    result = megane_parser.parse_mol(text)
+    return Structure(
+        n_atoms=result.n_atoms,
+        positions=np.asarray(result.positions, dtype=np.float32),
+        elements=np.asarray(result.elements, dtype=np.uint8),
+        bonds=np.asarray(result.bonds, dtype=np.uint32),
+        bond_orders=np.asarray(result.bond_orders, dtype=np.uint8),
+        box=np.asarray(result.box_matrix, dtype=np.float32),
+    )
+
+
+def load_mol(path: str) -> Structure:
+    """Load a MOL file using the shared Rust parser (megane-core).
+
+    Args:
+        path: Path to the .mol file.
+
+    Returns:
+        Parsed Structure with positions in Angstroms.
+    """
+    logger.debug("Loading MOL file: %s", path)
+    with open(path) as f:
+        text = f.read()
+
+    structure = _load_mol_text(text)
+    logger.info("Loaded MOL: %d atoms, %d bonds", structure.n_atoms, len(structure.bonds))
+    return structure
+
+
+def load_sdf(path: str) -> Structure:
+    """Load the first record from an SDF file using the shared Rust parser (megane-core).
+
+    SDF files may contain multiple records separated by ``$$$$``; only the
+    first record is loaded.
+
+    Args:
+        path: Path to the .sdf file.
+
+    Returns:
+        Parsed Structure with positions in Angstroms.
+    """
+    logger.debug("Loading SDF file: %s", path)
+    with open(path) as f:
+        text = f.read()
+
+    structure = _load_mol_text(text)
+    logger.info("Loaded SDF: %d atoms, %d bonds", structure.n_atoms, len(structure.bonds))
+    return structure

--- a/python/megane/parsers/mol2.py
+++ b/python/megane/parsers/mol2.py
@@ -1,0 +1,40 @@
+"""MOL2 structure reader backed by shared Rust megane-core via PyO3."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from megane import megane_parser
+from megane.parsers.pdb import Structure
+
+__all__ = ["load_mol2"]
+
+logger = logging.getLogger(__name__)
+
+
+def load_mol2(path: str) -> Structure:
+    """Load a MOL2 (Tripos SYBYL) file using the shared Rust parser (megane-core).
+
+    Args:
+        path: Path to the .mol2 file.
+
+    Returns:
+        Parsed Structure with positions in Angstroms.
+    """
+    logger.debug("Loading MOL2 file: %s", path)
+    with open(path) as f:
+        text = f.read()
+
+    result = megane_parser.parse_mol2(text)
+    logger.info("Loaded MOL2: %d atoms, %d bonds", result.n_atoms, len(result.bonds))
+
+    return Structure(
+        n_atoms=result.n_atoms,
+        positions=np.asarray(result.positions, dtype=np.float32),
+        elements=np.asarray(result.elements, dtype=np.uint8),
+        bonds=np.asarray(result.bonds, dtype=np.uint32),
+        bond_orders=np.asarray(result.bond_orders, dtype=np.uint8),
+        box=np.asarray(result.box_matrix, dtype=np.float32),
+    )

--- a/tests/python/test_gro_parser.py
+++ b/tests/python/test_gro_parser.py
@@ -1,0 +1,69 @@
+"""Tests for GROMACS GRO structure parser."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from megane.parsers.gro import load_gro
+from megane.parsers import load_gro as load_gro_from_init
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+
+def test_load_water_gro():
+    """Test loading a GROMACS GRO file (water box with 3 molecules)."""
+    s = load_gro(str(FIXTURES / "water.gro"))
+
+    assert s.n_atoms == 9
+    assert s.positions.shape == (9, 3)
+    assert s.positions.dtype == np.float32
+    assert s.elements.shape == (9,)
+    assert s.elements.dtype == np.uint8
+
+
+def test_water_gro_elements():
+    """Water box should have 3 O and 6 H atoms."""
+    s = load_gro(str(FIXTURES / "water.gro"))
+
+    elements = s.elements.tolist()
+    assert elements.count(8) == 3   # 3 oxygen atoms
+    assert elements.count(1) == 6   # 6 hydrogen atoms
+
+
+def test_water_gro_box():
+    """GRO files always carry a box; water.gro has a cubic 1.2 nm box."""
+    s = load_gro(str(FIXTURES / "water.gro"))
+
+    assert s.box.shape == (3, 3)
+    assert s.box.dtype == np.float32
+    # GRO stores lengths in nm; the Rust parser converts to Angstroms (×10)
+    assert np.any(s.box != 0)
+    # Diagonal elements should be ~12 Å (1.2 nm × 10)
+    assert abs(s.box[0, 0] - 12.0) < 0.1
+    assert abs(s.box[1, 1] - 12.0) < 0.1
+    assert abs(s.box[2, 2] - 12.0) < 0.1
+
+
+def test_water_gro_bonds():
+    """Bond arrays are present and consistent."""
+    s = load_gro(str(FIXTURES / "water.gro"))
+
+    assert s.bonds.dtype == np.uint32
+    assert s.bond_orders.dtype == np.uint8
+    assert len(s.bonds) == len(s.bond_orders)
+    # All bond indices must be in range
+    if len(s.bonds) > 0:
+        assert s.bonds.max() < s.n_atoms
+
+
+def test_load_gro_exported_from_parsers():
+    """load_gro must be importable from megane.parsers."""
+    s = load_gro_from_init(str(FIXTURES / "water.gro"))
+    assert s.n_atoms == 9
+
+
+def test_load_gro_missing_file():
+    """load_gro raises an error for a non-existent file."""
+    with pytest.raises((FileNotFoundError, OSError)):
+        load_gro("/nonexistent/path/missing.gro")

--- a/tests/python/test_mol2_parser.py
+++ b/tests/python/test_mol2_parser.py
@@ -1,0 +1,69 @@
+"""Tests for MOL2 (Tripos SYBYL) structure parser."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from megane.parsers.mol2 import load_mol2
+from megane.parsers import load_mol2 as load_mol2_init
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+
+def test_load_methanol_mol2():
+    """Test loading methanol from a MOL2 file."""
+    s = load_mol2(str(FIXTURES / "methanol.mol2"))
+
+    assert s.n_atoms == 6
+    assert s.positions.shape == (6, 3)
+    assert s.positions.dtype == np.float32
+    assert s.elements.dtype == np.uint8
+
+
+def test_methanol_mol2_elements():
+    """Methanol (CH3OH): 1 C, 1 O, 4 H."""
+    s = load_mol2(str(FIXTURES / "methanol.mol2"))
+
+    elements = s.elements.tolist()
+    assert elements.count(6) == 1   # carbon
+    assert elements.count(8) == 1   # oxygen
+    assert elements.count(1) == 4   # hydrogen
+
+
+def test_methanol_mol2_bonds():
+    """Methanol has 5 bonds."""
+    s = load_mol2(str(FIXTURES / "methanol.mol2"))
+
+    assert len(s.bonds) == 5
+    assert s.bonds.dtype == np.uint32
+    assert s.bond_orders.dtype == np.uint8
+    assert len(s.bond_orders) == len(s.bonds)
+
+
+def test_methanol_mol2_bond_indices_valid():
+    """All bond indices must be within atom range."""
+    s = load_mol2(str(FIXTURES / "methanol.mol2"))
+
+    assert s.bonds.max() < s.n_atoms
+
+
+def test_mol2_no_box():
+    """Small-molecule MOL2 files have no periodic box."""
+    s = load_mol2(str(FIXTURES / "methanol.mol2"))
+
+    assert s.box.shape == (3, 3)
+    assert s.box.dtype == np.float32
+    assert np.all(s.box == 0)
+
+
+def test_load_mol2_exported_from_parsers():
+    """load_mol2 must be importable from megane.parsers."""
+    s = load_mol2_init(str(FIXTURES / "methanol.mol2"))
+    assert s.n_atoms == 6
+
+
+def test_load_mol2_missing_file():
+    """load_mol2 raises an error for a non-existent file."""
+    with pytest.raises((FileNotFoundError, OSError)):
+        load_mol2("/nonexistent/missing.mol2")

--- a/tests/python/test_mol_parser.py
+++ b/tests/python/test_mol_parser.py
@@ -1,0 +1,124 @@
+"""Tests for MOL and SDF structure parsers."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from megane.parsers.mol import load_mol, load_sdf
+from megane.parsers import load_mol as load_mol_init, load_sdf as load_sdf_init
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# MOL tests (methane.mol)
+# ---------------------------------------------------------------------------
+
+
+def test_load_methane_mol():
+    """Test loading methane from a V2000 MOL file."""
+    s = load_mol(str(FIXTURES / "methane.mol"))
+
+    assert s.n_atoms == 5
+    assert s.positions.shape == (5, 3)
+    assert s.positions.dtype == np.float32
+    assert s.elements.dtype == np.uint8
+
+
+def test_methane_mol_elements():
+    """Methane: 1 C (6) and 4 H (1)."""
+    s = load_mol(str(FIXTURES / "methane.mol"))
+
+    elements = s.elements.tolist()
+    assert elements.count(6) == 1   # carbon
+    assert elements.count(1) == 4   # hydrogen
+
+
+def test_methane_mol_bonds():
+    """Methane has 4 C-H single bonds."""
+    s = load_mol(str(FIXTURES / "methane.mol"))
+
+    assert len(s.bonds) == 4
+    assert s.bonds.dtype == np.uint32
+    assert s.bond_orders.dtype == np.uint8
+    assert np.all(s.bond_orders == 1)  # all single bonds
+
+
+def test_methane_mol_bond_indices_valid():
+    """Bond indices must be within atom range."""
+    s = load_mol(str(FIXTURES / "methane.mol"))
+
+    assert s.bonds.max() < s.n_atoms
+
+
+def test_mol_no_box():
+    """MOL files have no periodic box; box matrix should be all-zero."""
+    s = load_mol(str(FIXTURES / "methane.mol"))
+
+    assert s.box.shape == (3, 3)
+    assert s.box.dtype == np.float32
+    assert np.all(s.box == 0)
+
+
+# ---------------------------------------------------------------------------
+# SDF tests (ethanol.sdf)
+# ---------------------------------------------------------------------------
+
+
+def test_load_ethanol_sdf():
+    """Test loading ethanol from an SDF file."""
+    s = load_sdf(str(FIXTURES / "ethanol.sdf"))
+
+    assert s.n_atoms == 9
+    assert s.positions.shape == (9, 3)
+    assert s.positions.dtype == np.float32
+
+
+def test_ethanol_sdf_elements():
+    """Ethanol (C2H5OH): 2 C, 1 O, 6 H."""
+    s = load_sdf(str(FIXTURES / "ethanol.sdf"))
+
+    elements = s.elements.tolist()
+    assert elements.count(6) == 2   # carbon
+    assert elements.count(8) == 1   # oxygen
+    assert elements.count(1) == 6   # hydrogen
+
+
+def test_ethanol_sdf_bonds():
+    """Ethanol has 8 bonds."""
+    s = load_sdf(str(FIXTURES / "ethanol.sdf"))
+
+    assert len(s.bonds) == 8
+    assert s.bonds.dtype == np.uint32
+    assert s.bond_orders.dtype == np.uint8
+    assert len(s.bond_orders) == len(s.bonds)
+
+
+# ---------------------------------------------------------------------------
+# Import-from-package tests
+# ---------------------------------------------------------------------------
+
+
+def test_load_mol_exported_from_parsers():
+    """load_mol must be importable from megane.parsers."""
+    s = load_mol_init(str(FIXTURES / "methane.mol"))
+    assert s.n_atoms == 5
+
+
+def test_load_sdf_exported_from_parsers():
+    """load_sdf must be importable from megane.parsers."""
+    s = load_sdf_init(str(FIXTURES / "ethanol.sdf"))
+    assert s.n_atoms == 9
+
+
+def test_load_mol_missing_file():
+    """load_mol raises an error for a non-existent file."""
+    with pytest.raises((FileNotFoundError, OSError)):
+        load_mol("/nonexistent/missing.mol")
+
+
+def test_load_sdf_missing_file():
+    """load_sdf raises an error for a non-existent file."""
+    with pytest.raises((FileNotFoundError, OSError)):
+        load_sdf("/nonexistent/missing.sdf")


### PR DESCRIPTION
## Summary

Closes part of #377 — adds high-level Python wrappers for the four structure formats that previously only had raw PyO3 bindings (`parse_gro`, `parse_mol`, `parse_mol2`). Brings GRO, MOL, SDF, and MOL2 to parity with the existing `load_pdb` / `load_cif` / `load_lammps_data` API.

### New modules

- `python/megane/parsers/gro.py` — `load_gro(path) → Structure`
- `python/megane/parsers/mol.py` — `load_mol(path) → Structure`, `load_sdf(path) → Structure` (first record)
- `python/megane/parsers/mol2.py` — `load_mol2(path) → Structure`

### Exports

- All four functions are now exported from `megane.parsers.__init__`
- Also adds the previously-documented-but-missing `load_xyz_trajectory` export

### Docs

- `docs/docs/platform-support.md`: load-methods table updated to list the new functions

## Test plan

- [x] 25 new unit tests across 3 new test files (`test_gro_parser.py`, `test_mol_parser.py`, `test_mol2_parser.py`)
- [x] 100% line coverage on `gro.py`, `mol.py`, `mol2.py`, and the updated `__init__.py`
- [x] Full Python test suite (272 tests) passes with no regressions
- [x] Verified against fixtures: `water.gro` (9 atoms, cubic box), `methane.mol` (5 atoms, 4 bonds), `ethanol.sdf` (9 atoms, 8 bonds), `methanol.mol2` (6 atoms, 5 bonds)

https://claude.ai/code/session_01QDrxzBnLTPwDDSCQVcTpuw