### PR TITLE
feat(top): resolve nested #include directives in GROMACS topology parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,22 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -21,10 +33,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "indoc"
@@ -52,10 +138,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "matrixmultiply"
@@ -72,6 +176,7 @@ name = "megane-core"
 version = "0.7.0"
 dependencies = [
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -187,6 +292,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,10 +401,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -345,16 +485,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -399,6 +576,149 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/crates/megane-core/Cargo.toml
+++ b/crates/megane-core/Cargo.toml
@@ -9,3 +9,6 @@ repository = "https://github.com/hodakamori/megane"
 
 [dependencies]
 serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/megane-core/src/top.rs
+++ b/crates/megane-core/src/top.rs
@@ -64,11 +64,9 @@ fn parse_include_directive(line: &str) -> Option<String> {
         return None;
     }
     let rest = trimmed["#include".len()..].trim();
-    if rest.starts_with('"') {
-        let inner = &rest[1..];
+    if let Some(inner) = rest.strip_prefix('"') {
         inner.find('"').map(|end| inner[..end].to_string())
-    } else if rest.starts_with('<') {
-        let inner = &rest[1..];
+    } else if let Some(inner) = rest.strip_prefix('<') {
         inner.find('>').map(|end| inner[..end].to_string())
     } else {
         None
@@ -208,8 +206,7 @@ pub fn parse_top_bonds_from_path(path: &str, n_atoms: usize) -> Result<Vec<(u32,
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_else(|| ".".to_string());
 
-    let text = std::fs::read_to_string(path)
-        .map_err(|e| format!("Cannot read {path}: {e}"))?;
+    let text = std::fs::read_to_string(path).map_err(|e| format!("Cannot read {path}: {e}"))?;
 
     let fs = RealTopFileSystem { base_dir };
     parse_top_bonds_with_fs(&text, &fs, n_atoms)
@@ -303,10 +300,7 @@ protein  3
     #[test]
     fn test_vfs_flat_include() {
         // molecule.itp provides the [ bonds ] section
-        let vfs = make_vfs(&[(
-            "molecule.itp",
-            "[ bonds ]\n1 2 1\n2 3 1\n",
-        )]);
+        let vfs = make_vfs(&[("molecule.itp", "[ bonds ]\n1 2 1\n2 3 1\n")]);
         let top = r#"#include "molecule.itp""#;
         let bonds = parse_top_bonds_with_fs(top, &vfs, 10).unwrap();
         assert_eq!(bonds.len(), 2);
@@ -360,8 +354,8 @@ protein  3
         // Bonds from main file: (0,1)
         // After include expansion the extra section follows; parser sees two [ bonds ] sections.
         // The second occurrence resets in_bonds_section = true, so both are collected.
-        assert!(bonds.iter().any(|&b| b == (0, 1)));
-        assert!(bonds.iter().any(|&b| b == (2, 3)));
+        assert!(bonds.contains(&(0, 1)));
+        assert!(bonds.contains(&(2, 3)));
     }
 
     #[test]
@@ -391,12 +385,11 @@ protein  3
         let itp_path = dir.path().join("mol.itp");
         fs::write(&itp_path, "[ bonds ]\n1 2 1\n2 3 1\n").unwrap();
 
-        let top_content = format!("#include \"mol.itp\"\n");
+        let top_content = "#include \"mol.itp\"\n".to_string();
         let top_path = dir.path().join("system.top");
         fs::write(&top_path, top_content).unwrap();
 
-        let bonds =
-            parse_top_bonds_from_path(top_path.to_str().unwrap(), 10).unwrap();
+        let bonds = parse_top_bonds_from_path(top_path.to_str().unwrap(), 10).unwrap();
         assert_eq!(bonds.len(), 2);
         assert_eq!(bonds[0], (0, 1));
         assert_eq!(bonds[1], (1, 2));

--- a/crates/megane-core/src/top.rs
+++ b/crates/megane-core/src/top.rs
@@ -1,9 +1,130 @@
-/// GROMACS .top topology file parser.
+/// GROMACS .top / .itp topology file parser.
 ///
-/// Extracts bond pairs from the [ bonds ] section.
+/// Parses bond pairs from the [ bonds ] section and resolves
+/// `#include` directives so that real-world multi-file topologies work.
+use std::collections::HashMap;
+
+// ── Virtual filesystem abstraction ────────────────────────────────────────────
+
+/// Abstraction over a filesystem used to resolve `#include` directives.
 ///
-/// Parse a GROMACS .top file and extract bond pairs.
-/// Returns Vec<(u32, u32)> with 0-indexed atom pairs.
+/// Implement this trait to provide custom include resolution (e.g. for
+/// WASM/browser contexts where real I/O is not available).
+pub trait TopFileSystem {
+    /// Return the contents of `path`, or `None` if the file does not exist.
+    fn read(&self, path: &str) -> Option<String>;
+}
+
+/// A [`TopFileSystem`] backed by the real OS filesystem.
+///
+/// Include paths are resolved relative to `base_dir` first, then tried as
+/// absolute paths.
+#[cfg(not(target_arch = "wasm32"))]
+pub struct RealTopFileSystem {
+    /// Directory of the top-level `.top` file.
+    pub base_dir: String,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl TopFileSystem for RealTopFileSystem {
+    fn read(&self, path: &str) -> Option<String> {
+        let in_base = std::path::Path::new(&self.base_dir).join(path);
+        std::fs::read_to_string(&in_base)
+            .or_else(|_| std::fs::read_to_string(path))
+            .ok()
+    }
+}
+
+/// A [`TopFileSystem`] backed by an in-memory map of path → content.
+///
+/// Used in WASM/browser contexts where caller provides all included file
+/// contents upfront.
+pub struct VirtualTopFileSystem {
+    files: HashMap<String, String>,
+}
+
+impl VirtualTopFileSystem {
+    pub fn new(files: HashMap<String, String>) -> Self {
+        Self { files }
+    }
+}
+
+impl TopFileSystem for VirtualTopFileSystem {
+    fn read(&self, path: &str) -> Option<String> {
+        self.files.get(path).cloned()
+    }
+}
+
+// ── Include resolution ─────────────────────────────────────────────────────────
+
+/// Extract the include path from a `#include "path"` or `#include <path>` line.
+fn parse_include_directive(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    if !trimmed.starts_with("#include") {
+        return None;
+    }
+    let rest = trimmed["#include".len()..].trim();
+    if rest.starts_with('"') {
+        let inner = &rest[1..];
+        inner.find('"').map(|end| inner[..end].to_string())
+    } else if rest.starts_with('<') {
+        let inner = &rest[1..];
+        inner.find('>').map(|end| inner[..end].to_string())
+    } else {
+        None
+    }
+}
+
+/// Recursively expand `#include` directives in `text`, using `fs` to read
+/// included files.  `include_stack` tracks the current include chain so that
+/// circular includes can be detected.
+///
+/// Missing includes are passed through as-is (silently skipped for bond
+/// parsing), which matches how system forcefield includes work in practice.
+fn expand_includes<F: TopFileSystem>(
+    text: &str,
+    fs: &F,
+    include_stack: &mut Vec<String>,
+) -> Result<String, String> {
+    let mut result = String::with_capacity(text.len());
+
+    for line in text.lines() {
+        if let Some(include_path) = parse_include_directive(line) {
+            if include_stack.contains(&include_path) {
+                return Err(format!(
+                    "Circular include detected: {} -> {}",
+                    include_stack.join(" -> "),
+                    include_path
+                ));
+            }
+            match fs.read(&include_path) {
+                Some(included_text) => {
+                    include_stack.push(include_path.clone());
+                    let expanded = expand_includes(&included_text, fs, include_stack)?;
+                    include_stack.pop();
+                    result.push_str(&expanded);
+                    result.push('\n');
+                }
+                None => {
+                    // Missing include (e.g. system forcefield files) — skip silently.
+                }
+            }
+        } else {
+            result.push_str(line);
+            result.push('\n');
+        }
+    }
+
+    Ok(result)
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Parse a GROMACS `.top` / `.itp` text and extract bond pairs.
+///
+/// Returns `Vec<(a, b)>` with 0-indexed atom pairs where `a < b`.
+/// `#include` directives are **not** resolved; pass pre-expanded text or use
+/// [`parse_top_bonds_with_fs`] / [`parse_top_bonds_from_path`] instead.
 pub fn parse_top_bonds(text: &str, n_atoms: usize) -> Vec<(u32, u32)> {
     let mut bonds = Vec::new();
     let mut in_bonds_section = false;
@@ -11,12 +132,10 @@ pub fn parse_top_bonds(text: &str, n_atoms: usize) -> Vec<(u32, u32)> {
     for line in text.lines() {
         let trimmed = line.trim();
 
-        // Skip empty lines and comments
-        if trimmed.is_empty() || trimmed.starts_with(';') {
+        if trimmed.is_empty() || trimmed.starts_with(';') || trimmed.starts_with('#') {
             continue;
         }
 
-        // Check for section headers
         if trimmed.starts_with('[') {
             let section_name = trimmed
                 .trim_start_matches('[')
@@ -31,8 +150,6 @@ pub fn parse_top_bonds(text: &str, n_atoms: usize) -> Vec<(u32, u32)> {
             continue;
         }
 
-        // Parse bond line: atom_i atom_j [func_type ...]
-        // Strip inline comments
         let data = if let Some(pos) = trimmed.find(';') {
             &trimmed[..pos]
         } else {
@@ -49,14 +166,12 @@ pub fn parse_top_bonds(text: &str, n_atoms: usize) -> Vec<(u32, u32)> {
             None => continue,
         };
 
-        // GROMACS uses 1-indexed atoms; convert to 0-indexed
         if ai == 0 || aj == 0 {
             continue;
         }
         let a = (ai - 1).min(aj - 1);
         let b = (ai - 1).max(aj - 1);
 
-        // Validate indices
         if (b as usize) < n_atoms {
             bonds.push((a, b));
         }
@@ -65,9 +180,48 @@ pub fn parse_top_bonds(text: &str, n_atoms: usize) -> Vec<(u32, u32)> {
     bonds
 }
 
+/// Parse a GROMACS `.top` text with `#include` resolution via a custom
+/// filesystem implementation.
+///
+/// Returns an error string if a circular include is detected.
+pub fn parse_top_bonds_with_fs<F: TopFileSystem>(
+    top_text: &str,
+    fs: &F,
+    n_atoms: usize,
+) -> Result<Vec<(u32, u32)>, String> {
+    let mut stack = Vec::new();
+    let expanded = expand_includes(top_text, fs, &mut stack)?;
+    Ok(parse_top_bonds(&expanded, n_atoms))
+}
+
+/// Parse a GROMACS `.top` file at `path`, resolving `#include` directives
+/// from the real filesystem.
+///
+/// Include paths are resolved relative to the directory of `path`.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn parse_top_bonds_from_path(path: &str, n_atoms: usize) -> Result<Vec<(u32, u32)>, String> {
+    use std::path::Path;
+
+    let top_path = Path::new(path);
+    let base_dir = top_path
+        .parent()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|| ".".to_string());
+
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("Cannot read {path}: {e}"))?;
+
+    let fs = RealTopFileSystem { base_dir };
+    parse_top_bonds_with_fs(&text, &fs, n_atoms)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── parse_top_bonds (existing behaviour) ──────────────────────────────────
 
     #[test]
     fn test_parse_top_bonds() {
@@ -89,7 +243,7 @@ protein  3
 "#;
         let bonds = parse_top_bonds(text, 20);
         assert_eq!(bonds.len(), 3);
-        assert_eq!(bonds[0], (0, 1)); // 1-indexed → 0-indexed
+        assert_eq!(bonds[0], (0, 1));
         assert_eq!(bonds[1], (1, 2));
         assert_eq!(bonds[2], (9, 10));
     }
@@ -97,8 +251,161 @@ protein  3
     #[test]
     fn test_out_of_range_bonds_filtered() {
         let text = "[ bonds ]\n1 2 1\n5 6 1\n";
-        let bonds = parse_top_bonds(text, 3); // only atoms 0,1,2
+        let bonds = parse_top_bonds(text, 3);
         assert_eq!(bonds.len(), 1);
         assert_eq!(bonds[0], (0, 1));
+    }
+
+    // ── parse_include_directive ───────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_include_double_quote() {
+        assert_eq!(
+            parse_include_directive(r#"#include "molecule.itp""#),
+            Some("molecule.itp".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_include_angle_bracket() {
+        assert_eq!(
+            parse_include_directive("#include <forcefield.itp>"),
+            Some("forcefield.itp".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_include_with_leading_whitespace() {
+        assert_eq!(
+            parse_include_directive(r#"  #include "ions.itp""#),
+            Some("ions.itp".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_include_none_for_normal_line() {
+        assert_eq!(parse_include_directive("[ bonds ]"), None);
+        assert_eq!(parse_include_directive("; comment"), None);
+        assert_eq!(parse_include_directive("1 2 1"), None);
+    }
+
+    // ── VirtualTopFileSystem + parse_top_bonds_with_fs ────────────────────────
+
+    fn make_vfs(entries: &[(&str, &str)]) -> VirtualTopFileSystem {
+        VirtualTopFileSystem::new(
+            entries
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn test_vfs_flat_include() {
+        // molecule.itp provides the [ bonds ] section
+        let vfs = make_vfs(&[(
+            "molecule.itp",
+            "[ bonds ]\n1 2 1\n2 3 1\n",
+        )]);
+        let top = r#"#include "molecule.itp""#;
+        let bonds = parse_top_bonds_with_fs(top, &vfs, 10).unwrap();
+        assert_eq!(bonds.len(), 2);
+        assert_eq!(bonds[0], (0, 1));
+        assert_eq!(bonds[1], (1, 2));
+    }
+
+    #[test]
+    fn test_vfs_nested_includes() {
+        // top.top → mol.itp → atoms.itp (which has [ bonds ])
+        let vfs = make_vfs(&[
+            ("mol.itp", r#"#include "atoms.itp""#),
+            ("atoms.itp", "[ bonds ]\n1 2 1\n3 4 1\n"),
+        ]);
+        let top = r#"#include "mol.itp""#;
+        let bonds = parse_top_bonds_with_fs(top, &vfs, 10).unwrap();
+        assert_eq!(bonds.len(), 2);
+        assert_eq!(bonds[0], (0, 1));
+        assert_eq!(bonds[1], (2, 3));
+    }
+
+    #[test]
+    fn test_vfs_missing_include_skipped() {
+        // system.itp is not in the vfs; should be skipped silently
+        let vfs = make_vfs(&[("mol.itp", "[ bonds ]\n1 2 1\n")]);
+        let top = "#include <system.itp>\n#include \"mol.itp\"";
+        let bonds = parse_top_bonds_with_fs(top, &vfs, 10).unwrap();
+        assert_eq!(bonds.len(), 1);
+    }
+
+    #[test]
+    fn test_vfs_circular_include_detected() {
+        // a.itp includes b.itp which includes a.itp → circular
+        let vfs = make_vfs(&[
+            ("a.itp", r#"#include "b.itp""#),
+            ("b.itp", r#"#include "a.itp""#),
+        ]);
+        let top = r#"#include "a.itp""#;
+        let result = parse_top_bonds_with_fs(top, &vfs, 10);
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("Circular include"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn test_vfs_bonds_in_top_and_itp() {
+        // Bonds come from both the main file and an included one
+        let vfs = make_vfs(&[("extra.itp", "[ bonds ]\n3 4 1\n")]);
+        let top = "[ bonds ]\n1 2 1\n#include \"extra.itp\"\n";
+        let bonds = parse_top_bonds_with_fs(top, &vfs, 10).unwrap();
+        // Bonds from main file: (0,1)
+        // After include expansion the extra section follows; parser sees two [ bonds ] sections.
+        // The second occurrence resets in_bonds_section = true, so both are collected.
+        assert!(bonds.iter().any(|&b| b == (0, 1)));
+        assert!(bonds.iter().any(|&b| b == (2, 3)));
+    }
+
+    #[test]
+    fn test_vfs_diamond_include_allowed() {
+        // A includes B and C; both include D — this is legal (not circular).
+        let vfs = make_vfs(&[
+            ("b.itp", "#include \"d.itp\""),
+            ("c.itp", "#include \"d.itp\""),
+            ("d.itp", "[ bonds ]\n1 2 1\n"),
+        ]);
+        let top = "#include \"b.itp\"\n#include \"c.itp\"\n";
+        let bonds = parse_top_bonds_with_fs(top, &vfs, 10).unwrap();
+        // d.itp is expanded twice; both occurrences yield the same bond.
+        assert!(!bonds.is_empty());
+    }
+
+    // ── parse_top_bonds_from_path (native only) ───────────────────────────────
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_from_path_with_itp() {
+        use std::fs;
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+
+        let itp_path = dir.path().join("mol.itp");
+        fs::write(&itp_path, "[ bonds ]\n1 2 1\n2 3 1\n").unwrap();
+
+        let top_content = format!("#include \"mol.itp\"\n");
+        let top_path = dir.path().join("system.top");
+        fs::write(&top_path, top_content).unwrap();
+
+        let bonds =
+            parse_top_bonds_from_path(top_path.to_str().unwrap(), 10).unwrap();
+        assert_eq!(bonds.len(), 2);
+        assert_eq!(bonds[0], (0, 1));
+        assert_eq!(bonds[1], (1, 2));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_from_path_missing_file_error() {
+        let result = parse_top_bonds_from_path("/nonexistent/path.top", 10);
+        assert!(result.is_err());
     }
 }

--- a/crates/megane-wasm/src/lib.rs
+++ b/crates/megane-wasm/src/lib.rs
@@ -1,4 +1,4 @@
-use js_sys::{Float32Array, Uint32Array, Uint8Array};
+use js_sys::{Float32Array, Object, Reflect, Uint32Array, Uint8Array};
 use wasm_bindgen::prelude::*;
 
 use megane_core::{
@@ -454,6 +454,46 @@ pub fn parse_top_bonds(text: &str, n_atoms: u32) -> Uint32Array {
         flat.push(*b);
     }
     Uint32Array::from(&flat[..])
+}
+
+/// Parse a GROMACS `.top` text with `#include` resolution.
+///
+/// `include_files` is a plain JS object mapping include path (string) to file
+/// content (string).  Missing keys are silently skipped (matches how system
+/// forcefield includes behave in practice).
+///
+/// Returns a flat `Uint32Array` `[a0, b0, a1, b1, ...]` of 0-indexed bond
+/// pairs, or throws if a circular include is detected.
+#[wasm_bindgen]
+pub fn parse_top_bonds_with_includes(
+    text: &str,
+    include_files: &Object,
+    n_atoms: u32,
+) -> Result<Uint32Array, JsError> {
+    use std::collections::HashMap;
+
+    let mut files: HashMap<String, String> = HashMap::new();
+    let keys = Object::keys(include_files);
+    for i in 0..keys.length() {
+        let key = keys.get(i);
+        let key_str = key.as_string().unwrap_or_default();
+        if let Ok(val) = Reflect::get(include_files, &key) {
+            if let Some(s) = val.as_string() {
+                files.insert(key_str, s);
+            }
+        }
+    }
+
+    let vfs = top::VirtualTopFileSystem::new(files);
+    let result = top::parse_top_bonds_with_fs(text, &vfs, n_atoms as usize)
+        .map_err(|e| JsError::new(&e))?;
+
+    let mut flat: Vec<u32> = Vec::with_capacity(result.len() * 2);
+    for (a, b) in &result {
+        flat.push(*a);
+        flat.push(*b);
+    }
+    Ok(Uint32Array::from(&flat[..]))
 }
 
 /// Extract atom labels from a structure file text.

--- a/crates/megane-wasm/src/lib.rs
+++ b/crates/megane-wasm/src/lib.rs
@@ -485,8 +485,8 @@ pub fn parse_top_bonds_with_includes(
     }
 
     let vfs = top::VirtualTopFileSystem::new(files);
-    let result = top::parse_top_bonds_with_fs(text, &vfs, n_atoms as usize)
-        .map_err(|e| JsError::new(&e))?;
+    let result =
+        top::parse_top_bonds_with_fs(text, &vfs, n_atoms as usize).map_err(|e| JsError::new(&e))?;
 
     let mut flat: Vec<u32> = Vec::with_capacity(result.len() * 2);
     for (a, b) in &result {

--- a/docs/wasm-stub.d.ts
+++ b/docs/wasm-stub.d.ts
@@ -13,5 +13,6 @@ export function infer_bonds_vdw(
 ): any;
 export function parse_xtc_file(data: Uint8Array): any;
 export function parse_top_bonds(text: string, n_atoms: number): any;
+export function parse_top_bonds_with_includes(text: string, include_files: Record<string, string>, n_atoms: number): any;
 export function parse_pdb_bonds(text: string, n_atoms: number): any;
 export function extract_labels(text: string, format: string): string;

--- a/python/megane/parsers/top.py
+++ b/python/megane/parsers/top.py
@@ -7,7 +7,7 @@ Extracts bond pairs from the ``[ bonds ]`` section and resolves
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable
+
 import numpy as np
 
 
@@ -16,11 +16,11 @@ def _parse_include_directive(line: str) -> str | None:
     stripped = line.strip()
     if not stripped.startswith("#include"):
         return None
-    rest = stripped[len("#include"):].strip()
+    rest = stripped[len("#include") :].strip()
     if rest.startswith('"') and '"' in rest[1:]:
-        return rest[1:rest.index('"', 1)]
+        return rest[1 : rest.index('"', 1)]
     if rest.startswith("<") and ">" in rest[1:]:
-        return rest[1:rest.index(">", 1)]
+        return rest[1 : rest.index(">", 1)]
     return None
 
 

--- a/python/megane/parsers/top.py
+++ b/python/megane/parsers/top.py
@@ -1,37 +1,76 @@
-"""GROMACS .top topology file parser.
+"""GROMACS .top / .itp topology file parser.
 
-Extracts bond pairs from the ``[ bonds ]`` section.  Mirrors the Rust
-implementation in ``crates/megane-core/src/top.rs``.
+Extracts bond pairs from the ``[ bonds ]`` section and resolves
+``#include`` directives so that real-world multi-file topologies work.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Iterable
 import numpy as np
 
 
-def parse_top_bonds(path: str) -> np.ndarray:
-    """Parse a GROMACS .top file and extract bond pairs.
+def _parse_include_directive(line: str) -> str | None:
+    """Return the include path from a ``#include`` line, or ``None``."""
+    stripped = line.strip()
+    if not stripped.startswith("#include"):
+        return None
+    rest = stripped[len("#include"):].strip()
+    if rest.startswith('"') and '"' in rest[1:]:
+        return rest[1:rest.index('"', 1)]
+    if rest.startswith("<") and ">" in rest[1:]:
+        return rest[1:rest.index(">", 1)]
+    return None
 
-    Args:
-        path: Path to a ``.top`` topology file.
 
-    Returns:
-        ``(M, 2)`` uint32 array of 0-indexed bond pairs.
+def _expand_includes(
+    text: str,
+    base_dir: Path,
+    include_stack: list[str],
+) -> str:
+    """Recursively expand ``#include`` directives in *text*.
+
+    Missing include files are silently skipped (system forcefield files are
+    typically absent in test environments).  Circular includes are detected
+    and raise a ``RecursionError``.
     """
-    with open(path, encoding="utf-8", errors="replace") as f:
-        text = f.read()
+    lines: list[str] = []
+    for line in text.splitlines():
+        include_path = _parse_include_directive(line)
+        if include_path is None:
+            lines.append(line)
+            continue
 
+        if include_path in include_stack:
+            chain = " -> ".join(include_stack + [include_path])
+            raise RecursionError(f"Circular include detected: {chain}")
+
+        candidate = base_dir / include_path
+        if not candidate.is_file():
+            # Skip missing includes (e.g. system forcefield .itp files).
+            continue
+
+        included_text = candidate.read_text(encoding="utf-8", errors="replace")
+        include_stack.append(include_path)
+        expanded = _expand_includes(included_text, base_dir, include_stack)
+        include_stack.pop()
+        lines.append(expanded)
+
+    return "\n".join(lines)
+
+
+def _extract_bonds(text: str) -> list[tuple[int, int]]:
+    """Extract 0-indexed bond pairs from the ``[ bonds ]`` section(s) of *text*."""
     bonds: list[tuple[int, int]] = []
     in_bonds_section = False
 
     for line in text.splitlines():
         trimmed = line.strip()
 
-        # Skip empty lines and comments
-        if not trimmed or trimmed.startswith(";"):
+        if not trimmed or trimmed.startswith(";") or trimmed.startswith("#"):
             continue
 
-        # Check for section headers
         if trimmed.startswith("["):
             section_name = trimmed.strip("[]").strip().lower()
             in_bonds_section = section_name == "bonds"
@@ -40,7 +79,6 @@ def parse_top_bonds(path: str) -> np.ndarray:
         if not in_bonds_section:
             continue
 
-        # Strip inline comments
         if ";" in trimmed:
             trimmed = trimmed[: trimmed.index(";")]
 
@@ -54,12 +92,33 @@ def parse_top_bonds(path: str) -> np.ndarray:
         except ValueError:
             continue
 
-        # GROMACS uses 1-indexed atoms; convert to 0-indexed
         if ai <= 0 or aj <= 0:
             continue
         a = min(ai - 1, aj - 1)
         b = max(ai - 1, aj - 1)
         bonds.append((a, b))
+
+    return bonds
+
+
+def parse_top_bonds(path: str) -> np.ndarray:
+    """Parse a GROMACS ``.top`` file and extract bond pairs.
+
+    ``#include`` directives are resolved relative to the directory of *path*.
+    Missing include files (e.g. system forcefield ``.itp`` files) are skipped
+    silently.  Circular includes raise ``RecursionError``.
+
+    Args:
+        path: Path to a ``.top`` topology file.
+
+    Returns:
+        ``(M, 2)`` uint32 array of 0-indexed bond pairs.
+    """
+    top_path = Path(path)
+    base_dir = top_path.parent
+    text = top_path.read_text(encoding="utf-8", errors="replace")
+    expanded = _expand_includes(text, base_dir, [])
+    bonds = _extract_bonds(expanded)
 
     if not bonds:
         return np.empty((0, 2), dtype=np.uint32)

--- a/src/parsers/structure.ts
+++ b/src/parsers/structure.ts
@@ -66,7 +66,11 @@ interface WasmModule {
   parse_traj: BinaryParseFn;
   infer_bonds_vdw: (positions: Float32Array, elements: Uint8Array, n_atoms: number) => Uint32Array;
   parse_top_bonds: (text: string, n_atoms: number) => Uint32Array;
-  parse_top_bonds_with_includes: (text: string, include_files: Record<string, string>, n_atoms: number) => Uint32Array;
+  parse_top_bonds_with_includes: (
+    text: string,
+    include_files: Record<string, string>,
+    n_atoms: number,
+  ) => Uint32Array;
   parse_psf_bonds: (text: string, n_atoms: number) => Uint32Array;
   parse_pdb_bonds: (text: string, n_atoms: number) => Uint32Array;
   extract_labels: (text: string, format: string) => string;

--- a/src/parsers/structure.ts
+++ b/src/parsers/structure.ts
@@ -66,6 +66,7 @@ interface WasmModule {
   parse_traj: BinaryParseFn;
   infer_bonds_vdw: (positions: Float32Array, elements: Uint8Array, n_atoms: number) => Uint32Array;
   parse_top_bonds: (text: string, n_atoms: number) => Uint32Array;
+  parse_top_bonds_with_includes: (text: string, include_files: Record<string, string>, n_atoms: number) => Uint32Array;
   parse_psf_bonds: (text: string, n_atoms: number) => Uint32Array;
   parse_pdb_bonds: (text: string, n_atoms: number) => Uint32Array;
   extract_labels: (text: string, format: string) => string;
@@ -96,6 +97,7 @@ async function ensureInit(): Promise<void> {
         parse_traj: wasm.parse_traj,
         infer_bonds_vdw: wasm.infer_bonds_vdw,
         parse_top_bonds: wasm.parse_top_bonds,
+        parse_top_bonds_with_includes: wasm.parse_top_bonds_with_includes,
         parse_psf_bonds: wasm.parse_psf_bonds,
         parse_pdb_bonds: wasm.parse_pdb_bonds,
         extract_labels: wasm.extract_labels,
@@ -242,6 +244,23 @@ export async function inferBondsVdw(
 export async function parseTopBonds(text: string, nAtoms: number): Promise<Uint32Array> {
   await ensureInit();
   return wasmModule!.parse_top_bonds(text, nAtoms);
+}
+
+/**
+ * Parse a GROMACS `.top` text with `#include` resolution.
+ *
+ * `includeFiles` maps include path → file content for all `.itp` files that
+ * the topology references.  Missing keys are silently skipped (system
+ * forcefield files are typically unavailable in browser contexts).
+ * Throws if a circular include is detected.
+ */
+export async function parseTopBondsWithIncludes(
+  text: string,
+  includeFiles: Record<string, string>,
+  nAtoms: number,
+): Promise<Uint32Array> {
+  await ensureInit();
+  return wasmModule!.parse_top_bonds_with_includes(text, includeFiles, nAtoms);
 }
 
 /** Parse CHARMM/NAMD PSF topology file and extract bond pairs. */

--- a/tests/fixtures/test_bonds.itp
+++ b/tests/fixtures/test_bonds.itp
@@ -1,0 +1,6 @@
+; GROMACS .itp file with bond definitions
+[ bonds ]
+     1     2     1  ; N-CA
+     2     3     1  ; CA-C
+     3     4     1  ; C-O
+     2     5     1  ; CA-CB

--- a/tests/fixtures/test_nested.itp
+++ b/tests/fixtures/test_nested.itp
@@ -1,0 +1,5 @@
+; Intermediate .itp that includes the bonds definition
+[ moleculetype ]
+protein  3
+
+#include "test_bonds.itp"

--- a/tests/fixtures/test_with_includes.top
+++ b/tests/fixtures/test_with_includes.top
@@ -1,0 +1,11 @@
+; GROMACS topology using #include directives
+; Tests that megane resolves includes correctly.
+#include <forcefield.itp>
+
+[ system ]
+Protein
+
+[ molecules ]
+protein  1
+
+#include "test_nested.itp"

--- a/tests/python/test_top_parser.py
+++ b/tests/python/test_top_parser.py
@@ -3,10 +3,87 @@
 from pathlib import Path
 
 import numpy as np
+import pytest
 
-from megane.parsers.top import parse_top_bonds
+from megane.parsers.top import (
+    _expand_includes,
+    _extract_bonds,
+    _parse_include_directive,
+    parse_top_bonds,
+)
 
 FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+
+class TestParseIncludeDirective:
+    def test_double_quote(self):
+        assert _parse_include_directive('#include "molecule.itp"') == "molecule.itp"
+
+    def test_angle_bracket(self):
+        assert _parse_include_directive("#include <forcefield.itp>") == "forcefield.itp"
+
+    def test_leading_whitespace(self):
+        assert _parse_include_directive('  #include "ions.itp"') == "ions.itp"
+
+    def test_normal_line_returns_none(self):
+        assert _parse_include_directive("[ bonds ]") is None
+        assert _parse_include_directive("; comment") is None
+        assert _parse_include_directive("1 2 1") is None
+
+    def test_no_closing_quote_returns_none(self):
+        assert _parse_include_directive('#include "unclosed') is None
+
+
+class TestExtractBonds:
+    def test_basic(self):
+        text = "[ bonds ]\n1 2 1\n2 3 1\n"
+        bonds = _extract_bonds(text)
+        assert bonds == [(0, 1), (1, 2)]
+
+    def test_inline_comment_stripped(self):
+        bonds = _extract_bonds("[ bonds ]\n1 2 1 ; comment\n")
+        assert bonds == [(0, 1)]
+
+    def test_stops_at_next_section(self):
+        bonds = _extract_bonds("[ bonds ]\n1 2 1\n[ angles ]\n1 2 3 1\n")
+        assert bonds == [(0, 1)]
+
+    def test_skips_preprocessor_lines(self):
+        bonds = _extract_bonds("[ bonds ]\n#include \"x.itp\"\n1 2 1\n")
+        assert bonds == [(0, 1)]
+
+
+class TestExpandIncludes:
+    def test_resolves_itp(self, tmp_path):
+        (tmp_path / "mol.itp").write_text("[ bonds ]\n1 2 1\n")
+        expanded = _expand_includes('#include "mol.itp"', tmp_path, [])
+        assert "[ bonds ]" in expanded
+
+    def test_skips_missing_system_include(self, tmp_path):
+        text = "#include <forcefield.itp>\n[ bonds ]\n1 2 1\n"
+        expanded = _expand_includes(text, tmp_path, [])
+        assert "[ bonds ]" in expanded
+
+    def test_nested_includes(self, tmp_path):
+        (tmp_path / "atoms.itp").write_text("[ bonds ]\n1 2 1\n")
+        (tmp_path / "mol.itp").write_text('#include "atoms.itp"')
+        expanded = _expand_includes('#include "mol.itp"', tmp_path, [])
+        assert "[ bonds ]" in expanded
+
+    def test_circular_include_raises(self, tmp_path):
+        (tmp_path / "a.itp").write_text('#include "b.itp"')
+        (tmp_path / "b.itp").write_text('#include "a.itp"')
+        with pytest.raises(RecursionError, match="Circular include"):
+            _expand_includes('#include "a.itp"', tmp_path, [])
+
+    def test_diamond_include_allowed(self, tmp_path):
+        (tmp_path / "d.itp").write_text("[ bonds ]\n1 2 1\n")
+        (tmp_path / "b.itp").write_text('#include "d.itp"')
+        (tmp_path / "c.itp").write_text('#include "d.itp"')
+        text = '#include "b.itp"\n#include "c.itp"\n'
+        # Should not raise — diamond includes are legal.
+        expanded = _expand_includes(text, tmp_path, [])
+        assert expanded.count("[ bonds ]") == 2
 
 
 class TestParseTopBonds:
@@ -19,7 +96,6 @@ class TestParseTopBonds:
 
     def test_zero_indexed(self):
         bonds = parse_top_bonds(str(FIXTURES / "test_topology.top"))
-        # 1-2 -> 0-1, 2-3 -> 1-2, 3-4 -> 2-3, 2-5 -> 1-4
         expected = np.array([[0, 1], [1, 2], [2, 3], [1, 4]], dtype=np.uint32)
         np.testing.assert_array_equal(bonds, expected)
 
@@ -46,3 +122,35 @@ class TestParseTopBonds:
         f.write_text("[ bonds ]\n1 2 1\n[ angles ]\n1 2 3 1\n")
         bonds = parse_top_bonds(str(f))
         assert len(bonds) == 1
+
+    # ── include resolution ────────────────────────────────────────────────────
+
+    def test_resolves_itp_include(self, tmp_path):
+        (tmp_path / "mol.itp").write_text("[ bonds ]\n1 2 1\n2 3 1\n")
+        top = tmp_path / "system.top"
+        top.write_text('#include "mol.itp"\n')
+        bonds = parse_top_bonds(str(top))
+        assert bonds.shape == (2, 2)
+        np.testing.assert_array_equal(bonds[0], [0, 1])
+        np.testing.assert_array_equal(bonds[1], [1, 2])
+
+    def test_resolves_nested_includes(self):
+        bonds = parse_top_bonds(str(FIXTURES / "test_with_includes.top"))
+        # test_with_includes.top -> test_nested.itp -> test_bonds.itp (4 bonds)
+        assert bonds.shape == (4, 2)
+        np.testing.assert_array_equal(bonds[0], [0, 1])
+
+    def test_missing_system_include_skipped(self, tmp_path):
+        (tmp_path / "mol.itp").write_text("[ bonds ]\n1 2 1\n")
+        top = tmp_path / "system.top"
+        top.write_text("#include <forcefield.itp>\n#include \"mol.itp\"\n")
+        bonds = parse_top_bonds(str(top))
+        assert bonds.shape == (1, 2)
+
+    def test_circular_include_raises(self, tmp_path):
+        (tmp_path / "a.itp").write_text('#include "b.itp"')
+        (tmp_path / "b.itp").write_text('#include "a.itp"')
+        top = tmp_path / "system.top"
+        top.write_text('#include "a.itp"')
+        with pytest.raises(RecursionError, match="Circular include"):
+            parse_top_bonds(str(top))


### PR DESCRIPTION
## Summary

Closes #360

Adds `#include` resolution to the GROMACS `.top` / `.itp` parser so that real-world multi-file topologies work correctly. Previously, the parser only handled single-file `.top` inputs; now it can follow the `#include "molecule.itp"` chain that almost all real GROMACS systems use.

## Changes

### Rust (`crates/megane-core/src/top.rs`)
- Added `TopFileSystem` trait for injectable file resolution (enables browser/WASM use)
- Added `RealTopFileSystem` (native) — resolves paths relative to the `.top` file directory
- Added `VirtualTopFileSystem` (HashMap-based) — for WASM/browser contexts where callers supply included file contents upfront
- Added `expand_includes()` — recursive `#include` resolver with circular-include detection
- Added `parse_top_bonds_with_fs()` — new public API using any `TopFileSystem`
- Added `parse_top_bonds_from_path()` (native only) — reads a `.top` file and resolves includes from the real filesystem
- Missing includes (e.g. system forcefield `.itp` files) are silently skipped
- Circular includes produce a clear error message (not a stack overflow)
- Added `tempfile` as a dev-dependency for path-based tests

### WASM (`crates/megane-wasm/src/lib.rs`)
- Added `parse_top_bonds_with_includes(text, include_files, n_atoms)` — accepts a JS object mapping path → content, uses `VirtualTopFileSystem`
- Throws a `JsError` on circular include detection

### Python (`python/megane/parsers/top.py`)
- Rewrote `parse_top_bonds()` to resolve `#include` directives before parsing
- Added `_parse_include_directive()`, `_expand_includes()`, `_extract_bonds()` helpers
- Circular includes raise `RecursionError` with a descriptive chain message
- Missing system includes are silently skipped

### TypeScript (`src/parsers/structure.ts`, `docs/wasm-stub.d.ts`)
- Exposed `parseTopBondsWithIncludes()` binding for the new WASM function

### Tests & Fixtures
- **Rust**: 10 new unit tests covering flat include, nested includes, diamond includes (legal), circular include detection, missing include skip, virtual filesystem, and native path resolution
- **Python**: 18 new tests across `TestParseIncludeDirective`, `TestExtractBonds`, `TestExpandIncludes`, and `TestParseTopBonds`
- **Fixtures**: `tests/fixtures/test_bonds.itp`, `test_nested.itp`, `test_with_includes.top`

## Test plan

- [x] `cargo test -p megane-core` — 187 tests pass (10 new `top::tests::*`)
- [x] `uv run python -m pytest tests/python/test_top_parser.py` — 24 tests pass (18 new)
- [x] `npm test` — 1164 TypeScript tests pass
- [x] `cargo check -p megane-wasm --target wasm32-unknown-unknown` — WASM crate compiles
- [x] Rust patch coverage: 10 new tests cover new code paths in `top.rs`
- [x] Python patch coverage: `top.py` at 94%
- [ ] E2E: no UI changes — no E2E baseline updates required

## Playwright projects run
None — this PR touches only a Rust parser, Python wrapper, and TypeScript binding. No renderer, pipeline editor, or UI component was modified.

https://claude.ai/code/session_01YZNJkE8xgMoFYTBbATkGpq

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZNJkE8xgMoFYTBbATkGpq)_