### PR TITLE
feat: add Surface Mesh template (OVITO-style alpha-shape envelope)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,7 @@ import { MemoryFrameProvider } from "./pipeline/types";
 import defaultPDB from "../tests/fixtures/caffeine_water.pdb?raw";
 import defaultXtcUrl from "../tests/fixtures/caffeine_water_vibration.xtc?url";
 import perovskiteXYZ from "../tests/fixtures/perovskite_srtio3_3x3x3.xyz?raw";
+import quartzXYZ from "../tests/fixtures/quartz_sio2_2x2x2.xyz?raw";
 import ubiquitinPDB from "../tests/fixtures/1ubq.pdb?raw";
 import "./styles/megane.css";
 import { useThemeStore } from "./stores/useThemeStore";
@@ -90,6 +91,8 @@ function App() {
         await ds.local.loadXtc(xtcFile);
       } else if (pendingTemplateId === "solid") {
         await ds.local.loadText(perovskiteXYZ, "perovskite_srtio3_3x3x3.xyz");
+      } else if (pendingTemplateId === "surface_mesh") {
+        await ds.local.loadText(quartzXYZ, "quartz_sio2_2x2x2.xyz");
       } else if (pendingTemplateId === "protein") {
         await ds.local.loadText(ubiquitinPDB, "1ubq.pdb");
       } else if (pendingTemplateId === "streaming") {

--- a/src/pipeline/templates.ts
+++ b/src/pipeline/templates.ts
@@ -243,6 +243,94 @@ function createSolidTemplate(): {
 }
 
 /**
+ * Surface mesh template: quartz SiO2 wrapped in an OVITO-style alpha-shape
+ * surface mesh.
+ * LoadStructure → SurfaceMesh → Viewport (mesh)
+ *              → Viewport (particle, cell)
+ */
+function createSurfaceMeshTemplate(): {
+  nodes: Node<PipelineNodeData>[];
+  edges: Edge[];
+} {
+  return {
+    nodes: [
+      {
+        id: "loader-1",
+        type: "load_structure",
+        position: { x: 425, y: 0 },
+        data: {
+          params: {
+            type: "load_structure",
+            fileName: "quartz_sio2_2x2x2.xyz",
+            hasTrajectory: false,
+            hasCell: true,
+          },
+          enabled: true,
+        },
+      },
+      {
+        id: "surface-1",
+        type: "surface_mesh",
+        position: { x: 680, y: 310 },
+        data: {
+          params: {
+            type: "surface_mesh",
+            alphaRadius: 3.0,
+            color: "#4488ff",
+            opacity: 0.5,
+          },
+          enabled: true,
+        },
+      },
+      {
+        id: "viewport-1",
+        type: "viewport",
+        position: { x: 425, y: 615 },
+        data: {
+          params: {
+            type: "viewport",
+            perspective: false,
+            cellAxesVisible: true,
+            pivotMarkerVisible: true,
+          },
+          enabled: true,
+        },
+      },
+    ],
+    edges: [
+      {
+        id: "e1",
+        source: "loader-1",
+        target: "surface-1",
+        sourceHandle: "particle",
+        targetHandle: "particle",
+      },
+      {
+        id: "e2",
+        source: "loader-1",
+        target: "viewport-1",
+        sourceHandle: "particle",
+        targetHandle: "particle",
+      },
+      {
+        id: "e3",
+        source: "loader-1",
+        target: "viewport-1",
+        sourceHandle: "cell",
+        targetHandle: "cell",
+      },
+      {
+        id: "e4",
+        source: "surface-1",
+        target: "viewport-1",
+        sourceHandle: "mesh",
+        targetHandle: "mesh",
+      },
+    ],
+  };
+}
+
+/**
  * Streaming template: WebSocket streaming with bonds and trajectory.
  * Streaming → Viewport (particle, bond, trajectory, cell)
  */
@@ -495,6 +583,12 @@ export const PIPELINE_TEMPLATES: PipelineTemplate[] = [
     label: "Solid",
     description: "Perovskite with coordination polyhedra",
     create: createSolidTemplate,
+  },
+  {
+    id: "surface_mesh",
+    label: "Surface Mesh",
+    description: "Quartz SiO2 with OVITO-style alpha-shape surface envelope",
+    create: createSurfaceMeshTemplate,
   },
   {
     id: "protein",

--- a/tests/ts/pipeline/templates.test.ts
+++ b/tests/ts/pipeline/templates.test.ts
@@ -5,6 +5,7 @@ import type {
   FilterParams,
   ModifyParams,
   RepresentationParams,
+  SurfaceMeshParams,
 } from "@/pipeline/types";
 
 describe("PIPELINE_TEMPLATES", () => {
@@ -88,5 +89,57 @@ describe("PIPELINE_TEMPLATES protein", () => {
     const rep = nodes.find((n) => n.type === "representation");
     expect(rep).toBeDefined();
     expect((rep!.data.params as RepresentationParams).mode).toBe("both");
+  });
+});
+
+describe("PIPELINE_TEMPLATES surface mesh", () => {
+  const surface = PIPELINE_TEMPLATES.find((t) => t.id === "surface_mesh");
+
+  it("is registered", () => {
+    expect(surface).toBeDefined();
+  });
+
+  it("loads the quartz_sio2_2x2x2.xyz fixture with cell metadata", () => {
+    const { nodes } = surface!.create();
+    const loader = nodes.find((n) => n.type === "load_structure");
+    expect(loader).toBeDefined();
+    const params = loader!.data.params as LoadStructureParams;
+    expect(params.fileName).toBe("quartz_sio2_2x2x2.xyz");
+    expect(params.hasCell).toBe(true);
+  });
+
+  it("includes a surface_mesh node with documented default params", () => {
+    const { nodes } = surface!.create();
+    const mesh = nodes.find((n) => n.type === "surface_mesh");
+    expect(mesh).toBeDefined();
+    const params = mesh!.data.params as SurfaceMeshParams;
+    expect(params.alphaRadius).toBe(3.0);
+    expect(params.color).toBe("#4488ff");
+    expect(params.opacity).toBe(0.5);
+  });
+
+  it("wires loader→surface_mesh on particle and surface_mesh→viewport on mesh", () => {
+    const { nodes, edges } = surface!.create();
+    const loader = nodes.find((n) => n.type === "load_structure")!;
+    const mesh = nodes.find((n) => n.type === "surface_mesh")!;
+    const viewport = nodes.find((n) => n.type === "viewport")!;
+
+    const loaderToMesh = edges.find(
+      (e) =>
+        e.source === loader.id &&
+        e.target === mesh.id &&
+        e.sourceHandle === "particle" &&
+        e.targetHandle === "particle",
+    );
+    expect(loaderToMesh).toBeDefined();
+
+    const meshToViewport = edges.find(
+      (e) =>
+        e.source === mesh.id &&
+        e.target === viewport.id &&
+        e.sourceHandle === "mesh" &&
+        e.targetHandle === "mesh",
+    );
+    expect(meshToViewport).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

- Adds a fifth pipeline template, **Surface Mesh**, that loads `quartz_sio2_2x2x2.xyz` and wraps the atoms in a semi-transparent alpha-shape envelope using the recently added OVITO-style surface mesh node.
- Pipeline shape: `LoadStructure → SurfaceMesh ── mesh ──> Viewport` (plus loader → viewport for `particle` / `cell`). Default mesh params match the `SurfaceMeshNode` UI defaults: `alphaRadius=3.0`, `color=#4488ff`, `opacity=0.5`.
- Inserts the entry between `solid` and `protein` in the dropdown so the mesh-producing templates sit together (molecule → solid → surface_mesh → protein → streaming).
- Wires the quartz fixture into the webapp's pre-loaded fixtures (`src/index.tsx`) alongside the existing template fixtures.

## Files touched

- `src/pipeline/templates.ts` — new `createSurfaceMeshTemplate()` factory + `PIPELINE_TEMPLATES` entry.
- `src/index.tsx` — `?raw` import for `quartz_sio2_2x2x2.xyz` and a dispatch branch for the new `pendingTemplateId`.
- `tests/ts/pipeline/templates.test.ts` — `PIPELINE_TEMPLATES surface mesh` describe block covering registration, fixture, default params, and edge wiring.

## Visual confirmation

Applied the template in the standalone webapp; the SiO₂ atoms render inside a smooth blue alpha-shape envelope with the pipeline editor showing `LoadStructure → SurfaceMesh → Viewport`. No console / pageerror events.

## Test plan

- [x] `npm run build:wasm` (WASM rebuilt for this change)
- [x] `npm test` — 1168/1168 pass; `templates.ts` reaches 100 % statement / branch / function / line coverage (well above the 70 % Codecov gate).
- [x] `npm run test:e2e:webapp` — 4/4 pass.
- [x] `npm run test:e2e:pipeline-editor` (excluding the pre-existing `Render button mounts RenderModal` failure that also reproduces on `main` without these changes).
- [x] Visual: opened the dropdown in the webapp and confirmed the surface mesh wraps the quartz lattice as expected; saved a screenshot during verification.
- [x] `format-loading` failures observed during the run reproduce on `main` without these changes (unrelated to this PR).

No baseline PNGs moved (no committed Playwright spec exercises the Templates dropdown contents).

https://claude.ai/code/session_01SAw1RbKAXZjGhuaG4NLtGe

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAw1RbKAXZjGhuaG4NLtGe)_