### PR TITLE
fix(share): replace silent toast with visible Share dialog

### DIFF
--- a/src/components/PipelineEditor.tsx
+++ b/src/components/PipelineEditor.tsx
@@ -47,6 +47,7 @@ import { VectorOverlayNode } from "./nodes/VectorOverlayNode";
 import { StreamingNode } from "./nodes/StreamingNode";
 import { PipelineChatBox } from "./PipelineChatBox";
 import { RenderModal } from "./RenderModal";
+import { ShareDialog } from "./ShareDialog";
 import { startTour, startPipelineTutorial } from "../tour/MeganeTour";
 import type { MoleculeRenderer } from "../renderer/MoleculeRenderer";
 
@@ -387,36 +388,6 @@ const shareBtnStyle: React.CSSProperties = {
   color: "#059669",
 };
 
-const shareFeedbackBase: React.CSSProperties = {
-  display: "inline-block",
-  fontSize: 12,
-  fontWeight: 600,
-  padding: "4px 10px",
-  borderRadius: 4,
-  lineHeight: 1.2,
-};
-
-const SHARE_FEEDBACK_STYLES: Record<"success" | "warning" | "error", React.CSSProperties> = {
-  success: {
-    ...shareFeedbackBase,
-    background: "rgba(16, 185, 129, 0.12)",
-    border: "1px solid rgba(16, 185, 129, 0.35)",
-    color: "#047857",
-  },
-  warning: {
-    ...shareFeedbackBase,
-    background: "rgba(220, 38, 38, 0.12)",
-    border: "1px solid rgba(220, 38, 38, 0.35)",
-    color: "#b91c1c",
-  },
-  error: {
-    ...shareFeedbackBase,
-    background: "rgba(220, 38, 38, 0.12)",
-    border: "1px solid rgba(220, 38, 38, 0.35)",
-    color: "#b91c1c",
-  },
-};
-
 const guideBtnStyle: React.CSSProperties = {
   ...textBtnBase,
   background: "rgba(100, 116, 139, 0.08)",
@@ -557,9 +528,9 @@ function PipelineEditorInner({
   const [showAddMenu, setShowAddMenu] = useState(false);
   const [showTemplateMenu, setShowTemplateMenu] = useState(false);
   const [showRenderModal, setShowRenderModal] = useState(false);
-  const [shareFeedback, setShareFeedback] = useState<{
-    message: string;
-    tone: "success" | "warning" | "error";
+  const [shareDialog, setShareDialog] = useState<{
+    url: string;
+    tooLong: boolean;
   } | null>(null);
   const [panelWidth, setPanelWidth] = useState(DEFAULT_WIDTH);
   const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
@@ -719,18 +690,11 @@ function PipelineEditorInner({
   const handleShare = useCallback(async () => {
     try {
       const serialized = usePipelineStore.getState().serialize();
-      const outcome = await shareCurrentPipeline(serialized);
-      const tone: "success" | "warning" | "error" = outcome.tooLong
-        ? "warning"
-        : outcome.copyFailed
-          ? "error"
-          : "success";
-      setShareFeedback({ message: outcome.message, tone });
-      setTimeout(() => setShareFeedback(null), outcome.clearAfterMs);
+      const { url, tooLong } = await shareCurrentPipeline(serialized);
+      setShareDialog({ url, tooLong });
     } catch (err) {
       console.error("Share failed:", err);
-      setShareFeedback({ message: "Share failed — see console", tone: "error" });
-      setTimeout(() => setShareFeedback(null), 5000);
+      window.alert("Share failed: " + (err as Error).message);
     }
   }, []);
 
@@ -860,20 +824,6 @@ function PipelineEditorInner({
           {IconRender} Render
         </button>
       </div>
-      {shareFeedback && (
-        <div style={{ padding: "2px 0 0 68px" }}>
-          <span
-            data-testid="pipeline-editor-share-feedback"
-            data-tone={shareFeedback.tone}
-            style={SHARE_FEEDBACK_STYLES[shareFeedback.tone]}
-            role="status"
-            aria-live="polite"
-          >
-            {shareFeedback.message}
-          </span>
-        </div>
-      )}
-
       {/* Row 3 — Others: help & appearance */}
       <div style={toolbarRowStyle}>
         <span style={toolbarCategoryLabelStyle}>Others</span>
@@ -998,6 +948,12 @@ function PipelineEditorInner({
         totalFrames={totalFrames}
         currentFrame={currentFrame}
         onSeek={onSeek}
+      />
+      <ShareDialog
+        open={shareDialog !== null}
+        url={shareDialog?.url ?? ""}
+        tooLong={shareDialog?.tooLong ?? false}
+        onClose={() => setShareDialog(null)}
       />
     </CollapsiblePanel>
   );

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -1,0 +1,268 @@
+/**
+ * Share dialog – shows the encoded pipeline URL and offers copy / open-in-tab.
+ *
+ * Mounted via portal so it escapes the React Flow z-index / overflow stack.
+ * Copy uses the modern Clipboard API with an `execCommand('copy')` fallback;
+ * even if every clipboard path fails the URL is selectable from the dialog
+ * input and from the address bar.
+ */
+
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { copyShareUrl as defaultCopy } from "../pipeline/shareLink";
+
+type CopyState = "idle" | "copying" | "copied" | "failed";
+
+interface ShareDialogProps {
+  open: boolean;
+  url: string;
+  tooLong: boolean;
+  onClose: () => void;
+  /** DI hook for tests; defaults to the real `copyShareUrl`. */
+  copy?: (url: string) => Promise<"copied" | "failed">;
+}
+
+const backdropStyle: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  background: "rgba(0,0,0,0.3)",
+  backdropFilter: "blur(4px)",
+  zIndex: 1000,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+};
+
+const panelStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.97)",
+  backdropFilter: "blur(16px)",
+  borderRadius: 16,
+  boxShadow: "0 8px 32px rgba(0,0,0,0.12)",
+  border: "1px solid rgba(226,232,240,0.6)",
+  maxWidth: 520,
+  width: "90vw",
+  padding: "20px 24px",
+};
+
+const headerRowStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  marginBottom: 16,
+};
+
+const titleStyle: React.CSSProperties = {
+  fontSize: 16,
+  fontWeight: 700,
+  color: "#1e293b",
+};
+
+const closeBtnStyle: React.CSSProperties = {
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  fontSize: 18,
+  color: "#94a3b8",
+  padding: 4,
+};
+
+const inputStyle: React.CSSProperties = {
+  border: "1px solid #e2e8f0",
+  borderRadius: 8,
+  padding: "8px 10px",
+  fontSize: 13,
+  width: "100%",
+  boxSizing: "border-box",
+  outline: "none",
+  fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+};
+
+const buttonRowStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 12,
+  marginTop: 14,
+};
+
+const copyBtnBaseStyle: React.CSSProperties = {
+  border: "1px solid rgba(16, 185, 129, 0.35)",
+  background: "rgba(16, 185, 129, 0.1)",
+  color: "#047857",
+  padding: "7px 14px",
+  borderRadius: 8,
+  fontSize: 13,
+  fontWeight: 600,
+  cursor: "pointer",
+};
+
+const copyBtnDisabledStyle: React.CSSProperties = {
+  ...copyBtnBaseStyle,
+  background: "rgba(148, 163, 184, 0.08)",
+  border: "1px solid rgba(148, 163, 184, 0.3)",
+  color: "#94a3b8",
+  cursor: "not-allowed",
+};
+
+const copyBtnFailedStyle: React.CSSProperties = {
+  ...copyBtnBaseStyle,
+  background: "rgba(220, 38, 38, 0.1)",
+  border: "1px solid rgba(220, 38, 38, 0.35)",
+  color: "#b91c1c",
+};
+
+const openTabStyle: React.CSSProperties = {
+  fontSize: 13,
+  color: "#3b82f6",
+  textDecoration: "none",
+};
+
+const warningStyle: React.CSSProperties = {
+  background: "rgba(220, 38, 38, 0.08)",
+  border: "1px solid rgba(220, 38, 38, 0.3)",
+  borderRadius: 8,
+  padding: "10px 12px",
+  color: "#b91c1c",
+  fontSize: 13,
+  marginBottom: 12,
+  lineHeight: 1.4,
+};
+
+function copyBtnLabel(state: CopyState): string {
+  if (state === "copying") return "Copying…";
+  if (state === "copied") return "Copied!";
+  if (state === "failed") return "Copy failed";
+  return "Copy link";
+}
+
+function copyBtnStyleFor(state: CopyState, disabled: boolean): React.CSSProperties {
+  if (disabled) return copyBtnDisabledStyle;
+  if (state === "failed") return copyBtnFailedStyle;
+  return copyBtnBaseStyle;
+}
+
+export function ShareDialog({ open, url, tooLong, onClose, copy }: ShareDialogProps) {
+  const [copyState, setCopyState] = useState<CopyState>("idle");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const revertTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const titleId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    setCopyState("idle");
+    const id = window.requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    });
+    return () => window.cancelAnimationFrame(id);
+  }, [open, url]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [open, onClose]);
+
+  useEffect(() => {
+    return () => {
+      if (revertTimerRef.current !== null) {
+        clearTimeout(revertTimerRef.current);
+        revertTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    if (tooLong) return;
+    if (revertTimerRef.current !== null) {
+      clearTimeout(revertTimerRef.current);
+      revertTimerRef.current = null;
+    }
+    setCopyState("copying");
+    const fn = copy ?? defaultCopy;
+    const result = await fn(url);
+    setCopyState(result);
+    revertTimerRef.current = setTimeout(() => {
+      setCopyState("idle");
+      revertTimerRef.current = null;
+    }, 2500);
+  }, [copy, tooLong, url]);
+
+  if (!open) return null;
+
+  const copyDisabled = tooLong || copyState === "copying";
+
+  return createPortal(
+    <div style={backdropStyle} onClick={onClose} data-testid="share-dialog-backdrop">
+      <div
+        style={panelStyle}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        data-testid="share-dialog"
+      >
+        <div style={headerRowStyle}>
+          <span id={titleId} style={titleStyle}>
+            Share pipeline
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            style={closeBtnStyle}
+            aria-label="Close"
+            data-testid="share-dialog-close"
+          >
+            ✕
+          </button>
+        </div>
+
+        {tooLong && (
+          <div style={warningStyle} data-testid="share-dialog-warning">
+            Pipeline too large to share via URL (over 8000 characters). Use Export instead.
+          </div>
+        )}
+
+        <input
+          ref={inputRef}
+          type="text"
+          readOnly
+          value={url}
+          style={inputStyle}
+          onFocus={(e) => e.currentTarget.select()}
+          onClick={(e) => e.currentTarget.select()}
+          data-testid="share-dialog-url-input"
+          aria-label="Share URL"
+        />
+
+        <div style={buttonRowStyle}>
+          <button
+            type="button"
+            onClick={handleCopy}
+            disabled={copyDisabled}
+            style={copyBtnStyleFor(copyState, copyDisabled)}
+            data-testid="share-dialog-copy"
+            data-state={copyState}
+          >
+            {copyBtnLabel(copyState)}
+          </button>
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={openTabStyle}
+            data-testid="share-dialog-open-tab"
+          >
+            Open in new tab
+          </a>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/pipeline/shareLink.ts
+++ b/src/pipeline/shareLink.ts
@@ -1,10 +1,16 @@
 /**
  * URL permalink encoding/decoding for pipeline state.
- * Serializes the pipeline JSON to a base64url string stored in the URL hash
- * so viewers can share a reproducible pipeline state via link.
  *
  * Format: `#pipeline=<base64url(deflate-raw(JSON))>`
  * Falls back to uncompressed base64url when CompressionStream is unavailable.
+ *
+ * Side-effect contract for the share button flow:
+ *   - `shareCurrentPipeline` ALWAYS commits the hash to the address bar
+ *     before returning (when the payload fits), independently of clipboard
+ *     availability. The dialog UI then drives the user-visible copy step.
+ *   - `copyShareUrl` tries the modern Clipboard API first and falls back to
+ *     a hidden-textarea + `document.execCommand('copy')` for non-secure
+ *     contexts and sandboxed iframes.
  */
 
 import type { SerializedPipeline } from "./types";
@@ -12,13 +18,6 @@ import type { SerializedPipeline } from "./types";
 const HASH_PARAM = "pipeline";
 /** Warn the user when the hash fragment would exceed this many characters. */
 const MAX_HASH_LENGTH = 8000;
-
-const TOO_LONG_MESSAGE = "Pipeline too large for a share link — use Export instead";
-const COPIED_MESSAGE = "Link copied to clipboard!";
-const COPY_FAILED_MESSAGE = "Copy failed — see console for the link";
-
-const COPIED_TOAST_MS = 3000;
-const TOO_LONG_TOAST_MS = 5000;
 
 // ── byte ↔ base64url ────────────────────────────────────────────────────────
 
@@ -91,7 +90,6 @@ export async function buildShareUrl(
   try {
     encoded = bytesToBase64url(await deflate(raw));
   } catch {
-    // CompressionStream not available — fall back to plain base64url
     encoded = bytesToBase64url(raw);
   }
 
@@ -119,7 +117,6 @@ export async function readPipelineFromHash(): Promise<SerializedPipeline | null>
     try {
       json = new TextDecoder().decode(await inflate(bytes));
     } catch {
-      // Not compressed — treat as plain UTF-8 base64url
       json = new TextDecoder().decode(bytes);
     }
 
@@ -139,60 +136,74 @@ export async function readPipelineFromHash(): Promise<SerializedPipeline | null>
   }
 }
 
-// ── share-button outcome helper ─────────────────────────────────────────────
-
-export type ShareOutcome = {
-  /** Toast message to surface to the user. */
-  message: string;
-  /** Milliseconds the toast should remain visible before auto-clearing. */
-  clearAfterMs: number;
-  /** The share URL (always set, even when copy failed). */
-  url: string;
-  /** True when the pipeline was too large to fit a shareable hash. */
-  tooLong: boolean;
-  /** True when navigator.clipboard.writeText threw. */
-  copyFailed: boolean;
-};
+// ── side-effect helpers ─────────────────────────────────────────────────────
 
 /**
- * Build a share URL for the given pipeline, copy it to the clipboard, and
- * mirror the resulting hash into the address bar. Returns a presentation-ready
- * outcome that the caller can render as a toast.
- *
- * Pure side effects (clipboard write, history.replaceState, console.info on
- * failure) are kept out of the React component so the flow is testable.
+ * Mirror the URL's hash fragment into the browser address bar.
+ * Swallows `SecurityError` from sandboxed iframes so a missing history API
+ * never blocks the share flow.
  */
-export async function shareCurrentPipeline(pipeline: SerializedPipeline): Promise<ShareOutcome> {
-  const { url, tooLong } = await buildShareUrl(pipeline);
-  if (tooLong) {
-    return {
-      message: TOO_LONG_MESSAGE,
-      clearAfterMs: TOO_LONG_TOAST_MS,
-      url,
-      tooLong: true,
-      copyFailed: false,
-    };
-  }
+export function commitShareHashToHistory(url: string): void {
   try {
-    await navigator.clipboard.writeText(url);
     history.replaceState(null, "", new URL(url).hash);
-    return {
-      message: COPIED_MESSAGE,
-      clearAfterMs: COPIED_TOAST_MS,
-      url,
-      tooLong: false,
-      copyFailed: false,
-    };
   } catch {
-    console.info("Share URL:", url);
-    return {
-      message: COPY_FAILED_MESSAGE,
-      clearAfterMs: COPIED_TOAST_MS,
-      url,
-      tooLong: false,
-      copyFailed: true,
-    };
+    // Sandboxed iframes / non-browser hosts: nothing to do.
   }
+}
+
+/**
+ * Copy `url` to the user's clipboard.
+ *
+ * Tries the modern async Clipboard API first; falls back to a hidden
+ * `<textarea>` + `document.execCommand('copy')` so non-secure contexts and
+ * permission-denied environments still get a working copy. On full failure
+ * the URL is logged via `console.info` so it can still be retrieved.
+ */
+export async function copyShareUrl(url: string): Promise<"copied" | "failed"> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(url);
+      return "copied";
+    } catch {
+      // fall through to legacy path
+    }
+  }
+
+  if (typeof document !== "undefined" && document.body) {
+    const textarea = document.createElement("textarea");
+    textarea.value = url;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    textarea.style.pointerEvents = "none";
+    document.body.appendChild(textarea);
+    try {
+      textarea.focus();
+      textarea.select();
+      const ok = document.execCommand("copy");
+      if (ok) return "copied";
+    } catch {
+      // ignore — handled below
+    } finally {
+      textarea.remove();
+    }
+  }
+
+  console.info("Share URL:", url);
+  return "failed";
+}
+
+/**
+ * Build a share URL for `pipeline` and commit the hash to the address bar.
+ * Returns the dialog payload (URL + tooLong flag); does NOT touch the
+ * clipboard — that is driven by an explicit user click in `<ShareDialog>`.
+ */
+export async function shareCurrentPipeline(
+  pipeline: SerializedPipeline,
+): Promise<{ url: string; tooLong: boolean }> {
+  const { url, tooLong } = await buildShareUrl(pipeline);
+  if (!tooLong) commitShareHashToHistory(url);
+  return { url, tooLong };
 }
 
 // ── hash-restore helper ─────────────────────────────────────────────────────

--- a/tests/ts/components/PipelineEditor.test.tsx
+++ b/tests/ts/components/PipelineEditor.test.tsx
@@ -101,78 +101,60 @@ describe("PipelineEditor — collapsed state", () => {
   });
 });
 
