### PR TITLE
feat(timeline): add step buttons, speed multiplier, and loop range controls

### DIFF
--- a/src/components/MeganeViewer.tsx
+++ b/src/components/MeganeViewer.tsx
@@ -246,9 +246,16 @@ export function MeganeViewer({
 
   const storePlaying = usePlaybackStore((s) => s.playing);
   const storeFps = usePlaybackStore((s) => s.fps);
+  const storeSpeedMultiplier = usePlaybackStore((s) => s.speedMultiplier);
+  const storeLoopStart = usePlaybackStore((s) => s.loopStart);
+  const storeLoopEnd = usePlaybackStore((s) => s.loopEnd);
   const storeSeek = usePlaybackStore((s) => s.seekFrame);
   const storeTogglePlayPause = usePlaybackStore((s) => s.togglePlayPause);
   const storeSetFps = usePlaybackStore((s) => s.setFps);
+  const storeSetSpeedMultiplier = usePlaybackStore((s) => s.setSpeedMultiplier);
+  const storeSetLoopRange = usePlaybackStore((s) => s.setLoopRange);
+  const storeStepForward = usePlaybackStore((s) => s.stepForward);
+  const storeStepBackward = usePlaybackStore((s) => s.stepBackward);
 
   // Hosts may forward custom playback callbacks (the webapp wraps them to
   // pause on file uploads). When omitted (VSCode webview, JupyterLab
@@ -453,9 +460,16 @@ export function MeganeViewer({
         totalFrames={totalFrames}
         playing={effectivePlaying}
         fps={effectiveFps}
+        speedMultiplier={storeSpeedMultiplier}
+        loopStart={storeLoopStart}
+        loopEnd={storeLoopEnd}
         onSeek={effectiveOnSeek}
         onPlayPause={effectiveOnPlayPause}
         onFpsChange={effectiveOnFpsChange}
+        onSpeedChange={storeSetSpeedMultiplier}
+        onLoopRangeChange={storeSetLoopRange}
+        onStepBackward={storeStepBackward}
+        onStepForward={storeStepForward}
       />
       <Tooltip info={hoverInfo} />
       <MeasurementPanel

--- a/src/components/PipelineViewer.tsx
+++ b/src/components/PipelineViewer.tsx
@@ -285,19 +285,22 @@ export function PipelineViewer({ pipeline, width = "100%", height = 500 }: Pipel
 
   const startInterval = useCallback(() => {
     if (playIntervalRef.current !== null) return;
-    playIntervalRef.current = setInterval(() => {
-      const prov = providerRef.current;
-      const total = totalFramesRef.current;
-      if (!prov || total <= 1) return;
-      const effectiveEnd = Math.min(loopEndRef.current, total - 1);
-      const effectiveStart = Math.max(loopStartRef.current, 0);
-      let next = currentFrameRef.current + 1;
-      if (next > effectiveEnd) next = effectiveStart;
-      const frame = prov.getFrame(next);
-      currentFrameRef.current = next;
-      setCurrentFrame(next);
-      setCurrentFrameData(frame);
-    }, 1000 / (fpsRef.current * speedRef.current));
+    playIntervalRef.current = setInterval(
+      () => {
+        const prov = providerRef.current;
+        const total = totalFramesRef.current;
+        if (!prov || total <= 1) return;
+        const effectiveEnd = Math.min(loopEndRef.current, total - 1);
+        const effectiveStart = Math.max(loopStartRef.current, 0);
+        let next = currentFrameRef.current + 1;
+        if (next > effectiveEnd) next = effectiveStart;
+        const frame = prov.getFrame(next);
+        currentFrameRef.current = next;
+        setCurrentFrame(next);
+        setCurrentFrameData(frame);
+      },
+      1000 / (fpsRef.current * speedRef.current),
+    );
   }, []);
 
   const stopInterval = useCallback(() => {

--- a/src/components/PipelineViewer.tsx
+++ b/src/components/PipelineViewer.tsx
@@ -86,6 +86,9 @@ export function PipelineViewer({ pipeline, width = "100%", height = 500 }: Pipel
   const [currentFrameData, setCurrentFrameData] = useState<Frame | null>(null);
   const [playing, setPlaying] = useState(false);
   const [fps, setFpsState] = useState(30);
+  const [speedMultiplier, setSpeedMultiplier] = useState(1);
+  const [loopStart, setLoopStart] = useState(0);
+  const [loopEnd, setLoopEnd] = useState(0);
 
   // Refs for setInterval (avoids stale closure)
   const rendererRef = useRef<MoleculeRenderer | null>(null);
@@ -95,12 +98,18 @@ export function PipelineViewer({ pipeline, width = "100%", height = 500 }: Pipel
   const providerRef = useRef<FrameProvider | null>(null);
   const totalFramesRef = useRef(0);
   const fpsRef = useRef(30);
+  const speedRef = useRef(1);
+  const loopStartRef = useRef(0);
+  const loopEndRef = useRef(0);
   const [hoverInfo, setHoverInfo] = useState<HoverInfo | null>(null);
 
   // Keep refs in sync
   providerRef.current = provider;
   totalFramesRef.current = totalFrames;
   fpsRef.current = fps;
+  speedRef.current = speedMultiplier;
+  loopStartRef.current = loopStart;
+  loopEndRef.current = loopEnd;
 
   const { handleAtomRightClick, handleFrameUpdated } = useAtomSelection(rendererRef);
 
@@ -122,6 +131,8 @@ export function PipelineViewer({ pipeline, width = "100%", height = 500 }: Pipel
     currentFrameRef.current = 0;
     setCurrentFrame(0);
     setCurrentFrameData(null);
+    setLoopStart(0);
+    setLoopEnd(0);
 
     async function init() {
       try {
@@ -183,6 +194,8 @@ export function PipelineViewer({ pipeline, width = "100%", height = 500 }: Pipel
         currentFrameRef.current = 0;
         setCurrentFrame(0);
         setCurrentFrameData(frame0);
+        setLoopStart(0);
+        setLoopEnd(frames > 0 ? frames - 1 : 0);
         setStatus("ready");
       } catch (err) {
         if (signal.aborted) return;
@@ -276,12 +289,15 @@ export function PipelineViewer({ pipeline, width = "100%", height = 500 }: Pipel
       const prov = providerRef.current;
       const total = totalFramesRef.current;
       if (!prov || total <= 1) return;
-      const next = (currentFrameRef.current + 1) % total;
+      const effectiveEnd = Math.min(loopEndRef.current, total - 1);
+      const effectiveStart = Math.max(loopStartRef.current, 0);
+      let next = currentFrameRef.current + 1;
+      if (next > effectiveEnd) next = effectiveStart;
       const frame = prov.getFrame(next);
       currentFrameRef.current = next;
       setCurrentFrame(next);
       setCurrentFrameData(frame);
-    }, 1000 / fpsRef.current);
+    }, 1000 / (fpsRef.current * speedRef.current));
   }, []);
 
   const stopInterval = useCallback(() => {
@@ -328,6 +344,48 @@ export function PipelineViewer({ pipeline, width = "100%", height = 500 }: Pipel
     },
     [playing, startInterval, stopInterval],
   );
+
+  const handleSpeedChange = useCallback(
+    (newSpeed: number) => {
+      setSpeedMultiplier(newSpeed);
+      speedRef.current = newSpeed;
+      if (playing) {
+        stopInterval();
+        startInterval();
+      }
+    },
+    [playing, startInterval, stopInterval],
+  );
+
+  const handleLoopRangeChange = useCallback(
+    (start: number, end: number) => {
+      const cStart = Math.max(0, Math.min(start, totalFrames - 1));
+      const cEnd = Math.max(0, Math.min(end, totalFrames - 1));
+      setLoopStart(cStart);
+      setLoopEnd(cEnd);
+    },
+    [totalFrames],
+  );
+
+  const handleStepForward = useCallback(() => {
+    const prov = providerRef.current;
+    if (!prov) return;
+    const next = Math.min(currentFrameRef.current + 1, loopEndRef.current);
+    const frame = prov.getFrame(next);
+    currentFrameRef.current = next;
+    setCurrentFrame(next);
+    setCurrentFrameData(frame);
+  }, []);
+
+  const handleStepBackward = useCallback(() => {
+    const prov = providerRef.current;
+    if (!prov) return;
+    const prev = Math.max(currentFrameRef.current - 1, loopStartRef.current);
+    const frame = prov.getFrame(prev);
+    currentFrameRef.current = prev;
+    setCurrentFrame(prev);
+    setCurrentFrameData(frame);
+  }, []);
 
   // Cleanup interval on unmount
   useEffect(() => {
@@ -399,9 +457,16 @@ export function PipelineViewer({ pipeline, width = "100%", height = 500 }: Pipel
           totalFrames={totalFrames}
           playing={playing}
           fps={fps}
+          speedMultiplier={speedMultiplier}
+          loopStart={loopStart}
+          loopEnd={loopEnd}
           onSeek={handleSeek}
           onPlayPause={handlePlayPause}
           onFpsChange={handleFpsChange}
+          onSpeedChange={handleSpeedChange}
+          onLoopRangeChange={handleLoopRangeChange}
+          onStepBackward={handleStepBackward}
+          onStepForward={handleStepForward}
         />
       )}
       <Tooltip info={hoverInfo} />

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,27 +1,110 @@
 /**
- * Trajectory playback timeline with play/pause and seek.
+ * Trajectory playback timeline with play/pause, step, seek, speed, loop range,
+ * and keyboard shortcut support (ArrowLeft / ArrowRight to step frames).
  */
+
+import { useEffect, useCallback } from "react";
 
 interface TimelineProps {
   currentFrame: number;
   totalFrames: number;
   playing: boolean;
   fps: number;
+  speedMultiplier: number;
+  loopStart: number;
+  loopEnd: number;
   onSeek: (frame: number) => void;
   onPlayPause: () => void;
   onFpsChange: (fps: number) => void;
+  onSpeedChange: (speed: number) => void;
+  onLoopRangeChange: (start: number, end: number) => void;
+  onStepBackward: () => void;
+  onStepForward: () => void;
 }
+
+const SPEED_OPTIONS = [0.25, 0.5, 1, 2, 4] as const;
+const FPS_OPTIONS = [10, 20, 30, 60] as const;
+
+const buttonStyle: React.CSSProperties = {
+  background: "none",
+  border: "1px solid #e2e8f0",
+  borderRadius: 8,
+  width: 28,
+  height: 28,
+  cursor: "pointer",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  fontSize: 13,
+  color: "#64748b",
+  flexShrink: 0,
+  transition: "all 0.15s",
+  padding: 0,
+};
+
+const selectStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.8)",
+  border: "1px solid #e2e8f0",
+  borderRadius: 6,
+  padding: "2px 4px",
+  fontSize: 12,
+  fontWeight: 500,
+  color: "#64748b",
+  cursor: "pointer",
+  flexShrink: 0,
+};
 
 export function Timeline({
   currentFrame,
   totalFrames,
   playing,
   fps,
+  speedMultiplier,
+  loopStart,
+  loopEnd,
   onSeek,
   onPlayPause,
   onFpsChange,
+  onSpeedChange,
+  onLoopRangeChange,
+  onStepBackward,
+  onStepForward,
 }: TimelineProps) {
+  const handleSliderChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onSeek(parseInt(e.target.value, 10));
+    },
+    [onSeek],
+  );
+
+  // Keyboard shortcuts: ArrowLeft / ArrowRight step one frame
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === "INPUT" || tag === "SELECT" || tag === "TEXTAREA") return;
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        onStepBackward();
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault();
+        onStepForward();
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onStepBackward, onStepForward]);
+
   if (totalFrames <= 1) return null;
+
+  const handleLoopStartChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = parseInt(e.target.value, 10);
+    if (!isNaN(val)) onLoopRangeChange(val, loopEnd);
+  };
+
+  const handleLoopEndChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = parseInt(e.target.value, 10);
+    if (!isNaN(val)) onLoopRangeChange(loopStart, val);
+  };
 
   return (
     <div
@@ -31,7 +114,7 @@ export function Timeline({
         bottom: 0,
         left: 0,
         right: 0,
-        padding: "10px 20px 14px",
+        padding: "8px 16px 12px",
         background: "rgba(255, 255, 255, 0.88)",
         backdropFilter: "blur(16px)",
         WebkitBackdropFilter: "blur(16px)",
@@ -39,48 +122,54 @@ export function Timeline({
         boxShadow: "0 -1px 8px rgba(0,0,0,0.04)",
         display: "flex",
         alignItems: "center",
-        gap: 12,
+        gap: 8,
         zIndex: 10,
         fontSize: 13,
         color: "#64748b",
       }}
     >
-      {/* Play/Pause button */}
+      {/* Step backward */}
+      <button
+        data-testid="step-backward"
+        onClick={onStepBackward}
+        style={buttonStyle}
+        title="Step backward (←)"
+      >
+        ⏮
+      </button>
+
+      {/* Play/Pause */}
       <button
         data-testid="playback-toggle"
         data-playing={playing ? "true" : "false"}
         onClick={onPlayPause}
-        style={{
-          background: "none",
-          border: "1px solid #e2e8f0",
-          borderRadius: 8,
-          width: 32,
-          height: 32,
-          cursor: "pointer",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          fontSize: 14,
-          fontWeight: 500,
-          color: "#64748b",
-          flexShrink: 0,
-          transition: "all 0.15s",
-        }}
+        style={{ ...buttonStyle, width: 32, height: 32, fontSize: 14, fontWeight: 500 }}
         title={playing ? "Pause" : "Play"}
       >
         {playing ? "⏸" : "▶"}
+      </button>
+
+      {/* Step forward */}
+      <button
+        data-testid="step-forward"
+        onClick={onStepForward}
+        style={buttonStyle}
+        title="Step forward (→)"
+      >
+        ⏭
       </button>
 
       {/* Frame counter */}
       <span
         data-testid="frame-counter"
         style={{
-          minWidth: 80,
+          minWidth: 72,
           textAlign: "center",
           fontVariantNumeric: "tabular-nums",
           fontWeight: 500,
           color: "#64748b",
           flexShrink: 0,
+          fontSize: 12,
         }}
       >
         {currentFrame + 1} / {totalFrames}
@@ -93,36 +182,77 @@ export function Timeline({
         min={0}
         max={totalFrames - 1}
         value={currentFrame}
-        onChange={(e) => onSeek(parseInt(e.target.value, 10))}
+        onChange={handleSliderChange}
         style={{
           flex: 1,
           height: 4,
           cursor: "pointer",
           accentColor: "#3b82f6",
+          minWidth: 60,
         }}
       />
+
+      {/* Loop range */}
+      <span style={{ fontSize: 11, color: "#94a3b8", flexShrink: 0 }}>Loop</span>
+      <input
+        data-testid="loop-start"
+        type="number"
+        min={0}
+        max={totalFrames - 1}
+        value={loopStart}
+        onChange={handleLoopStartChange}
+        style={{
+          ...selectStyle,
+          width: 52,
+          textAlign: "center",
+          padding: "2px 4px",
+        }}
+        title="Loop start frame (0-based)"
+      />
+      <span style={{ fontSize: 11, color: "#94a3b8" }}>–</span>
+      <input
+        data-testid="loop-end"
+        type="number"
+        min={0}
+        max={totalFrames - 1}
+        value={loopEnd}
+        onChange={handleLoopEndChange}
+        style={{
+          ...selectStyle,
+          width: 52,
+          textAlign: "center",
+          padding: "2px 4px",
+        }}
+        title="Loop end frame (0-based)"
+      />
+
+      {/* Speed multiplier */}
+      <select
+        data-testid="playback-speed"
+        value={speedMultiplier}
+        onChange={(e) => onSpeedChange(parseFloat(e.target.value))}
+        style={selectStyle}
+        title="Playback speed"
+      >
+        {SPEED_OPTIONS.map((s) => (
+          <option key={s} value={s}>
+            {s}×
+          </option>
+        ))}
+      </select>
 
       {/* FPS selector */}
       <select
         data-testid="playback-fps"
         value={fps}
         onChange={(e) => onFpsChange(parseInt(e.target.value, 10))}
-        style={{
-          background: "rgba(255,255,255,0.8)",
-          border: "1px solid #e2e8f0",
-          borderRadius: 6,
-          padding: "2px 6px",
-          fontSize: 12,
-          fontWeight: 500,
-          color: "#64748b",
-          cursor: "pointer",
-          flexShrink: 0,
-        }}
+        style={selectStyle}
       >
-        <option value={10}>10 fps</option>
-        <option value={20}>20 fps</option>
-        <option value={30}>30 fps</option>
-        <option value={60}>60 fps</option>
+        {FPS_OPTIONS.map((f) => (
+          <option key={f} value={f}>
+            {f} fps
+          </option>
+        ))}
       </select>
     </div>
   );

--- a/src/components/WidgetViewer.tsx
+++ b/src/components/WidgetViewer.tsx
@@ -84,6 +84,12 @@ export function WidgetViewer({
   const playIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const [playing, setPlaying] = useState(false);
   const [fps, setFps] = useState(30);
+  const [speedMultiplier, setSpeedMultiplier] = useState(1);
+  const [loopStart, setLoopStart] = useState(0);
+  const [loopEnd, setLoopEnd] = useState(0);
+  const currentFrameRef = useRef(0);
+  const loopStartRef = useRef(0);
+  const loopEndRef = useRef(0);
   const [hoverInfo, setHoverInfo] = useState<HoverInfo | null>(null);
   const [bondCount, setBondCount] = useState<number>(0);
   const prevViewportStateRef = useRef<ViewportState | null>(null);
@@ -104,6 +110,17 @@ export function WidgetViewer({
   // Keep a ref so handleRendererReady can apply the initial selection
   const selectedAtomsRef = useRef(selectedAtoms);
   selectedAtomsRef.current = selectedAtoms;
+
+  // Keep loop refs in sync with state for use inside setInterval closure
+  currentFrameRef.current = currentFrame;
+  loopStartRef.current = loopStart;
+  loopEndRef.current = loopEnd;
+
+  // Reset loop range when a new trajectory loads
+  useEffect(() => {
+    setLoopStart(0);
+    setLoopEnd(totalFrames > 0 ? totalFrames - 1 : 0);
+  }, [totalFrames]);
 
   // Sync external atom selection from Python
   useEffect(() => {
@@ -270,6 +287,21 @@ export function WidgetViewer({
     [setExternalSelection, pipelineStore],
   );
 
+  const startPlayInterval = useCallback(
+    (intervalFps: number, intervalSpeed: number) => {
+      if (playIntervalRef.current) clearInterval(playIntervalRef.current);
+      playIntervalRef.current = setInterval(() => {
+        const next = currentFrameRef.current + 1;
+        if (next > loopEndRef.current) {
+          onSeek(loopStartRef.current);
+        } else {
+          onSeek(next);
+        }
+      }, 1000 / (intervalFps * intervalSpeed));
+    },
+    [onSeek],
+  );
+
   const handlePlayPause = useCallback(() => {
     setPlaying((prev) => {
       if (prev) {
@@ -279,26 +311,47 @@ export function WidgetViewer({
         }
         return false;
       } else {
-        playIntervalRef.current = setInterval(() => {
-          onSeek(-1);
-        }, 1000 / fps);
+        startPlayInterval(fps, speedMultiplier);
         return true;
       }
     });
-  }, [fps, onSeek]);
+  }, [fps, speedMultiplier, startPlayInterval]);
 
   const handleFpsChange = useCallback(
     (newFps: number) => {
       setFps(newFps);
-      if (playIntervalRef.current) {
-        clearInterval(playIntervalRef.current);
-        playIntervalRef.current = setInterval(() => {
-          onSeek(-1);
-        }, 1000 / newFps);
-      }
+      if (playIntervalRef.current) startPlayInterval(newFps, speedMultiplier);
     },
-    [onSeek],
+    [speedMultiplier, startPlayInterval],
   );
+
+  const handleSpeedChange = useCallback(
+    (newSpeed: number) => {
+      setSpeedMultiplier(newSpeed);
+      if (playIntervalRef.current) startPlayInterval(fps, newSpeed);
+    },
+    [fps, startPlayInterval],
+  );
+
+  const handleLoopRangeChange = useCallback(
+    (start: number, end: number) => {
+      const cStart = Math.max(0, Math.min(start, totalFrames - 1));
+      const cEnd = Math.max(0, Math.min(end, totalFrames - 1));
+      setLoopStart(cStart);
+      setLoopEnd(cEnd);
+    },
+    [totalFrames],
+  );
+
+  const handleStepForward = useCallback(() => {
+    const next = Math.min(currentFrame + 1, loopEndRef.current);
+    onSeek(next);
+  }, [currentFrame, onSeek]);
+
+  const handleStepBackward = useCallback(() => {
+    const prev = Math.max(currentFrame - 1, loopStartRef.current);
+    onSeek(prev);
+  }, [currentFrame, onSeek]);
 
   const handleSeek = useCallback(
     (frame: number) => {
@@ -346,9 +399,16 @@ export function WidgetViewer({
           totalFrames={totalFrames}
           playing={playing}
           fps={fps}
+          speedMultiplier={speedMultiplier}
+          loopStart={loopStart}
+          loopEnd={loopEnd}
           onSeek={handleSeek}
           onPlayPause={handlePlayPause}
           onFpsChange={handleFpsChange}
+          onSpeedChange={handleSpeedChange}
+          onLoopRangeChange={handleLoopRangeChange}
+          onStepBackward={handleStepBackward}
+          onStepForward={handleStepForward}
         />
       )}
       <Tooltip info={hoverInfo} />

--- a/src/components/WidgetViewer.tsx
+++ b/src/components/WidgetViewer.tsx
@@ -290,14 +290,17 @@ export function WidgetViewer({
   const startPlayInterval = useCallback(
     (intervalFps: number, intervalSpeed: number) => {
       if (playIntervalRef.current) clearInterval(playIntervalRef.current);
-      playIntervalRef.current = setInterval(() => {
-        const next = currentFrameRef.current + 1;
-        if (next > loopEndRef.current) {
-          onSeek(loopStartRef.current);
-        } else {
-          onSeek(next);
-        }
-      }, 1000 / (intervalFps * intervalSpeed));
+      playIntervalRef.current = setInterval(
+        () => {
+          const next = currentFrameRef.current + 1;
+          if (next > loopEndRef.current) {
+            onSeek(loopStartRef.current);
+          } else {
+            onSeek(next);
+          }
+        },
+        1000 / (intervalFps * intervalSpeed),
+      );
     },
     [onSeek],
   );

--- a/src/stores/usePlaybackStore.ts
+++ b/src/stores/usePlaybackStore.ts
@@ -12,8 +12,11 @@ export interface PlaybackStore {
   // State
   playing: boolean;
   fps: number;
+  speedMultiplier: number;
   currentFrame: number;
   totalFrames: number;
+  loopStart: number;
+  loopEnd: number;
 
   // Frame delivery
   provider: FrameProvider | null;
@@ -29,6 +32,10 @@ export interface PlaybackStore {
   pause: () => void;
   togglePlayPause: () => void;
   setFps: (fps: number) => void;
+  setSpeedMultiplier: (speed: number) => void;
+  setLoopRange: (start: number, end: number) => void;
+  stepForward: () => void;
+  stepBackward: () => void;
 
   // Internal: called by StreamFrameProvider when async frame arrives
   _onAsyncFrame: (frame: Frame) => void;
@@ -42,8 +49,11 @@ export interface PlaybackStore {
 export const usePlaybackStore = create<PlaybackStore>((set, get) => ({
   playing: false,
   fps: 30,
+  speedMultiplier: 1,
   currentFrame: 0,
   totalFrames: 0,
+  loopStart: 0,
+  loopEnd: 0,
   provider: null,
   currentFrameData: null,
   _currentFrameRef: { current: 0 },
@@ -60,6 +70,8 @@ export const usePlaybackStore = create<PlaybackStore>((set, get) => ({
       currentFrame: 0,
       currentFrameData: frame0,
       playing: false,
+      loopStart: 0,
+      loopEnd: totalFrames > 0 ? totalFrames - 1 : 0,
     });
     state._currentFrameRef.current = 0;
   },
@@ -94,15 +106,48 @@ export const usePlaybackStore = create<PlaybackStore>((set, get) => ({
 
   setFps: (fps) => {
     set({ fps });
-    // Restart interval if playing
     if (get().playing) {
       get()._stopInterval();
       get()._startInterval();
     }
   },
 
+  setSpeedMultiplier: (speed) => {
+    set({ speedMultiplier: speed });
+    if (get().playing) {
+      get()._stopInterval();
+      get()._startInterval();
+    }
+  },
+
+  setLoopRange: (start, end) => {
+    const { totalFrames } = get();
+    const clampedStart = Math.max(0, Math.min(start, totalFrames - 1));
+    const clampedEnd = Math.max(0, Math.min(end, totalFrames - 1));
+    set({ loopStart: clampedStart, loopEnd: clampedEnd });
+  },
+
+  stepForward: () => {
+    const { provider, currentFrame, loopEnd, totalFrames, _currentFrameRef } = get();
+    if (!provider) return;
+    const effectiveEnd = Math.min(loopEnd, totalFrames - 1);
+    const next = Math.min(currentFrame + 1, effectiveEnd);
+    const frame = provider.getFrame(next);
+    _currentFrameRef.current = next;
+    set({ currentFrame: next, currentFrameData: frame });
+  },
+
+  stepBackward: () => {
+    const { provider, currentFrame, loopStart, _currentFrameRef } = get();
+    if (!provider) return;
+    const effectiveStart = Math.max(loopStart, 0);
+    const prev = Math.max(currentFrame - 1, effectiveStart);
+    const frame = provider.getFrame(prev);
+    _currentFrameRef.current = prev;
+    set({ currentFrame: prev, currentFrameData: frame });
+  },
+
   _onAsyncFrame: (frame) => {
-    // Called by StreamFrameProvider when a requested frame arrives
     const { currentFrame } = get();
     if (frame.frameId === currentFrame) {
       set({ currentFrameData: frame });
@@ -113,13 +158,16 @@ export const usePlaybackStore = create<PlaybackStore>((set, get) => ({
     const state = get();
     if (state._intervalId !== null) return;
     const id = setInterval(() => {
-      const { totalFrames, _currentFrameRef, provider } = get();
+      const { totalFrames, loopStart, loopEnd, _currentFrameRef, provider } = get();
       if (!provider || totalFrames <= 1) return;
-      const nextFrame = (_currentFrameRef.current + 1) % totalFrames;
+      const effectiveEnd = Math.min(loopEnd, totalFrames - 1);
+      const effectiveStart = Math.max(loopStart, 0);
+      let nextFrame = _currentFrameRef.current + 1;
+      if (nextFrame > effectiveEnd) nextFrame = effectiveStart;
       const frame = provider.getFrame(nextFrame);
       _currentFrameRef.current = nextFrame;
       set({ currentFrame: nextFrame, currentFrameData: frame });
-    }, 1000 / state.fps);
+    }, 1000 / (state.fps * state.speedMultiplier));
     set({ _intervalId: id });
   },
 

--- a/src/stores/usePlaybackStore.ts
+++ b/src/stores/usePlaybackStore.ts
@@ -157,17 +157,20 @@ export const usePlaybackStore = create<PlaybackStore>((set, get) => ({
   _startInterval: () => {
     const state = get();
     if (state._intervalId !== null) return;
-    const id = setInterval(() => {
-      const { totalFrames, loopStart, loopEnd, _currentFrameRef, provider } = get();
-      if (!provider || totalFrames <= 1) return;
-      const effectiveEnd = Math.min(loopEnd, totalFrames - 1);
-      const effectiveStart = Math.max(loopStart, 0);
-      let nextFrame = _currentFrameRef.current + 1;
-      if (nextFrame > effectiveEnd) nextFrame = effectiveStart;
-      const frame = provider.getFrame(nextFrame);
-      _currentFrameRef.current = nextFrame;
-      set({ currentFrame: nextFrame, currentFrameData: frame });
-    }, 1000 / (state.fps * state.speedMultiplier));
+    const id = setInterval(
+      () => {
+        const { totalFrames, loopStart, loopEnd, _currentFrameRef, provider } = get();
+        if (!provider || totalFrames <= 1) return;
+        const effectiveEnd = Math.min(loopEnd, totalFrames - 1);
+        const effectiveStart = Math.max(loopStart, 0);
+        let nextFrame = _currentFrameRef.current + 1;
+        if (nextFrame > effectiveEnd) nextFrame = effectiveStart;
+        const frame = provider.getFrame(nextFrame);
+        _currentFrameRef.current = nextFrame;
+        set({ currentFrame: nextFrame, currentFrameData: frame });
+      },
+      1000 / (state.fps * state.speedMultiplier),
+    );
     set({ _intervalId: id });
   },
 

--- a/tests/ts/components/Timeline.test.tsx
+++ b/tests/ts/components/Timeline.test.tsx
@@ -7,14 +7,22 @@ const defaultProps = {
   totalFrames: 100,
   playing: false,
   fps: 30,
+  speedMultiplier: 1,
+  loopStart: 0,
+  loopEnd: 99,
   onSeek: vi.fn(),
   onPlayPause: vi.fn(),
   onFpsChange: vi.fn(),
+  onSpeedChange: vi.fn(),
+  onLoopRangeChange: vi.fn(),
+  onStepBackward: vi.fn(),
+  onStepForward: vi.fn(),
 };
 
 describe("Timeline", () => {
   afterEach(() => {
     cleanup();
+    vi.clearAllMocks();
   });
 
   it("returns null when totalFrames <= 1", () => {
@@ -56,7 +64,7 @@ describe("Timeline", () => {
   });
 
   it("renders seek slider with correct range", () => {
-    render(<Timeline {...defaultProps} currentFrame={10} totalFrames={50} />);
+    render(<Timeline {...defaultProps} currentFrame={10} totalFrames={50} loopEnd={49} />);
     const slider = screen.getByRole("slider");
     expect(slider).toHaveAttribute("min", "0");
     expect(slider).toHaveAttribute("max", "49");
@@ -73,7 +81,92 @@ describe("Timeline", () => {
 
   it("renders FPS selector with options", () => {
     render(<Timeline {...defaultProps} fps={30} />);
-    const select = screen.getByRole("combobox");
+    const select = screen.getByTestId("playback-fps");
     expect(select).toHaveValue("30");
+  });
+
+  it("renders step backward button", () => {
+    render(<Timeline {...defaultProps} />);
+    expect(screen.getByTestId("step-backward")).toBeInTheDocument();
+  });
+
+  it("renders step forward button", () => {
+    render(<Timeline {...defaultProps} />);
+    expect(screen.getByTestId("step-forward")).toBeInTheDocument();
+  });
+
+  it("calls onStepBackward when step-backward is clicked", () => {
+    const onStepBackward = vi.fn();
+    render(<Timeline {...defaultProps} onStepBackward={onStepBackward} />);
+    fireEvent.click(screen.getByTestId("step-backward"));
+    expect(onStepBackward).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onStepForward when step-forward is clicked", () => {
+    const onStepForward = vi.fn();
+    render(<Timeline {...defaultProps} onStepForward={onStepForward} />);
+    fireEvent.click(screen.getByTestId("step-forward"));
+    expect(onStepForward).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders speed selector with correct value", () => {
+    render(<Timeline {...defaultProps} speedMultiplier={2} />);
+    const select = screen.getByTestId("playback-speed");
+    expect(select).toHaveValue("2");
+  });
+
+  it("calls onSpeedChange when speed selector changes", () => {
+    const onSpeedChange = vi.fn();
+    render(<Timeline {...defaultProps} onSpeedChange={onSpeedChange} />);
+    fireEvent.change(screen.getByTestId("playback-speed"), { target: { value: "0.5" } });
+    expect(onSpeedChange).toHaveBeenCalledWith(0.5);
+  });
+
+  it("renders loop start input with correct value", () => {
+    render(<Timeline {...defaultProps} loopStart={5} />);
+    const input = screen.getByTestId("loop-start");
+    expect(input).toHaveValue(5);
+  });
+
+  it("renders loop end input with correct value", () => {
+    render(<Timeline {...defaultProps} loopEnd={80} />);
+    const input = screen.getByTestId("loop-end");
+    expect(input).toHaveValue(80);
+  });
+
+  it("calls onLoopRangeChange when loop-start changes", () => {
+    const onLoopRangeChange = vi.fn();
+    render(<Timeline {...defaultProps} loopStart={0} loopEnd={99} onLoopRangeChange={onLoopRangeChange} />);
+    fireEvent.change(screen.getByTestId("loop-start"), { target: { value: "10" } });
+    expect(onLoopRangeChange).toHaveBeenCalledWith(10, 99);
+  });
+
+  it("calls onLoopRangeChange when loop-end changes", () => {
+    const onLoopRangeChange = vi.fn();
+    render(<Timeline {...defaultProps} loopStart={0} loopEnd={99} onLoopRangeChange={onLoopRangeChange} />);
+    fireEvent.change(screen.getByTestId("loop-end"), { target: { value: "50" } });
+    expect(onLoopRangeChange).toHaveBeenCalledWith(0, 50);
+  });
+
+  it("calls onStepBackward on ArrowLeft key press", () => {
+    const onStepBackward = vi.fn();
+    render(<Timeline {...defaultProps} onStepBackward={onStepBackward} />);
+    fireEvent.keyDown(document, { key: "ArrowLeft" });
+    expect(onStepBackward).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onStepForward on ArrowRight key press", () => {
+    const onStepForward = vi.fn();
+    render(<Timeline {...defaultProps} onStepForward={onStepForward} />);
+    fireEvent.keyDown(document, { key: "ArrowRight" });
+    expect(onStepForward).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call step on ArrowLeft when focus is in an input", () => {
+    const onStepBackward = vi.fn();
+    render(<Timeline {...defaultProps} onStepBackward={onStepBackward} />);
+    const input = screen.getByTestId("loop-start");
+    fireEvent.keyDown(input, { key: "ArrowLeft", target: input });
+    expect(onStepBackward).not.toHaveBeenCalled();
   });
 });

--- a/tests/ts/stores/usePlaybackStore.test.ts
+++ b/tests/ts/stores/usePlaybackStore.test.ts
@@ -32,8 +32,11 @@ describe("usePlaybackStore", () => {
     usePlaybackStore.setState({
       playing: false,
       fps: 30,
+      speedMultiplier: 1,
       currentFrame: 0,
       totalFrames: 0,
+      loopStart: 0,
+      loopEnd: 0,
       provider: null,
       currentFrameData: null,
       _intervalId: null,
@@ -50,8 +53,11 @@ describe("usePlaybackStore", () => {
     const state = usePlaybackStore.getState();
     expect(state.playing).toBe(false);
     expect(state.fps).toBe(30);
+    expect(state.speedMultiplier).toBe(1);
     expect(state.currentFrame).toBe(0);
     expect(state.totalFrames).toBe(0);
+    expect(state.loopStart).toBe(0);
+    expect(state.loopEnd).toBe(0);
     expect(state.provider).toBeNull();
     expect(state.currentFrameData).toBeNull();
   });
@@ -65,6 +71,13 @@ describe("usePlaybackStore", () => {
       expect(state.totalFrames).toBe(10);
       expect(state.currentFrame).toBe(0);
       expect(state.currentFrameData).not.toBeNull();
+    });
+
+    it("resets loopStart and loopEnd to full range", () => {
+      usePlaybackStore.getState().setProvider(makeProvider(10));
+      const state = usePlaybackStore.getState();
+      expect(state.loopStart).toBe(0);
+      expect(state.loopEnd).toBe(9);
     });
 
     it("clears state when provider is null", () => {
@@ -136,6 +149,90 @@ describe("usePlaybackStore", () => {
     });
   });
 
+  describe("setSpeedMultiplier", () => {
+    it("updates speedMultiplier", () => {
+      usePlaybackStore.getState().setSpeedMultiplier(2);
+      expect(usePlaybackStore.getState().speedMultiplier).toBe(2);
+    });
+
+    it("restarts interval if playing", () => {
+      usePlaybackStore.getState().setProvider(makeProvider(10));
+      usePlaybackStore.getState().play();
+      const idBefore = usePlaybackStore.getState()._intervalId;
+      usePlaybackStore.getState().setSpeedMultiplier(2);
+      const idAfter = usePlaybackStore.getState()._intervalId;
+      expect(idAfter).not.toBe(idBefore);
+    });
+
+    it("does not restart interval if not playing", () => {
+      usePlaybackStore.getState().setProvider(makeProvider(10));
+      usePlaybackStore.getState().setSpeedMultiplier(2);
+      expect(usePlaybackStore.getState()._intervalId).toBeNull();
+    });
+  });
+
+  describe("setLoopRange", () => {
+    it("updates loopStart and loopEnd", () => {
+      usePlaybackStore.getState().setProvider(makeProvider(10));
+      usePlaybackStore.getState().setLoopRange(2, 7);
+      const state = usePlaybackStore.getState();
+      expect(state.loopStart).toBe(2);
+      expect(state.loopEnd).toBe(7);
+    });
+
+    it("clamps values to valid range", () => {
+      usePlaybackStore.getState().setProvider(makeProvider(10));
+      usePlaybackStore.getState().setLoopRange(-5, 50);
+      const state = usePlaybackStore.getState();
+      expect(state.loopStart).toBe(0);
+      expect(state.loopEnd).toBe(9);
+    });
+  });
+
+  describe("stepForward", () => {
+    it("advances by one frame", () => {
+      usePlaybackStore.getState().setProvider(makeProvider(10));
+      usePlaybackStore.getState().seekFrame(3);
+      usePlaybackStore.getState().stepForward();
+      expect(usePlaybackStore.getState().currentFrame).toBe(4);
+    });
+
+    it("clamps at loopEnd", () => {
+      usePlaybackStore.getState().setProvider(makeProvider(10));
+      usePlaybackStore.getState().setLoopRange(0, 5);
+      usePlaybackStore.getState().seekFrame(5);
+      usePlaybackStore.getState().stepForward();
+      expect(usePlaybackStore.getState().currentFrame).toBe(5);
+    });
+
+    it("does nothing without provider", () => {
+      usePlaybackStore.getState().stepForward();
+      expect(usePlaybackStore.getState().currentFrame).toBe(0);
+    });
+  });
+
+  describe("stepBackward", () => {
+    it("goes back by one frame", () => {
+      usePlaybackStore.getState().setProvider(makeProvider(10));
+      usePlaybackStore.getState().seekFrame(5);
+      usePlaybackStore.getState().stepBackward();
+      expect(usePlaybackStore.getState().currentFrame).toBe(4);
+    });
+
+    it("clamps at loopStart", () => {
+      usePlaybackStore.getState().setProvider(makeProvider(10));
+      usePlaybackStore.getState().setLoopRange(3, 9);
+      usePlaybackStore.getState().seekFrame(3);
+      usePlaybackStore.getState().stepBackward();
+      expect(usePlaybackStore.getState().currentFrame).toBe(3);
+    });
+
+    it("does nothing without provider", () => {
+      usePlaybackStore.getState().stepBackward();
+      expect(usePlaybackStore.getState().currentFrame).toBe(0);
+    });
+  });
+
   describe("interval playback", () => {
     it("advances frames on interval tick", () => {
       usePlaybackStore.getState().setProvider(makeProvider(5));
@@ -147,14 +244,36 @@ describe("usePlaybackStore", () => {
       expect(usePlaybackStore.getState().currentFrame).toBe(1);
     });
 
-    it("wraps around at end", () => {
-      usePlaybackStore.getState().setProvider(makeProvider(3));
+    it("wraps around at loopEnd", () => {
+      usePlaybackStore.getState().setProvider(makeProvider(5));
       usePlaybackStore.getState().play();
       const interval = 1000 / 30;
 
-      // Advance through all frames: 0→1→2→0
-      vi.advanceTimersByTime(interval * 3 + 1);
+      // 0→1→2→3→4→0 (5 frames, wraps)
+      vi.advanceTimersByTime(interval * 5 + 1);
       expect(usePlaybackStore.getState().currentFrame).toBe(0);
+    });
+
+    it("respects custom loop range", () => {
+      usePlaybackStore.getState().setProvider(makeProvider(10));
+      usePlaybackStore.getState().setLoopRange(2, 4);
+      usePlaybackStore.getState().seekFrame(2);
+      usePlaybackStore.getState().play();
+      const interval = 1000 / 30;
+
+      // 2→3→4→2 (loop between 2 and 4)
+      vi.advanceTimersByTime(interval * 3 + 1);
+      expect(usePlaybackStore.getState().currentFrame).toBe(2);
+    });
+
+    it("advances faster with speedMultiplier > 1", () => {
+      usePlaybackStore.getState().setProvider(makeProvider(10));
+      usePlaybackStore.getState().setSpeedMultiplier(2);
+      usePlaybackStore.getState().play();
+
+      // At 2× speed with 30fps, interval = 1000/(30*2) ≈ 16.7ms
+      vi.advanceTimersByTime(17);
+      expect(usePlaybackStore.getState().currentFrame).toBe(1);
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #368.

Extends the trajectory playback timeline with finer-grained controls requested in issue #368:

- **Step buttons** (⏮ / ⏭): click to advance or rewind by one frame. Keyboard shortcuts `ArrowLeft` / `ArrowRight` work when focus is not in a text input.
- **Speed multiplier** (0.25×, 0.5×, 1×, 2×, 4×): decoupled from the FPS selector — speed changes the interval timing independently.
- **Loop range inputs**: two number inputs (start frame / end frame) constrain playback so it wraps back to the start frame when the end frame is reached, instead of looping from frame 0.

Changes touch all three viewers:
- `usePlaybackStore` gains `speedMultiplier`, `loopStart`, `loopEnd`, `setSpeedMultiplier`, `setLoopRange`, `stepForward`, `stepBackward` actions. The playback interval respects both speed and loop range.
- `PipelineViewer` (local-state player) and `WidgetViewer` receive matching local state + refs and pass the new props through.
- `MeganeViewer` wires the new store selectors to `Timeline`.

## Test plan

- [x] 22 `Timeline` unit tests — step buttons, speed selector, loop range inputs, keyboard shortcuts
- [x] 29 `usePlaybackStore` unit tests — new actions, speed multiplier interval, custom loop range wrap
- [x] `npx vitest run` (affected tests) — 51/51 green
- [x] `npx tsc --noEmit` — no type errors
- [x] Patch coverage 96.81 % (≥ 70 % required by Codecov)

https://claude.ai/code/session_0167JxDXa7TPSsA6bfDrJgTk

---
_Generated by [Claude Code](https://claude.ai/code/session_0167JxDXa7TPSsA6bfDrJgTk)_