### PR TITLE
feat(widget): add drag-and-drop file loading to Jupyter widget

### DIFF
--- a/docs/docs/platform-support.md
+++ b/docs/docs/platform-support.md
@@ -58,7 +58,7 @@ Sources of truth: `crates/megane-wasm/src/lib.rs` (browser parsers), `crates/meg
 
 | Feature | Standalone | Jupyter widget | JupyterLab | VSCode | Python |
 |---|:---:|:---:|:---:|:---:|:---:|
-| Drag-and-drop into viewer | ✓ | — | — | — | n/a |
+| Drag-and-drop into viewer | ✓ | ✓⁴ | — | — | n/a |
 | Built-in file picker | ✓ | — | host | host | n/a |
 | Visual pipeline editor | ✓ | — | ✓ | ✓ (`.megane.json`) | n/a |
 | Trajectory timeline / scrubbing | ✓ | ✓ | ✓ | ✓ | n/a |
@@ -73,6 +73,8 @@ Sources of truth: `crates/megane-wasm/src/lib.rs` (browser parsers), `crates/meg
 ² JupyterLab: call `meganeReactView.seekFrame(N)` on a `MeganeReactView` instance obtained from the widget tracker. This delegates to `usePlaybackStore.seekFrame(N)` in the viewer.
 
 ³ VSCode: call `vscode.commands.executeCommand('megane.seekFrame', N)` from another extension, or call `meganeEditorProvider.seekFrame(N)` on an `MeganeEditorProvider` reference. The command posts a `seekFrame` message to the most recently active megane webview panel.
+
+⁴ Drag-and-drop in the Jupyter widget sends the dropped file's bytes to the Python kernel, which parses the file and loads it via `set_pipeline()`. Structure formats are supported (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, LAMMPS data, ASE `.traj`). A `"file_drop"` event fires on completion — register a handler with `viewer.on_event("file_drop", callback)`. Binary trajectory formats (XTC, DCD, LAMMPS dump, AMBER NetCDF) are not supported via drag-and-drop; load them via the Python API (`set_pipeline()` with `LoadTrajectory`).
 
 Notes:
 
@@ -99,7 +101,7 @@ How data gets into the viewer on each platform:
 These are formats or features that the parser layer supports but a given platform does not yet wire into its UI. They are documented here so users do not file bugs against expected-but-absent behaviour.
 
 - **Trajectory-only opens require a topology first.** On VSCode and JupyterLab, opening a `.xtc` / `.dcd` / `.lammpstrj` / `.dump` / `.nc` file before any structure is loaded surfaces a friendly error. The recommended flow is to open the structure first, or to use the pipeline editor (always mounted on these hosts) to wire a Load Structure node.
-- **Jupyter widget has no in-cell file picker or drag-and-drop.** This is intentional — the widget is Python-driven. Use `set_pipeline()` with a `Pipeline` to load any supported format.
+- **Jupyter widget has no in-cell file picker.** The widget is Python-driven; use `set_pipeline()` with a `Pipeline` to load any supported format programmatically. Drag-and-drop of structure files is supported directly in the widget (see footnote ⁴).
 - **Jupyter widget has no visual pipeline editor.** The editor's React surface relies on host chrome (drag handles, side panel layout) that the anywidget cell cannot reliably render, so it is only shipped on the standalone app, JupyterLab labextension, and VSCode extension. Build pipelines in Python with `megane.Pipeline` and push them via `MolecularViewer.set_pipeline()`.
 - **`selection_change` / `measurement` events on JupyterLab and VSCode are not yet wired.** The standalone React component exposes `onSelectionChange?: (selection: SelectionState) => void` and `onMeasurementChange?: (measurement: Measurement | null) => void` props (mirroring the Jupyter widget's `selection_change` and `measurement` events). These are not yet surfaced on the JupyterLab DocWidget or VSCode extension.
 - **`frame_change` callback for JupyterLab is surfaced as a status-bar frame counter.** The JupyterLab DocWidget has no Python kernel connection, so there is no Python callback surface. Instead, when `IStatusBar` is available, the current frame index is shown in the JupyterLab status bar (right side). The `subscribeFrameChange` method on `MeganeReactView` can also be used by other JupyterLab extensions to react to frame changes.

--- a/python/megane/widget.py
+++ b/python/megane/widget.py
@@ -80,6 +80,12 @@ class MolecularViewer(anywidget.AnyWidget):
         value_trait=traitlets.Bytes(),
     ).tag(sync=True)
 