-describe("PipelineEditor — Share button feedback", () => {
+describe("PipelineEditor — Share button opens dialog", () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let alertSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     shareCurrentPipelineMock.mockReset();
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
   });
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
+    alertSpy.mockRestore();
   });
 
-  it("shows the success pill when shareCurrentPipeline resolves with copied", async () => {
+  it("opens the share dialog with the URL when shareCurrentPipeline resolves", async () => {
     shareCurrentPipelineMock.mockResolvedValue({
-      message: "Link copied to clipboard!",
-      clearAfterMs: 3000,
       url: "http://example.test/#pipeline=abc",
       tooLong: false,
-      copyFailed: false,
     });
 
     render(<PipelineEditor collapsed={false} onToggleCollapse={() => {}} />);
     fireEvent.click(screen.getByTestId("pipeline-editor-share"));
 
-    const feedback = await screen.findByTestId("pipeline-editor-share-feedback");
-    expect(feedback.textContent).toContain("Link copied to clipboard!");
-    expect(feedback.getAttribute("data-tone")).toBe("success");
+    const input = await screen.findByTestId("share-dialog-url-input");
+    expect((input as HTMLInputElement).value).toBe("http://example.test/#pipeline=abc");
+    expect(screen.queryByTestId("share-dialog-warning")).toBeNull();
   });
 
-  it("shows the warning pill when the pipeline is too long", async () => {
+  it("renders the tooLong warning and disables Copy when the pipeline is too long", async () => {
     shareCurrentPipelineMock.mockResolvedValue({
-      message: "Pipeline too large for a share link — use Export instead",
-      clearAfterMs: 5000,
       url: "http://example.test/#pipeline=zzz",
       tooLong: true,
-      copyFailed: false,
     });
 
     render(<PipelineEditor collapsed={false} onToggleCollapse={() => {}} />);
     fireEvent.click(screen.getByTestId("pipeline-editor-share"));
 
-    const feedback = await screen.findByTestId("pipeline-editor-share-feedback");
-    expect(feedback.getAttribute("data-tone")).toBe("warning");
+    expect(await screen.findByTestId("share-dialog-warning")).toBeTruthy();
+    const copyBtn = screen.getByTestId("share-dialog-copy") as HTMLButtonElement;
+    expect(copyBtn.disabled).toBe(true);
   });
 
-  it("shows the error pill when clipboard write fails", async () => {
-    shareCurrentPipelineMock.mockResolvedValue({
-      message: "Copy failed — see console for the link",
-      clearAfterMs: 3000,
-      url: "http://example.test/#pipeline=abc",
-      tooLong: false,
-      copyFailed: true,
-    });
-
-    render(<PipelineEditor collapsed={false} onToggleCollapse={() => {}} />);
-    fireEvent.click(screen.getByTestId("pipeline-editor-share"));
-
-    const feedback = await screen.findByTestId("pipeline-editor-share-feedback");
-    expect(feedback.getAttribute("data-tone")).toBe("error");
-  });
-
-  it("surfaces silent rejections as a visible error pill (regression for the void-handler bug)", async () => {
+  it("alerts and skips the dialog when shareCurrentPipeline rejects", async () => {
     shareCurrentPipelineMock.mockRejectedValue(new Error("boom"));
 
     render(<PipelineEditor collapsed={false} onToggleCollapse={() => {}} />);
     fireEvent.click(screen.getByTestId("pipeline-editor-share"));
 
-    const feedback = await screen.findByTestId("pipeline-editor-share-feedback");
-    expect(feedback.textContent).toContain("Share failed");
-    expect(feedback.getAttribute("data-tone")).toBe("error");
     await waitFor(() => {
-      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(alertSpy).toHaveBeenCalled();
     });
+    expect(alertSpy.mock.calls[0][0]).toContain("Share failed");
+    expect(screen.queryByTestId("share-dialog")).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalled();
   });
 });

--- a/tests/ts/components/ShareDialog.test.tsx
+++ b/tests/ts/components/ShareDialog.test.tsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor, act } from "@testing-library/react";
+import { ShareDialog } from "@/components/ShareDialog";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ShareDialog", () => {
+  it("renders nothing when open=false", () => {
+    const { container } = render(
+      <ShareDialog open={false} url="http://x/#pipeline=abc" tooLong={false} onClose={() => {}} />,
+    );
+    expect(container.querySelector("[data-testid='share-dialog']")).toBeNull();
+  });
+
+  it("renders a read-only input containing the URL when open", () => {
+    render(
+      <ShareDialog open url="http://x/#pipeline=abc" tooLong={false} onClose={() => {}} />,
+    );
+    const input = screen.getByTestId("share-dialog-url-input") as HTMLInputElement;
+    expect(input.value).toBe("http://x/#pipeline=abc");
+    expect(input.readOnly).toBe(true);
+  });
+
+  it("selects the full URL when the input is clicked", () => {
+    render(
+      <ShareDialog open url="http://x/#pipeline=abcdef" tooLong={false} onClose={() => {}} />,
+    );
+    const input = screen.getByTestId("share-dialog-url-input") as HTMLInputElement;
+    fireEvent.click(input);
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe("http://x/#pipeline=abcdef".length);
+  });
+
+  it("invokes the injected copy function with the URL and shows 'Copied!'", async () => {
+    const copy = vi.fn().mockResolvedValue("copied" as const);
+    render(
+      <ShareDialog
+        open
+        url="http://x/#pipeline=abc"
+        tooLong={false}
+        onClose={() => {}}
+        copy={copy}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("share-dialog-copy"));
+    await waitFor(() => {
+      expect(copy).toHaveBeenCalledWith("http://x/#pipeline=abc");
+    });
+    const btn = await screen.findByTestId("share-dialog-copy");
+    await waitFor(() => {
+      expect(btn.textContent).toContain("Copied!");
+      expect(btn.getAttribute("data-state")).toBe("copied");
+    });
+  });
+
+  it("shows 'Copy failed' when the copy function returns failed", async () => {
+    const copy = vi.fn().mockResolvedValue("failed" as const);
+    render(
+      <ShareDialog
+        open
+        url="http://x/#pipeline=abc"
+        tooLong={false}
+        onClose={() => {}}
+        copy={copy}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("share-dialog-copy"));
+    const btn = await screen.findByTestId("share-dialog-copy");
+    await waitFor(() => {
+      expect(btn.textContent).toContain("Copy failed");
+      expect(btn.getAttribute("data-state")).toBe("failed");
+    });
+  });
+
+  it("reverts the copy label to 'Copy link' after 2.5 s", async () => {
+    vi.useFakeTimers();
+    try {
+      const copy = vi.fn().mockResolvedValue("copied" as const);
+      render(
+        <ShareDialog
+          open
+          url="http://x/#pipeline=abc"
+          tooLong={false}
+          onClose={() => {}}
+          copy={copy}
+        />,
+      );
+      fireEvent.click(screen.getByTestId("share-dialog-copy"));
+      // Drain pending microtasks so the awaited copy() resolves.
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const btn = screen.getByTestId("share-dialog-copy");
+      expect(btn.getAttribute("data-state")).toBe("copied");
+      act(() => {
+        vi.advanceTimersByTime(2500);
+      });
+      expect(btn.getAttribute("data-state")).toBe("idle");
+      expect(btn.textContent).toContain("Copy link");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("closes when Escape is pressed", () => {
+    const onClose = vi.fn();
+    render(<ShareDialog open url="http://x/#pipeline=abc" tooLong={false} onClose={onClose} />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on backdrop click but not on panel click", () => {
+    const onClose = vi.fn();
+    render(<ShareDialog open url="http://x/#pipeline=abc" tooLong={false} onClose={onClose} />);
+
+    fireEvent.click(screen.getByTestId("share-dialog"));
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("share-dialog-backdrop"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes when the × button is clicked", () => {
+    const onClose = vi.fn();
+    render(<ShareDialog open url="http://x/#pipeline=abc" tooLong={false} onClose={onClose} />);
+    fireEvent.click(screen.getByTestId("share-dialog-close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the warning and disables Copy when tooLong=true", () => {
+    render(<ShareDialog open url="http://x/#pipeline=zzz" tooLong onClose={() => {}} />);
+    expect(screen.getByTestId("share-dialog-warning")).toBeTruthy();
+    const copyBtn = screen.getByTestId("share-dialog-copy") as HTMLButtonElement;
+    expect(copyBtn.disabled).toBe(true);
+  });
+
+  it("does not invoke copy when tooLong=true even if the button is clicked", () => {
+    const copy = vi.fn();
+    render(
+      <ShareDialog open url="http://x/#pipeline=zzz" tooLong onClose={() => {}} copy={copy} />,
+    );
+    fireEvent.click(screen.getByTestId("share-dialog-copy"));
+    expect(copy).not.toHaveBeenCalled();
+  });
+
+  it("'Open in new tab' anchor has correct href / target / rel", () => {
+    render(
+      <ShareDialog open url="http://x/#pipeline=abc" tooLong={false} onClose={() => {}} />,
+    );
+    const anchor = screen.getByTestId("share-dialog-open-tab") as HTMLAnchorElement;
+    expect(anchor.getAttribute("href")).toBe("http://x/#pipeline=abc");
+    expect(anchor.getAttribute("target")).toBe("_blank");
+    expect(anchor.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("uses the real copyShareUrl when the copy prop is omitted", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const original = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    try {
+      render(
+        <ShareDialog open url="http://x/#pipeline=abc" tooLong={false} onClose={() => {}} />,
+      );
+      fireEvent.click(screen.getByTestId("share-dialog-copy"));
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith("http://x/#pipeline=abc");
+      });
+    } finally {
+      if (original) {
+        Object.defineProperty(navigator, "clipboard", original);
+      } else {
+        // @ts-expect-error - remove the test-installed property
+        delete navigator.clipboard;
+      }
+    }
+  });
+});

--- a/tests/ts/pipeline/shareLink.test.ts
+++ b/tests/ts/pipeline/shareLink.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   buildShareUrl,
+  commitShareHashToHistory,
+  copyShareUrl,
   readPipelineFromHash,
   restorePipelineFromHash,
   shareCurrentPipeline,
@@ -72,7 +74,6 @@ describe("buildShareUrl", () => {
         type: "load_structure",
         position: { x: i, y: i },
         enabled: true,
-        // pad with random-ish unique data so deflate cannot collapse it
         fileName: `${i}-${Math.random().toString(36).repeat(5)}-${"x".repeat(30)}`,
         hasTrajectory: false,
         hasCell: false,
@@ -85,15 +86,11 @@ describe("buildShareUrl", () => {
 
   it("falls back to plain base64url when CompressionStream is unavailable", async () => {
     const original = globalThis.CompressionStream;
-    // Simulate older browsers by removing CompressionStream entirely.
-    // The implementation catches the resulting ReferenceError/TypeError and
-    // falls back to encoding the raw JSON bytes.
     // @ts-expect-error - intentional removal for fallback test
     delete globalThis.CompressionStream;
     try {
       const { url } = await buildShareUrl(samplePipeline);
       const encoded = url.split("#pipeline=")[1];
-      // The fallback path stores the raw JSON, so atob(decode) should yield JSON text.
       const padded = encoded.replace(/-/g, "+").replace(/_/g, "/");
       const padding = (4 - (padded.length % 4)) % 4;
       const decoded = atob(padded + "=".repeat(padding));
@@ -127,7 +124,6 @@ describe("readPipelineFromHash", () => {
   });
 
   it("returns null when decoded JSON is malformed", async () => {
-    // base64url("not json") → "bm90IGpzb24"
     const encoded = btoa("not json").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
     setHash(`pipeline=${encoded}`);
     expect(await readPipelineFromHash()).toBeNull();
@@ -177,16 +173,11 @@ describe("readPipelineFromHash", () => {
 
 describe("buildShareUrl ↔ readPipelineFromHash compatibility", () => {
   let originalCompression: typeof CompressionStream | undefined;
-  let originalDecompression: typeof DecompressionStream | undefined;
 
   afterEach(() => {
     if (originalCompression !== undefined) {
       globalThis.CompressionStream = originalCompression;
       originalCompression = undefined;
-    }
-    if (originalDecompression !== undefined) {
-      globalThis.DecompressionStream = originalDecompression;
-      originalDecompression = undefined;
     }
     setHash("");
   });
@@ -200,9 +191,6 @@ describe("buildShareUrl ↔ readPipelineFromHash compatibility", () => {
     const hashIndex = url.indexOf("#");
     setHash(url.slice(hashIndex + 1));
 
-    // Restore compression so the decoder will try inflate first; the inflate
-    // attempt should fail on plain bytes, and the catch should fall through
-    // to the plain UTF-8 path.
     globalThis.CompressionStream = originalCompression;
     originalCompression = undefined;
 
@@ -227,11 +215,38 @@ describe("buildShareUrl ↔ readPipelineFromHash compatibility", () => {
   });
 });
 
-describe("shareCurrentPipeline", () => {
+describe("commitShareHashToHistory", () => {
+  let replaceStateSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    replaceStateSpy = vi.spyOn(history, "replaceState").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    replaceStateSpy.mockRestore();
+  });
+
+  it("calls history.replaceState with the URL's hash fragment", () => {
+    commitShareHashToHistory("https://example.com/path#pipeline=abc123");
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+    expect(String(replaceStateSpy.mock.calls[0][2])).toBe("#pipeline=abc123");
+  });
+
+  it("swallows replaceState exceptions so the share flow continues", () => {
+    replaceStateSpy.mockImplementationOnce(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+    expect(() =>
+      commitShareHashToHistory("https://example.com/path#pipeline=abc123"),
+    ).not.toThrow();
+  });
+});
+
+describe("copyShareUrl", () => {
   let writeText: ReturnType<typeof vi.fn>;
   let originalClipboard: PropertyDescriptor | undefined;
-  let replaceStateSpy: ReturnType<typeof vi.spyOn>;
   let infoSpy: ReturnType<typeof vi.spyOn>;
+  let originalExec: typeof document.execCommand;
 
   beforeEach(() => {
     writeText = vi.fn().mockResolvedValue(undefined);
@@ -240,9 +255,8 @@ describe("shareCurrentPipeline", () => {
       value: { writeText },
       configurable: true,
     });
-    replaceStateSpy = vi.spyOn(history, "replaceState").mockImplementation(() => {});
     infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
-    window.location.hash = "";
+    originalExec = document.execCommand;
   });
 
   afterEach(() => {
@@ -252,25 +266,106 @@ describe("shareCurrentPipeline", () => {
       // @ts-expect-error - remove the test-installed property
       delete navigator.clipboard;
     }
-    replaceStateSpy.mockRestore();
     infoSpy.mockRestore();
+    document.execCommand = originalExec;
   });
 
-  it("ok path: writes to clipboard, mirrors hash, returns success outcome", async () => {
-    const outcome = await shareCurrentPipeline(samplePipeline);
-    expect(outcome.tooLong).toBe(false);
-    expect(outcome.copyFailed).toBe(false);
-    expect(outcome.message).toBe("Link copied to clipboard!");
-    expect(outcome.clearAfterMs).toBe(3000);
-    expect(outcome.url).toContain("#pipeline=");
-    expect(writeText).toHaveBeenCalledWith(outcome.url);
+  it("returns 'copied' on navigator.clipboard.writeText success", async () => {
+    const result = await copyShareUrl("https://example.com/#pipeline=abc");
+    expect(result).toBe("copied");
+    expect(writeText).toHaveBeenCalledWith("https://example.com/#pipeline=abc");
+  });
+
+  it("falls back to execCommand('copy') when writeText rejects", async () => {
+    writeText.mockRejectedValueOnce(new Error("denied"));
+    const exec = vi.fn().mockReturnValue(true);
+    document.execCommand = exec as unknown as typeof document.execCommand;
+
+    const before = document.body.querySelectorAll("textarea").length;
+    const result = await copyShareUrl("https://example.com/#pipeline=abc");
+    const after = document.body.querySelectorAll("textarea").length;
+
+    expect(result).toBe("copied");
+    expect(exec).toHaveBeenCalledWith("copy");
+    expect(after).toBe(before);
+  });
+
+  it("falls back to execCommand('copy') when navigator.clipboard is missing", async () => {
+    // @ts-expect-error - simulate missing API
+    delete navigator.clipboard;
+    const exec = vi.fn().mockReturnValue(true);
+    document.execCommand = exec as unknown as typeof document.execCommand;
+
+    const result = await copyShareUrl("https://example.com/#pipeline=abc");
+    expect(result).toBe("copied");
+    expect(exec).toHaveBeenCalledWith("copy");
+  });
+
+  it("returns 'failed' and logs the URL when both paths fail", async () => {
+    writeText.mockRejectedValueOnce(new Error("denied"));
+    const exec = vi.fn().mockReturnValue(false);
+    document.execCommand = exec as unknown as typeof document.execCommand;
+
+    const result = await copyShareUrl("https://example.com/#pipeline=abc");
+    expect(result).toBe("failed");
+    expect(infoSpy).toHaveBeenCalledWith("Share URL:", "https://example.com/#pipeline=abc");
+  });
+
+  it("returns 'failed' when execCommand throws after clipboard fails", async () => {
+    writeText.mockRejectedValueOnce(new Error("denied"));
+    document.execCommand = (() => {
+      throw new Error("blocked");
+    }) as unknown as typeof document.execCommand;
+
+    const result = await copyShareUrl("https://example.com/#pipeline=abc");
+    expect(result).toBe("failed");
+  });
+});
+
+describe("shareCurrentPipeline", () => {
+  let replaceStateSpy: ReturnType<typeof vi.spyOn>;
+  let writeText: ReturnType<typeof vi.fn>;
+  let originalClipboard: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    replaceStateSpy = vi.spyOn(history, "replaceState").mockImplementation(() => {});
+    writeText = vi.fn().mockResolvedValue(undefined);
+    originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    window.location.hash = "";
+  });
+
+  afterEach(() => {
+    replaceStateSpy.mockRestore();
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    } else {
+      // @ts-expect-error - remove the test-installed property
+      delete navigator.clipboard;
+    }
+  });
+
+  it("returns the URL and tooLong=false on the success path", async () => {
+    const out = await shareCurrentPipeline(samplePipeline);
+    expect(out.tooLong).toBe(false);
+    expect(out.url).toContain("#pipeline=");
+  });
+
+  it("mirrors the hash to history.replaceState before returning", async () => {
+    await shareCurrentPipeline(samplePipeline);
     expect(replaceStateSpy).toHaveBeenCalledTimes(1);
-    // Second arg of replaceState is the URL fragment (e.g. "#pipeline=...")
-    const replaceArgs = replaceStateSpy.mock.calls[0];
-    expect(String(replaceArgs[2])).toMatch(/^#pipeline=/);
+    expect(String(replaceStateSpy.mock.calls[0][2])).toMatch(/^#pipeline=/);
   });
 
-  it("tooLong path: skips clipboard, returns 4-second toast", async () => {
+  it("never touches the clipboard (copy is owned by the dialog)", async () => {
+    await shareCurrentPipeline(samplePipeline);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("skips replaceState on the tooLong path but still returns the URL", async () => {
     const big: SerializedPipeline = {
       version: 3,
       nodes: Array.from({ length: 800 }, (_, i) => ({
@@ -284,24 +379,11 @@ describe("shareCurrentPipeline", () => {
       })) as SerializedPipeline["nodes"],
       edges: [],
     };
-    const outcome = await shareCurrentPipeline(big);
-    expect(outcome.tooLong).toBe(true);
-    expect(outcome.copyFailed).toBe(false);
-    expect(outcome.message).toBe("Pipeline too large for a share link — use Export instead");
-    expect(outcome.clearAfterMs).toBe(5000);
+    const out = await shareCurrentPipeline(big);
+    expect(out.tooLong).toBe(true);
+    expect(out.url).toContain("#pipeline=");
+    expect(replaceStateSpy).not.toHaveBeenCalled();
     expect(writeText).not.toHaveBeenCalled();
-    expect(replaceStateSpy).not.toHaveBeenCalled();
-  });
-
-  it("copyFailed path: clipboard rejection logs URL and returns failure outcome", async () => {
-    writeText.mockRejectedValueOnce(new Error("denied"));
-    const outcome = await shareCurrentPipeline(samplePipeline);
-    expect(outcome.tooLong).toBe(false);
-    expect(outcome.copyFailed).toBe(true);
-    expect(outcome.message).toBe("Copy failed — see console for the link");
-    expect(outcome.clearAfterMs).toBe(3000);
-    expect(infoSpy).toHaveBeenCalledWith("Share URL:", outcome.url);
-    expect(replaceStateSpy).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

The Share button in the pipeline editor was reported as completely
unresponsive in the HTTPS browser build — no URL hash mirror, no clipboard
write, no toast feedback. Investigation found two structural problems:

1. **Side-effect ordering** in `shareCurrentPipeline` ran
   `history.replaceState` **after** `navigator.clipboard.writeText` resolved,
   so any clipboard rejection (sandboxed iframe, denied permissions, focus
   issues) skipped the hash mirror and left the user with no fallback path to
   grab the link.
2. The **toast pill** auto-dismissed in 3 s, was easy to miss, and offered no
   manual-copy affordance when the modern Clipboard API was unavailable.

This PR reworks the share flow around an explicit modal so the response is
unmistakable and robust to any clipboard failure:

- `shareCurrentPipeline` now commits the hash to the address bar **first** and
  returns `{ url, tooLong }`. Clipboard work is owned by the dialog, triggered
  by an explicit user click.
- New `copyShareUrl` helper tries `navigator.clipboard.writeText` first and
  falls back to a hidden `<textarea>` + `document.execCommand('copy')` so
  non-secure contexts and restricted iframes still get a working copy. Final
  failure logs the URL via `console.info`.
- New `ShareDialog` component (`createPortal`, modeled after `RenderModal`)
  shows the URL in a read-only input, offers **Copy link** / **Open in new
  tab**, and dismisses on Escape / backdrop / × button. When the encoded
  payload exceeds 8000 chars the dialog renders a warning and disables Copy.
- `PipelineEditor` swaps the `shareFeedback` toast state for `shareDialog`
  state and removes the `SHARE_FEEDBACK_STYLES` constants.

### Hosts (CRITICAL RULE #6)

- **Standalone webapp / JupyterLab labextension / VSCode extension**: all
  import the shared `PipelineEditor` and pick this up automatically.
- **Jupyter widget** does not mount the pipeline editor (CRITICAL RULE #7) and
  is unaffected.

### Coverage (CRITICAL RULE #8)

- `src/pipeline/shareLink.ts` — **100 %** patch coverage
- `src/components/ShareDialog.tsx` — **98.6 %** patch coverage

Both well above the 70 % gate. Full local run: `npm test -- --coverage` →
1098/1098 tests pass.

## Test plan

- [x] `npm run lint` — 0 errors (only pre-existing warnings in unrelated files)
- [x] `npm run build:wasm`
- [x] `npm test -- --coverage` — 1098 tests pass; new files at 100 % / 98.6 %
- [ ] Manual smoke test in `npm run dev`:
  - [ ] Click Share → dialog opens, URL bar shows `#pipeline=...`
  - [ ] Click Copy → clipboard contains URL, label says "Copied!"
  - [ ] DevTools `Object.defineProperty(navigator,'clipboard',{value:undefined})`
        then click Copy → execCommand fallback succeeds
  - [ ] "Open in new tab" loads the same pipeline
  - [ ] ESC, backdrop click, × all dismiss the dialog
  - [ ] Pipeline that exceeds 8000 chars hash → dialog shows warning, Copy
        is disabled

https://claude.ai/code/session_01B14Tr46NhsXP58pvh8EBF1

---
_Generated by [Claude Code](https://claude.ai/code/session_01B14Tr46NhsXP58pvh8EBF1)_