### PR TITLE
fix(share): unblock buildShareUrl by reading CompressionStream concurrently

### DIFF
--- a/src/pipeline/shareLink.ts
+++ b/src/pipeline/shareLink.ts
@@ -38,40 +38,38 @@ function base64urlToBytes(str: string): Uint8Array<ArrayBuffer> {
 
 // ── deflate-raw helpers (async, CompressionStream) ──────────────────────────
 
+// CompressionStream's writer.write() / writer.close() promises only resolve
+// once a reader drains the produced chunks (backpressure protocol). The naive
+// "await writer.write(data); await writer.close(); then read" sequence hangs
+// forever in Chromium and WebKit because nothing is reading. Pipe the input
+// through the stream and read it via Response so the producer and consumer
+// run concurrently.
 async function deflate(data: Uint8Array<ArrayBuffer>): Promise<Uint8Array<ArrayBuffer>> {
-  const cs = new CompressionStream("deflate-raw");
-  const writer = cs.writable.getWriter();
-  await writer.write(data);
-  await writer.close();
-  return collectStream(cs.readable);
+  return runStream(data, new CompressionStream("deflate-raw"));
 }
 
 async function inflate(data: Uint8Array<ArrayBuffer>): Promise<Uint8Array<ArrayBuffer>> {
-  const ds = new DecompressionStream("deflate-raw");
-  const writer = ds.writable.getWriter();
-  await writer.write(data);
-  await writer.close();
-  return collectStream(ds.readable);
+  return runStream(data, new DecompressionStream("deflate-raw"));
 }
 
-async function collectStream(
-  readable: ReadableStream<Uint8Array>,
+async function runStream(
+  data: Uint8Array<ArrayBuffer>,
+  transform: CompressionStream | DecompressionStream,
 ): Promise<Uint8Array<ArrayBuffer>> {
-  const chunks: Uint8Array[] = [];
-  const reader = readable.getReader();
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    chunks.push(value);
-  }
-  const total = chunks.reduce((n, c) => n + c.length, 0);
-  const out = new Uint8Array(total);
-  let offset = 0;
-  for (const c of chunks) {
-    out.set(c, offset);
-    offset += c.length;
-  }
-  return out;
+  const input = new ReadableStream({
+    start(controller) {
+      controller.enqueue(data);
+      controller.close();
+    },
+  });
+  // CompressionStream / DecompressionStream both implement
+  // ReadableWritablePair<BufferSource, Uint8Array>; the lib.dom typings model
+  // it loosely, so cast to the structural pair pipeThrough expects.
+  const piped = input.pipeThrough(
+    transform as unknown as ReadableWritablePair<Uint8Array, Uint8Array>,
+  );
+  const buf = await new Response(piped).arrayBuffer();
+  return new Uint8Array(buf);
 }
 
 // ── public API ───────────────────────────────────────────────────────────────

--- a/tests/ts/pipeline/shareLink.test.ts
+++ b/tests/ts/pipeline/shareLink.test.ts
@@ -84,6 +84,31 @@ describe("buildShareUrl", () => {
     expect(tooLong).toBe(true);
   });
 
+  it("resolves promptly without deadlock under CompressionStream backpressure (regression: buildShareUrl hung in browsers when the deflate writer awaited before any reader drained)", async () => {
+    // Larger payload exercises chunking; if the implementation awaits
+    // writer.write() before draining cs.readable the promise will never
+    // resolve in real browsers. Vitest's jsdom uses Node's polyfill which
+    // also follows the backpressure protocol.
+    const big: SerializedPipeline = {
+      version: 3,
+      nodes: Array.from({ length: 50 }, (_, i) => ({
+        id: `n-${i}`,
+        type: "load_structure",
+        position: { x: i, y: i },
+        enabled: true,
+        fileName: `node-${i}-${"abcdefghij".repeat(20)}`,
+        hasTrajectory: false,
+        hasCell: false,
+      })) as SerializedPipeline["nodes"],
+      edges: [],
+    };
+    const result = await Promise.race([
+      buildShareUrl(big),
+      new Promise<never>((_, rej) => setTimeout(() => rej(new Error("timeout")), 4000)),
+    ]);
+    expect(result.url).toContain("#pipeline=");
+  });
+
   it("falls back to plain base64url when CompressionStream is unavailable", async () => {
     const original = globalThis.CompressionStream;
     // @ts-expect-error - intentional removal for fallback test


### PR DESCRIPTION
## Why the previous PR didn't actually fix it

PR #420 fixed the **UI feedback** side of the share flow (modal,
copy fallback, side-effect ordering) but the **upstream URL builder
itself was hanging**, so the dialog never opened on real devices.

I reproduced the user's report (HTTPS, mobile) by driving the
deployed bundle with Chromium emulating an iPhone 14 Pro:

- Click reaches the button (capture + bubble phases observed)
- React's `onClick` is bound and invokes synchronously
- **No** `setShareDialog` call, **no** `history.replaceState`, **no**
  `console.error`, **no** `window.alert` — `handleShare`'s `await`
  never returns

## Root cause

`buildShareUrl` deflated the JSON via:

```ts
const writer = cs.writable.getWriter();
await writer.write(data);   // ← never resolves
await writer.close();
return collectStream(cs.readable);
```

`writer.write()` and `writer.close()` only resolve once a reader
drains the produced chunks (streams-spec backpressure). Because no
reader is attached until *after* the awaits, the write promise never
settles. `shareCurrentPipeline` → `handleShare` then awaits forever
without throwing — perfectly silent.

A live in-page probe confirms it:

```
"write TIMED OUT (1s)"
"close TIMED OUT (1s)"
"read ok done=false bytes=32"   ← bytes WERE produced but writer awaits never resolved
```

## Fix

Run producer and consumer concurrently via `pipeThrough` +
`new Response(stream).arrayBuffer()`:

```ts
const input = new ReadableStream({ start(c) { c.enqueue(data); c.close(); } });
const piped = input.pipeThrough(transform);
const buf = await new Response(piped).arrayBuffer();
return new Uint8Array(buf);
```

Applied to both `deflate` and `inflate`. The now-unused `collectStream`
helper is removed. After the fix, the same in-page probe opens the
dialog and mirrors the hash within ~50 ms.

## Why unit tests didn't catch it before

Vitest under jsdom uses Node's WHATWG streams, which also follow the
backpressure protocol — so the original code *should* have hung in
tests too. It happened not to in practice (the tiny 1–2 chunk payload
fits in the implementation's internal queue), but real engines plus
larger payloads expose it. New regression test: races
`buildShareUrl` against a 4 s timeout with a 50-node pipeline.

## Test plan

- [x] `npm test -- shareLink.test.ts` → 31/31 pass (incl. new
      backpressure regression)
- [x] `npm test` → 1099/1099 pass
- [x] `npm run build:app`
- [x] Local serve + Playwright `devices['iPhone 14 Pro']` → dialog
      opens, URL bar shows `#pipeline=...`, all six dialog testids
      mount
- [ ] Verify on the real production deploy after merge

https://claude.ai/code/session_01B14Tr46NhsXP58pvh8EBF1

---
_Generated by [Claude Code](https://claude.ai/code/session_01B14Tr46NhsXP58pvh8EBF1)_