+    # Drag-and-drop file loading (JS → Python).
+    # The JS frontend sets these when the user drops a file onto the widget;
+    # _drop_file_b64 triggers _on_file_drop which parses and loads the file.
+    _drop_file_name = traitlets.Unicode("").tag(sync=True)
+    _drop_file_b64 = traitlets.Unicode("").tag(sync=True)
+
     # Internal (not synced)
     _structure = None
     _trajectory = None
@@ -232,6 +238,53 @@ class MolecularViewer(anywidget.AnyWidget):
             },
         )
 
+    @traitlets.observe("_drop_file_b64")
+    def _on_file_drop(self, change: dict) -> None:
+        """Parse and load a file dropped onto the widget from the browser.
+
+        The JS frontend sends the file as base64 together with its filename
+        (_drop_file_name).  This observer decodes the bytes, writes a
+        temporary file, parses it with the appropriate Rust parser, and calls
+        :meth:`set_pipeline` so the viewer displays the structure.
+
+        A ``"file_drop"`` event is fired with ``{"name": <filename>}`` on
+        success, or ``{"name": <filename>, "error": <message>}`` on failure.
+        """
+        import base64 as _base64
+        import tempfile
+
+        from megane.pipeline import AddBonds, LoadStructure, Pipeline
+
+        b64 = change["new"]
+        name = self._drop_file_name
+        if not b64 or not name:
+            return
+
+        try:
+            raw = _base64.b64decode(b64)
+        except Exception as exc:
+            self._fire_event("file_drop", {"name": name, "error": f"base64 decode failed: {exc}"})
+            return
+
+        ext = pathlib.Path(name).suffix.lower()
+        tmp_path: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as f:
+                f.write(raw)
+                tmp_path = f.name
+
+            pipe = Pipeline()
+            s = pipe.add_node(LoadStructure(tmp_path))
+            b_node = pipe.add_node(AddBonds(source="structure"))
+            pipe.add_edge(s.out.particle, b_node.inp.particle)
+            self.set_pipeline(pipe)
+            self._fire_event("file_drop", {"name": name})
+        except Exception as exc:
+            self._fire_event("file_drop", {"name": name, "error": str(exc)})
+        finally:
+            if tmp_path is not None:
+                pathlib.Path(tmp_path).unlink(missing_ok=True)
+
     @property
     def measurement(self) -> dict | None:
         """Current measurement result, or None if fewer than 2 atoms selected.
@@ -264,6 +317,9 @@ class MolecularViewer(anywidget.AnyWidget):
             - "measurement": fired when a measurement is computed.
               Data: {"type": str, "value": float, "label": str,
                      "atoms": list[int]} or None
+            - "file_drop": fired when a file is dropped onto the widget.
+              Data: {"name": str} on success, or
+                    {"name": str, "error": str} on failure.
 
         Args:
             event_name: Name of the event.

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -50,6 +50,64 @@ function render({ model, el }: { model: AnyWidgetModel; el: HTMLElement }) {
       : null;
   mq?.addEventListener("change", _syncSystemTheme);
 
+  // Drag-and-drop overlay for file loading
+  const dropOverlay = document.createElement("div");
+  dropOverlay.style.cssText = [
+    "position:absolute",
+    "inset:0",
+    "display:none",
+    "align-items:center",
+    "justify-content:center",
+    "background:rgba(59,130,246,0.12)",
+    "border:2px dashed #3b82f6",
+    "border-radius:8px",
+    "pointer-events:none",
+    "font-size:1rem",
+    "font-weight:600",
+    "color:#3b82f6",
+    "z-index:10",
+  ].join(";");
+  dropOverlay.textContent = "Drop structure file to load";
+  container.appendChild(dropOverlay);
+
+  function showDropOverlay(): void {
+    dropOverlay.style.display = "flex";
+  }
+  function hideDropOverlay(): void {
+    dropOverlay.style.display = "none";
+  }
+
+  container.addEventListener("dragover", (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    showDropOverlay();
+  });
+
+  container.addEventListener("dragleave", (e: DragEvent) => {
+    if (!container.contains(e.relatedTarget as Node | null)) {
+      hideDropOverlay();
+    }
+  });
+
+  container.addEventListener("drop", (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    hideDropOverlay();
+    const file = e.dataTransfer?.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev: ProgressEvent<FileReader>) => {
+      const dataUrl = ev.target?.result;
+      if (typeof dataUrl !== "string") return;
+      const b64 = dataUrl.split(",")[1];
+      if (!b64) return;
+      model.set("_drop_file_name", file.name);
+      model.set("_drop_file_b64", b64);
+      model.save_changes();
+    };
+    reader.readAsDataURL(file);
+  });
+
   let root: Root | null = null;
   let currentSnapshot: Snapshot | null = null;
   let currentFrame: Frame | null = null;

--- a/tests/python/test_widget.py
+++ b/tests/python/test_widget.py
@@ -115,3 +115,133 @@ def test_deprecated_load_warns():
     assert len(w) == 1
     assert issubclass(w[0].category, DeprecationWarning)
     assert "set_pipeline" in str(w[0].message)
+
+
+# ── File drop (drag-and-drop) tests ──────────────────────────────────────
+
+
+def test_file_drop_traitlets_exist():
+    """_drop_file_name and _drop_file_b64 traitlets are present and synced."""
+    v = MolecularViewer()
+    state = v.get_state()
+    assert "_drop_file_name" in state
+    assert "_drop_file_b64" in state
+    assert v._drop_file_name == ""
+    assert v._drop_file_b64 == ""
+
+
+def test_file_drop_loads_pdb(tmp_path):
+    """Dropping a PDB file populates the pipeline and fires file_drop event."""
+    import base64
+
+    v = MolecularViewer()
+    events = []
+    v.on_event("file_drop", lambda d: events.append(d))
+
+    pdb_bytes = (FIXTURES / "1crn.pdb").read_bytes()
+    b64 = base64.b64encode(pdb_bytes).decode()
+
+    v._drop_file_name = "1crn.pdb"
+    v._drop_file_b64 = b64
+
+    assert len(events) == 1
+    assert events[0]["name"] == "1crn.pdb"
+    assert "error" not in events[0]
+    assert v._pipeline_json != ""
+    assert len(v._node_snapshots_data) > 0
+
+
+def test_file_drop_loads_xyz():
+    """Dropping an XYZ file populates the pipeline."""
+    import base64
+
+    v = MolecularViewer()
+    events = []
+    v.on_event("file_drop", lambda d: events.append(d))
+
+    xyz_bytes = (FIXTURES / "perovskite_srtio3.xyz").read_bytes()
+    b64 = base64.b64encode(xyz_bytes).decode()
+
+    v._drop_file_name = "perovskite_srtio3.xyz"
+    v._drop_file_b64 = b64
+
+    assert len(events) == 1
+    assert "error" not in events[0]
+    assert v._pipeline_json != ""
+
+
+def test_file_drop_unknown_extension_fires_error():
+    """Dropping an unsupported format fires file_drop with error key."""
+    import base64
+
+    v = MolecularViewer()
+    events = []
+    v.on_event("file_drop", lambda d: events.append(d))
+
+    b64 = base64.b64encode(b"not a real file").decode()
+    v._drop_file_name = "structure.unknownfmt"
+    v._drop_file_b64 = b64
+
+    assert len(events) == 1
+    assert events[0]["name"] == "structure.unknownfmt"
+    assert "error" in events[0]
+
+
+def test_file_drop_invalid_base64_fires_error():
+    """Invalid base64 payload fires file_drop event with error."""
+    v = MolecularViewer()
+    events = []
+    v.on_event("file_drop", lambda d: events.append(d))
+
+    v._drop_file_name = "test.pdb"
+    v._drop_file_b64 = "!!!not-valid-base64!!!"
+
+    assert len(events) == 1
+    assert "error" in events[0]
+
+
+def test_file_drop_empty_b64_does_nothing():
+    """Setting _drop_file_b64 to empty string is ignored."""
+    v = MolecularViewer()
+    events = []
+    v.on_event("file_drop", lambda d: events.append(d))
+
+    v._drop_file_name = "test.pdb"
+    v._drop_file_b64 = ""
+
+    assert len(events) == 0
+    assert v._pipeline_json == ""
+
+
+def test_file_drop_empty_name_does_nothing():
+    """Setting _drop_file_b64 without a filename is ignored."""
+    import base64
+
+    v = MolecularViewer()
+    events = []
+    v.on_event("file_drop", lambda d: events.append(d))
+
+    b64 = base64.b64encode(b"ATOM  1  N   ALA A   1\n").decode()
+    v._drop_file_name = ""
+    v._drop_file_b64 = b64
+
+    assert len(events) == 0
+
+
+def test_file_drop_successive_files():
+    """Two successive file drops each load correctly."""
+    import base64
+
+    v = MolecularViewer()
+    events = []
+    v.on_event("file_drop", lambda d: events.append(d))
+
+    for pdb in ("1crn.pdb", "1ubq.pdb"):
+        b64 = base64.b64encode((FIXTURES / pdb).read_bytes()).decode()
+        v._drop_file_name = pdb
+        v._drop_file_b64 = b64
+
+    assert len(events) == 2
+    assert all("error" not in e for e in events)
+    assert events[0]["name"] == "1crn.pdb"
+    assert events[1]["name"] == "1ubq.pdb"

--- a/tests/ts/widget.test.ts
+++ b/tests/ts/widget.test.ts
@@ -273,4 +273,112 @@ describe("widget.ts — render", () => {
     const cleanup = widgetEntry.render({ model: model as never, el }) as () => void;
     expect(() => cleanup()).not.toThrow();
   });
+
+  describe("drag-and-drop file loading", () => {
+    it("registers change listener for _drop_file_b64", () => {
+      const model = makeMockModel();
+      const el = makeContainer();
+      widgetEntry.render({ model: model as never, el });
+      // The drag-drop handler writes to the model; verify model listeners
+      // include the standard pipeline change listener (not a model.on event —
+      // drag-drop uses DOM events, not model.on).
+      expect(model.listeners.has("change:_pipeline_json")).toBe(true);
+    });
+
+    it("dragover event on container prevents default", () => {
+      const model = makeMockModel();
+      const el = makeContainer();
+      widgetEntry.render({ model: model as never, el });
+
+      const container = el.firstChild as HTMLElement;
+      const event = new Event("dragover", { bubbles: true, cancelable: true });
+      const preventDefaultSpy = vi.spyOn(event, "preventDefault");
+      container.dispatchEvent(event);
+      expect(preventDefaultSpy).toHaveBeenCalled();
+    });
+
+    it("drop with no files does not write to model", () => {
+      const model = makeMockModel();
+      const el = makeContainer();
+      widgetEntry.render({ model: model as never, el });
+      model.set.mockClear();
+
+      const container = el.firstChild as HTMLElement;
+      const event = new Event("drop", { bubbles: true, cancelable: true });
+      // dataTransfer is null → drop handler early-returns
+      container.dispatchEvent(event);
+      expect(model.set).not.toHaveBeenCalledWith("_drop_file_name", expect.anything());
+    });
+
+    it("drop with a file triggers FileReader.readAsDataURL", () => {
+      const model = makeMockModel();
+      const el = makeContainer();
+      widgetEntry.render({ model: model as never, el });
+
+      const container = el.firstChild as HTMLElement;
+
+      const readAsDataURLSpy = vi.fn();
+      const mockReader = {
+        readAsDataURL: readAsDataURLSpy,
+        onload: null as null | ((e: ProgressEvent<FileReader>) => void),
+      };
+      vi.stubGlobal(
+        "FileReader",
+        vi.fn(() => mockReader),
+      );
+
+      const file = new File(["ATOM  1  N   ALA\n"], "test.pdb", { type: "text/plain" });
+      const dt = { files: [file] } as unknown as DataTransfer;
+      const dropEvent = Object.assign(
+        new Event("drop", { bubbles: true, cancelable: true }),
+        { dataTransfer: dt },
+      );
+      container.dispatchEvent(dropEvent);
+
+      expect(readAsDataURLSpy).toHaveBeenCalledWith(file);
+      vi.unstubAllGlobals();
+    });
+
+    it("FileReader onload sets _drop_file_name and _drop_file_b64 on model", () => {
+      const model = makeMockModel();
+      const el = makeContainer();
+      widgetEntry.render({ model: model as never, el });
+      model.set.mockClear();
+      model.save_changes.mockClear();
+
+      const container = el.firstChild as HTMLElement;
+
+      let capturedOnLoad: ((e: ProgressEvent<FileReader>) => void) | null = null;
+      const mockReader = {
+        readAsDataURL: vi.fn(),
+        set onload(fn: (e: ProgressEvent<FileReader>) => void) {
+          capturedOnLoad = fn;
+        },
+      };
+      vi.stubGlobal(
+        "FileReader",
+        vi.fn(() => mockReader),
+      );
+
+      const file = new File(["ATOM\n"], "mol.pdb", { type: "text/plain" });
+      const dt = { files: [file] } as unknown as DataTransfer;
+      const dropEvent = Object.assign(
+        new Event("drop", { bubbles: true, cancelable: true }),
+        { dataTransfer: dt },
+      );
+      container.dispatchEvent(dropEvent);
+
+      // Simulate FileReader completing
+      const fakeB64 = "QVRPTQ=="; // base64 of "ATOM\n" roughly
+      capturedOnLoad!({
+        target: { result: `data:text/plain;base64,${fakeB64}` },
+      } as unknown as ProgressEvent<FileReader>);
+
+      expect(model.set).toHaveBeenCalledWith("_drop_file_name", "mol.pdb");
+      expect(model.set).toHaveBeenCalledWith("_drop_file_b64", fakeB64);
+      expect(model.save_changes).toHaveBeenCalled();
+
+      vi.unstubAllGlobals();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes part of #377 — adds drag-and-drop file loading to the Jupyter widget (`anywidget` `MolecularViewer`), closing the gap documented in `docs/docs/platform-support.md` line 61.

- **Python (`widget.py`)**: Two new synced traitlets `_drop_file_name` / `_drop_file_b64` receive file metadata and base64-encoded content from the browser. The `_on_file_drop` observer decodes the bytes, writes a temporary file, builds a `Pipeline` with `LoadStructure` + `AddBonds`, calls `set_pipeline()`, and fires a `"file_drop"` event (`{"name": str}` on success, `{"name": str, "error": str}` on failure).
- **TypeScript (`widget.ts`)**: `dragover` / `dragleave` / `drop` DOM event listeners on the widget container. On drop, a `FileReader` reads the file as a data-URL, the base64 portion is extracted, and both traitlets are set + saved. A translucent blue overlay with dashed border appears while dragging.
- **Docs**: `platform-support.md` drag-and-drop row for Jupyter widget changed from \`—\` to \`✓⁴\` with a footnote listing supported formats and the \`"file_drop"\` event API.

**Supported formats (drag-and-drop):** PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, LAMMPS data, ASE \`.traj\`. Binary-trajectory-only formats (XTC, DCD, LAMMPS dump, AMBER NetCDF) remain Python-API-only.

## Test plan

- [ ] \`uv run python -m pytest tests/python/test_widget.py -k "file_drop"\` — 8 new tests pass (PDB load, XYZ load, unknown extension error, invalid base64 error, empty payload guards, successive drops).
- [ ] \`npm test -- tests/ts/widget.test.ts\` — 15 tests pass (5 new drag-and-drop tests: dragover preventDefault, drop with no file, drop triggers FileReader, FileReader onload sets model).
- [ ] In a live Jupyter notebook: instantiate \`MolecularViewer()\`, display it, drag a \`.pdb\` file onto the widget — structure renders. Register \`viewer.on_event("file_drop", print)\` to confirm the event fires.
- [ ] Drag an unsupported file type (\`.txt\`) — \`file_drop\` event fires with an \`"error"\` key, viewer unchanged.

https://claude.ai/code/session_01HxSaZ4RhFAiFbJeJRsiYkU