### PR TITLE
feat(pipeline-editor): split editor and chat into tabs

### DIFF
--- a/src/components/PipelineChatBox.tsx
+++ b/src/components/PipelineChatBox.tsx
@@ -1,6 +1,6 @@
 /**
  * Chat interface for AI-powered pipeline generation.
- * Renders at the bottom of the PipelineEditor panel.
+ * Renders inside the Chat tab of the PipelineEditor panel.
  * Includes inline config panel for API key and model settings.
  */
 
@@ -9,6 +9,7 @@ import { useAIConfigStore, PROVIDER_MODELS } from "../ai/config";
 import type { AIProvider } from "../ai/config";
 import { generatePipeline, extractPipelineJSON } from "../ai/client";
 import { usePipelineStore } from "../pipeline/store";
+import { usePipelineUIStore } from "../stores/usePipelineUIStore";
 
 interface ChatMessage {
   role: "user" | "assistant" | "error";
@@ -18,15 +19,16 @@ interface ChatMessage {
 // ─── Styles ──────────────────────────────────────────────────────────
 
 const containerStyle: React.CSSProperties = {
-  flexShrink: 0,
-  borderTop: "1px solid rgba(226,232,240,0.6)",
+  flex: 1,
+  minHeight: 0,
   display: "flex",
   flexDirection: "column",
   background: "rgba(248, 250, 252, 0.95)",
 };
 
 const messagesAreaStyle: React.CSSProperties = {
-  maxHeight: 120,
+  flex: 1,
+  minHeight: 0,
   overflowY: "auto",
   padding: "6px 10px",
   display: "flex",
@@ -247,6 +249,9 @@ export function PipelineChatBox({ onPipelineApplied }: { onPipelineApplied?: () 
       const pipeline = extractPipelineJSON(fullResponse);
       deserialize(pipeline);
       autoLayout();
+      // Surface the result on the editor tab and trigger fitView via the
+      // panel's mode-change effect.
+      usePipelineUIStore.getState().markPipelineApplied();
       onPipelineApplied?.();
 
       setMessages((prev) => [
@@ -335,10 +340,21 @@ export function PipelineChatBox({ onPipelineApplied }: { onPipelineApplied?: () 
         </div>
       )}
 
-      {/* Messages area */}
-      {messages.length > 0 && (
-        <div style={messagesAreaStyle}>
-          {messages.map((msg, i) => {
+      {/* Messages area (always rendered so the chat tab fills the panel) */}
+      <div style={messagesAreaStyle} data-testid="pipeline-chat-messages">
+        {messages.length === 0 ? (
+          <div
+            style={{
+              color: "var(--megane-text-muted)",
+              fontStyle: "italic",
+              fontSize: 11,
+              padding: "8px 0",
+            }}
+          >
+            Ask the assistant to build or edit the pipeline.
+          </div>
+        ) : (
+          messages.map((msg, i) => {
             if (msg.role === "user") {
               return (
                 <div key={i} style={userMsgStyle}>
@@ -371,10 +387,10 @@ export function PipelineChatBox({ onPipelineApplied }: { onPipelineApplied?: () 
                 {display}
               </div>
             );
-          })}
-          <div ref={messagesEndRef} />
-        </div>
-      )}
+          })
+        )}
+        <div ref={messagesEndRef} />
+      </div>
 
       {/* Input row */}
       <div style={inputRowStyle}>

--- a/src/components/PipelineEditor.tsx
+++ b/src/components/PipelineEditor.tsx
@@ -3,7 +3,7 @@
  * Typed data-flow pipeline with color-coded handles per data type.
  */
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ReactFlow,
   ReactFlowProvider,
@@ -15,6 +15,9 @@ import {
 } from "@xyflow/react";
 import { useThemeStore } from "../stores/useThemeStore";
 import type { Theme } from "../stores/useThemeStore";
+import { usePipelineUIStore } from "../stores/usePipelineUIStore";
+import type { PipelinePanelMode } from "../stores/usePipelineUIStore";
+import { TabSelector } from "./ui";
 import type { Connection } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { usePipelineStore } from "../pipeline/store";
@@ -545,6 +548,37 @@ function PipelineEditorInner({
     setTheme(next);
   }, [theme, setTheme]);
 
+  const mode = usePipelineUIStore((s) => s.mode);
+  const setMode = usePipelineUIStore((s) => s.setMode);
+  const pendingNotice = usePipelineUIStore((s) => s.pendingNotice);
+  const dismissNotice = usePipelineUIStore((s) => s.dismissNotice);
+
+  // When the panel switches back to the editor (e.g. after the chat assistant
+  // applies a generated pipeline) the ReactFlow viewport may have just been
+  // un-hidden, so we re-fit. Two RAFs give the layout/resize-observer a chance
+  // to pick up the new dimensions before fitView reads them.
+  useEffect(() => {
+    if (mode !== "editor") return;
+    let rafA = 0;
+    let rafB = 0;
+    rafA = window.requestAnimationFrame(() => {
+      rafB = window.requestAnimationFrame(() => {
+        fitView({ padding: 0.1, maxZoom: 1.95, duration: 300 });
+      });
+    });
+    return () => {
+      window.cancelAnimationFrame(rafA);
+      window.cancelAnimationFrame(rafB);
+    };
+  }, [mode, fitView]);
+
+  // Auto-dismiss the "pipeline applied" notice after a short delay.
+  useEffect(() => {
+    if (!pendingNotice) return;
+    const handle = window.setTimeout(() => dismissNotice(), 3000);
+    return () => window.clearTimeout(handle);
+  }, [pendingNotice, dismissNotice]);
+
   // Resize drag handling
   const handleResizeMouseDown = useCallback(
     (e: React.MouseEvent) => {
@@ -700,94 +734,102 @@ function PipelineEditorInner({
 
   const memoizedNodeTypes = useMemo(() => nodeTypes, []);
 
+  // Toolbar row that lives inside the Editor tab — its actions only make
+  // sense while the user can see the graph. Hidden on the Chat tab.
+  const editorToolbar = (
+    <div style={{ ...toolbarRowStyle, padding: "5px 8px" }}>
+      <span style={toolbarCategoryLabelStyle}>Pipeline</span>
+      <div style={{ position: "relative" }}>
+        <button
+          onClick={() => {
+            setShowAddMenu(!showAddMenu);
+            setShowTemplateMenu(false);
+          }}
+          style={addBtnStyle}
+          title="Add Node"
+        >
+          {IconPlus} Add Node
+        </button>
+        {showAddMenu && (
+          <div style={{ ...dropdownStyle, right: "auto", left: 0 }}>
+            {ADD_NODE_GROUPS.map((group) => (
+              <div key={group.category}>
+                <div style={{ ...groupHeaderStyle, color: NODE_CATEGORY_COLORS[group.category] }}>
+                  {CATEGORY_ICONS[group.category]}
+                  <span style={{ color: "#94a3b8" }}>{group.label}</span>
+                </div>
+                {group.types.map((type) => (
+                  <button
+                    key={type}
+                    onClick={() => handleAddNode(type)}
+                    style={dropdownItemStyle}
+                    onMouseEnter={(e) => {
+                      (e.target as HTMLElement).style.background = "rgba(59,130,246,0.06)";
+                    }}
+                    onMouseLeave={(e) => {
+                      (e.target as HTMLElement).style.background = "none";
+                    }}
+                  >
+                    {NODE_TYPE_LABELS[type]}
+                  </button>
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+      <button
+        onClick={handleAutoLayout}
+        style={layoutBtnStyle}
+        title="Auto Layout"
+        aria-label="Auto Layout"
+      >
+        {IconLayout} Layout
+      </button>
+      <div style={{ position: "relative" }}>
+        <button
+          data-testid="pipeline-editor-templates"
+          onClick={() => {
+            setShowTemplateMenu(!showTemplateMenu);
+            setShowAddMenu(false);
+          }}
+          style={templateBtnStyle}
+          title="Templates"
+        >
+          {IconTemplates} Templates
+        </button>
+        {showTemplateMenu && (
+          <div style={{ ...dropdownStyle, right: "auto", left: 0 }}>
+            {PIPELINE_TEMPLATES.map((template) => (
+              <button
+                key={template.id}
+                onClick={() => handleApplyTemplate(template.id)}
+                style={{ ...dropdownItemStyle, padding: "8px 14px" }}
+                onMouseEnter={(e) => {
+                  (e.target as HTMLElement).style.background = "rgba(139,92,246,0.06)";
+                }}
+                onMouseLeave={(e) => {
+                  (e.target as HTMLElement).style.background = "none";
+                }}
+              >
+                <div style={{ fontWeight: 500 }}>{template.label}</div>
+                <div style={templateItemDescStyle}>{template.description}</div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  const TAB_OPTIONS: { value: PipelinePanelMode; label: string }[] = [
+    { value: "editor", label: "Editor" },
+    { value: "chat", label: "Chat" },
+  ];
+
   const headerExtra = (
     <>
-      {/* Row 1 — Pipeline: compose the graph */}
-      <div style={toolbarRowStyle}>
-        <span style={toolbarCategoryLabelStyle}>Pipeline</span>
-        <div style={{ position: "relative" }}>
-          <button
-            onClick={() => {
-              setShowAddMenu(!showAddMenu);
-              setShowTemplateMenu(false);
-            }}
-            style={addBtnStyle}
-            title="Add Node"
-          >
-            {IconPlus} Add Node
-          </button>
-          {showAddMenu && (
-            <div style={{ ...dropdownStyle, right: "auto", left: 0 }}>
-              {ADD_NODE_GROUPS.map((group) => (
-                <div key={group.category}>
-                  <div style={{ ...groupHeaderStyle, color: NODE_CATEGORY_COLORS[group.category] }}>
-                    {CATEGORY_ICONS[group.category]}
-                    <span style={{ color: "#94a3b8" }}>{group.label}</span>
-                  </div>
-                  {group.types.map((type) => (
-                    <button
-                      key={type}
-                      onClick={() => handleAddNode(type)}
-                      style={dropdownItemStyle}
-                      onMouseEnter={(e) => {
-                        (e.target as HTMLElement).style.background = "rgba(59,130,246,0.06)";
-                      }}
-                      onMouseLeave={(e) => {
-                        (e.target as HTMLElement).style.background = "none";
-                      }}
-                    >
-                      {NODE_TYPE_LABELS[type]}
-                    </button>
-                  ))}
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-        <button
-          onClick={handleAutoLayout}
-          style={layoutBtnStyle}
-          title="Auto Layout"
-          aria-label="Auto Layout"
-        >
-          {IconLayout} Layout
-        </button>
-        <div style={{ position: "relative" }}>
-          <button
-            data-testid="pipeline-editor-templates"
-            onClick={() => {
-              setShowTemplateMenu(!showTemplateMenu);
-              setShowAddMenu(false);
-            }}
-            style={templateBtnStyle}
-            title="Templates"
-          >
-            {IconTemplates} Templates
-          </button>
-          {showTemplateMenu && (
-            <div style={{ ...dropdownStyle, right: "auto", left: 0 }}>
-              {PIPELINE_TEMPLATES.map((template) => (
-                <button
-                  key={template.id}
-                  onClick={() => handleApplyTemplate(template.id)}
-                  style={{ ...dropdownItemStyle, padding: "8px 14px" }}
-                  onMouseEnter={(e) => {
-                    (e.target as HTMLElement).style.background = "rgba(139,92,246,0.06)";
-                  }}
-                  onMouseLeave={(e) => {
-                    (e.target as HTMLElement).style.background = "none";
-                  }}
-                >
-                  <div style={{ fontWeight: 500 }}>{template.label}</div>
-                  <div style={templateItemDescStyle}>{template.description}</div>
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
-
-      {/* Row 2 — I/O: exchange and execute */}
+      {/* I/O: exchange and execute (visible from both tabs) */}
       <div style={toolbarRowStyle}>
         <span style={toolbarCategoryLabelStyle}>I/O</span>
         <button
@@ -824,7 +866,7 @@ function PipelineEditorInner({
           {IconRender} Render
         </button>
       </div>
-      {/* Row 3 — Others: help & appearance */}
+      {/* Others: help & appearance (visible from both tabs) */}
       <div style={toolbarRowStyle}>
         <span style={toolbarCategoryLabelStyle}>Others</span>
         <button
@@ -855,7 +897,35 @@ function PipelineEditorInner({
           {THEME_ICONS[theme]} {THEME_LABELS[theme]}
         </button>
       </div>
+      <div style={{ flexBasis: "100%", marginTop: 2 }}>
+        <TabSelector<PipelinePanelMode>
+          options={TAB_OPTIONS}
+          value={mode}
+          onChange={setMode}
+          ariaLabel="Pipeline panel mode"
+          tabIdFor={(v) => `pipeline-tab-${v}`}
+          panelIdFor={(v) => `pipeline-tabpanel-${v}`}
+          testIdFor={(v) => `pipeline-editor-tab-${v}`}
+        />
+      </div>
     </>
+  );
+
+  const appliedNoticeBanner = pendingNotice && mode === "editor" && (
+    <div
+      role="status"
+      data-testid="pipeline-editor-applied-notice"
+      style={{
+        padding: "4px 10px",
+        background: "rgba(16, 185, 129, 0.1)",
+        color: "#059669",
+        fontSize: 11,
+        fontWeight: 500,
+        borderBottom: "1px solid var(--megane-border)",
+      }}
+    >
+      Pipeline updated from chat
+    </div>
   );
 
   const resizeHandle = (
@@ -880,60 +950,82 @@ function PipelineEditorInner({
       headerExtra={headerExtra}
       containerExtra={resizeHandle}
     >
-      <div ref={flowContainerRef} style={{ flex: 1, position: "relative", minHeight: 0 }}>
-        <ReactFlow
-          nodes={nodes}
-          edges={styledEdges}
-          onNodesChange={onNodesChange}
-          onEdgesChange={onEdgesChange}
-          onConnect={onConnect}
-          isValidConnection={isValidConnection}
-          nodeTypes={memoizedNodeTypes}
-          fitView
-          fitViewOptions={{ padding: 0.1, maxZoom: 1.95 }}
-          minZoom={0.3}
-          maxZoom={2}
-          defaultEdgeOptions={{
-            type: "bezier",
-            animated: true,
-            style: { stroke: "#94a3b8", strokeWidth: 3 },
-          }}
-          proOptions={{ hideAttribution: true }}
-        >
-          <Background
-            variant={BackgroundVariant.Dots}
-            gap={16}
-            size={1}
-            color="var(--megane-border-solid)"
-          />
-          <MiniMap
-            style={{
-              background: "var(--megane-surface-solid)",
-              border: "1px solid var(--megane-border-solid)",
-              borderRadius: 6,
-              width: 100,
-              height: 70,
-            }}
-            nodeColor="var(--megane-primary)"
-            maskColor="rgba(59,130,246,0.05)"
-          />
-          <Controls
-            showInteractive={false}
-            style={{
-              border: "1px solid var(--megane-border-solid)",
-              borderRadius: 6,
-              boxShadow: "none",
-            }}
-          />
-        </ReactFlow>
-      </div>
-      <PipelineChatBox
-        onPipelineApplied={() => {
-          window.requestAnimationFrame(() => {
-            fitView({ padding: 0.1, maxZoom: 1.95, duration: 300 });
-          });
+      {appliedNoticeBanner}
+      <div
+        role="tabpanel"
+        id="pipeline-tabpanel-editor"
+        aria-labelledby="pipeline-tab-editor"
+        hidden={mode !== "editor"}
+        style={{
+          display: mode === "editor" ? "flex" : "none",
+          flexDirection: "column",
+          flex: 1,
+          minHeight: 0,
         }}
-      />
+      >
+        {editorToolbar}
+        <div ref={flowContainerRef} style={{ flex: 1, position: "relative", minHeight: 0 }}>
+          <ReactFlow
+            nodes={nodes}
+            edges={styledEdges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            onConnect={onConnect}
+            isValidConnection={isValidConnection}
+            nodeTypes={memoizedNodeTypes}
+            fitView
+            fitViewOptions={{ padding: 0.1, maxZoom: 1.95 }}
+            minZoom={0.3}
+            maxZoom={2}
+            defaultEdgeOptions={{
+              type: "bezier",
+              animated: true,
+              style: { stroke: "#94a3b8", strokeWidth: 3 },
+            }}
+            proOptions={{ hideAttribution: true }}
+          >
+            <Background
+              variant={BackgroundVariant.Dots}
+              gap={16}
+              size={1}
+              color="var(--megane-border-solid)"
+            />
+            <MiniMap
+              style={{
+                background: "var(--megane-surface-solid)",
+                border: "1px solid var(--megane-border-solid)",
+                borderRadius: 6,
+                width: 100,
+                height: 70,
+              }}
+              nodeColor="var(--megane-primary)"
+              maskColor="rgba(59,130,246,0.05)"
+            />
+            <Controls
+              showInteractive={false}
+              style={{
+                border: "1px solid var(--megane-border-solid)",
+                borderRadius: 6,
+                boxShadow: "none",
+              }}
+            />
+          </ReactFlow>
+        </div>
+      </div>
+      <div
+        role="tabpanel"
+        id="pipeline-tabpanel-chat"
+        aria-labelledby="pipeline-tab-chat"
+        hidden={mode !== "chat"}
+        style={{
+          display: mode === "chat" ? "flex" : "none",
+          flexDirection: "column",
+          flex: 1,
+          minHeight: 0,
+        }}
+      >
+        <PipelineChatBox />
+      </div>
       <input
         ref={importInputRef}
         type="file"

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -133,14 +133,28 @@ export function TabSelector<T extends string>({
   value,
   onChange,
   disabledOptions,
+  ariaLabel,
+  tabIdFor,
+  panelIdFor,
+  testIdFor,
 }: {
   options: { value: T; label: string }[];
   value: T;
   onChange: (v: T) => void;
   disabledOptions?: Set<T>;
+  /** Accessible label for the tablist as a whole. */
+  ariaLabel?: string;
+  /** Optional id generator so panels can reference the tab via aria-labelledby. */
+  tabIdFor?: (v: T) => string;
+  /** Optional id generator for the controlled tabpanel (used in aria-controls). */
+  panelIdFor?: (v: T) => string;
+  /** Optional data-testid generator for each tab button. */
+  testIdFor?: (v: T) => string;
 }) {
   return (
     <div
+      role="tablist"
+      aria-label={ariaLabel}
       style={{
         display: "flex",
         borderRadius: 10,
@@ -155,6 +169,13 @@ export function TabSelector<T extends string>({
         return (
           <button
             key={opt.value}
+            type="button"
+            role="tab"
+            id={tabIdFor?.(opt.value)}
+            aria-selected={isActive}
+            aria-controls={panelIdFor?.(opt.value)}
+            data-testid={testIdFor?.(opt.value)}
+            tabIndex={isActive ? 0 : -1}
             onClick={isActive || isDisabled ? undefined : () => onChange(opt.value)}
             style={{
               flex: 1,

--- a/src/stores/usePipelineUIStore.ts
+++ b/src/stores/usePipelineUIStore.ts
@@ -1,0 +1,72 @@
+/**
+ * UI state for the Pipeline panel: which tab is active (Editor vs Chat) and a
+ * transient "pipeline applied" notice surfaced after the chat assistant
+ * rewrites the graph.
+ *
+ * Mirrors the localStorage pattern used by useThemeStore / useAIConfigStore.
+ */
+
+import { create } from "zustand";
+
+export type PipelinePanelMode = "editor" | "chat";
+
+export interface PipelineAppliedNotice {
+  kind: "applied";
+  /** Monotonic id so consumers can de-dupe transient renders. */
+  id: number;
+}
+
+const STORAGE_KEY = "megane-pipeline-ui";
+
+function loadMode(): PipelinePanelMode {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (parsed && (parsed.mode === "editor" || parsed.mode === "chat")) {
+        return parsed.mode;
+      }
+    }
+  } catch {
+    // ignore parse / storage errors
+  }
+  return "editor";
+}
+
+function saveMode(mode: PipelinePanelMode) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ mode }));
+  } catch {
+    // ignore quota / blocked storage
+  }
+}
+
+interface PipelineUIStore {
+  mode: PipelinePanelMode;
+  pendingNotice: PipelineAppliedNotice | null;
+  setMode: (mode: PipelinePanelMode) => void;
+  /** Switch to the editor tab and surface a one-shot "applied" notice. */
+  markPipelineApplied: () => void;
+  dismissNotice: () => void;
+}
+
+let nextNoticeId = 1;
+
+export const usePipelineUIStore = create<PipelineUIStore>((set) => ({
+  mode: loadMode(),
+  pendingNotice: null,
+
+  setMode: (mode) => {
+    saveMode(mode);
+    set({ mode });
+  },
+
+  markPipelineApplied: () => {
+    saveMode("editor");
+    set({ mode: "editor", pendingNotice: { kind: "applied", id: nextNoticeId++ } });
+  },
+
+  dismissNotice: () => {
+    set({ pendingNotice: null });
+  },
+}));

--- a/tests/e2e/pipeline-editor.spec.ts
+++ b/tests/e2e/pipeline-editor.spec.ts
@@ -25,6 +25,12 @@ const SEEDED_KINDS = ["load_structure", "viewport"] as const;
 
 test.describe("pipeline-editor: webapp default graph", () => {
   test.beforeEach(async ({ page }) => {
+    // Set the global flag before any module-level code runs so useTour
+    // suppresses its auto-start. Without this, the driver.js overlay can
+    // intercept pointer events on the toolbar and tab buttons.
+    await page.addInitScript(() => {
+      (globalThis as { __MEGANE_TEST__?: boolean }).__MEGANE_TEST__ = true;
+    });
     await page.goto("/?test=1", { waitUntil: "domcontentloaded" });
     await waitForReady(page);
   });
@@ -49,5 +55,31 @@ test.describe("pipeline-editor: webapp default graph", () => {
     // Backdrop click closes (when not exporting).
     await page.locator('[data-testid="render-modal-backdrop"]').click({ position: { x: 5, y: 5 } });
     await expect(page.locator('[data-testid="render-modal"]')).toBeHidden();
+  });
+
+  test("tab selector switches between editor and chat panes", async ({ page }) => {
+    const editorTab = page.locator('[data-testid="pipeline-editor-tab-editor"]');
+    const chatTab = page.locator('[data-testid="pipeline-editor-tab-chat"]');
+    const editorPanel = page.locator("#pipeline-tabpanel-editor");
+    const chatPanel = page.locator("#pipeline-tabpanel-chat");
+
+    await expect(editorTab).toHaveAttribute("aria-selected", "true");
+    await expect(chatTab).toHaveAttribute("aria-selected", "false");
+    await expect(editorPanel).toBeVisible();
+    await expect(chatPanel).toBeHidden();
+    // Pipeline-tab-only buttons (Templates) are visible when on Editor.
+    await expect(page.locator('[data-testid="pipeline-editor-templates"]')).toBeVisible();
+
+    await chatTab.click();
+    await expect(chatTab).toHaveAttribute("aria-selected", "true");
+    await expect(editorTab).toHaveAttribute("aria-selected", "false");
+    await expect(chatPanel).toBeVisible();
+    await expect(editorPanel).toBeHidden();
+    // Templates button is inside the hidden editor tabpanel.
+    await expect(page.locator('[data-testid="pipeline-editor-templates"]')).toBeHidden();
+
+    // Common toolbar (I/O + Others) stays visible from Chat tab.
+    await expect(page.locator('[data-testid="pipeline-editor-render"]')).toBeVisible();
+    await expect(page.locator('[data-testid="pipeline-editor-theme"]')).toBeVisible();
   });
 });

--- a/tests/ts/components/PipelineEditor.tabs.test.tsx
+++ b/tests/ts/components/PipelineEditor.tabs.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
+
+vi.mock("@xyflow/react", async () => {
+  const React = await import("react");
+  return {
+    ReactFlow: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement("div", { "data-testid": "react-flow" }, children),
+    ReactFlowProvider: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement("div", null, children),
+    MiniMap: () => null,
+    Controls: () => null,
+    Background: () => null,
+    BackgroundVariant: { Dots: "dots" },
+    useReactFlow: () => ({
+      screenToFlowPosition: () => ({ x: 0, y: 0 }),
+      fitView: () => {},
+      getZoom: () => 1,
+    }),
+    Handle: () => null,
+    Position: { Left: "left", Right: "right", Top: "top", Bottom: "bottom" },
+  };
+});
+
+vi.mock("@/components/PipelineChatBox", () => ({
+  PipelineChatBox: () => <div data-testid="chat-stub">chat</div>,
+}));
+vi.mock("@/components/RenderModal", () => ({
+  RenderModal: () => null,
+}));
+vi.mock("@/tour/MeganeTour", () => ({
+  startTour: vi.fn(),
+  startPipelineTutorial: vi.fn(),
+}));
+vi.mock("@/renderer/RenderCapture", () => ({
+  downloadBlob: vi.fn(),
+}));
+
+import { PipelineEditor } from "@/components/PipelineEditor";
+import { usePipelineUIStore } from "@/stores/usePipelineUIStore";
+
+afterEach(() => {
+  cleanup();
+  usePipelineUIStore.setState({ mode: "editor", pendingNotice: null });
+  localStorage.clear();
+});
+
+describe("PipelineEditor — tab switching", () => {
+  beforeEach(() => {
+    usePipelineUIStore.setState({ mode: "editor", pendingNotice: null });
+  });
+
+  it("renders both tab buttons with the editor selected by default", () => {
+    render(<PipelineEditor collapsed={false} onToggleCollapse={() => {}} />);
+
+    const editorTab = screen.getByTestId("pipeline-editor-tab-editor");
+    const chatTab = screen.getByTestId("pipeline-editor-tab-chat");
+    expect(editorTab.getAttribute("aria-selected")).toBe("true");
+    expect(chatTab.getAttribute("aria-selected")).toBe("false");
+
+    expect(screen.getByTestId("pipeline-editor-templates")).toBeTruthy();
+    expect(screen.getByTestId("react-flow")).toBeTruthy();
+  });
+
+  it("hides the editor pane and reveals the chat pane when the chat tab is clicked", () => {
+    render(<PipelineEditor collapsed={false} onToggleCollapse={() => {}} />);
+
+    fireEvent.click(screen.getByTestId("pipeline-editor-tab-chat"));
+
+    expect(usePipelineUIStore.getState().mode).toBe("chat");
+    expect(screen.getByTestId("pipeline-editor-tab-chat").getAttribute("aria-selected")).toBe(
+      "true",
+    );
+
+    const editorPanel = document.getElementById("pipeline-tabpanel-editor");
+    const chatPanel = document.getElementById("pipeline-tabpanel-chat");
+    expect(editorPanel?.style.display).toBe("none");
+    expect(chatPanel?.style.display).toBe("flex");
+  });
+
+  it("keeps the I/O and Others toolbar rows visible from both tabs", () => {
+    render(<PipelineEditor collapsed={false} onToggleCollapse={() => {}} />);
+
+    expect(screen.getByTestId("pipeline-editor-share")).toBeTruthy();
+    expect(screen.getByTestId("pipeline-editor-render")).toBeTruthy();
+    expect(screen.getByTestId("pipeline-editor-theme")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("pipeline-editor-tab-chat"));
+
+    expect(screen.getByTestId("pipeline-editor-share")).toBeTruthy();
+    expect(screen.getByTestId("pipeline-editor-render")).toBeTruthy();
+    expect(screen.getByTestId("pipeline-editor-theme")).toBeTruthy();
+  });
+
+  it("hides Pipeline-tab-only buttons (Templates) when the chat tab is active", () => {
+    render(<PipelineEditor collapsed={false} onToggleCollapse={() => {}} />);
+
+    fireEvent.click(screen.getByTestId("pipeline-editor-tab-chat"));
+
+    const editorPanel = document.getElementById("pipeline-tabpanel-editor")!;
+    expect(editorPanel.style.display).toBe("none");
+    // The Templates button lives inside the Editor tab — it is still in the
+    // DOM (display:none parent) so we assert its containing tabpanel is hidden.
+    expect(editorPanel.contains(screen.getByTestId("pipeline-editor-templates"))).toBe(true);
+  });
+
+  it("auto-switches back to editor and shows the applied notice when chat applies a pipeline", () => {
+    usePipelineUIStore.setState({ mode: "chat", pendingNotice: null });
+    render(<PipelineEditor collapsed={false} onToggleCollapse={() => {}} />);
+
+    expect(screen.getByTestId("pipeline-editor-tab-chat").getAttribute("aria-selected")).toBe(
+      "true",
+    );
+    expect(screen.queryByTestId("pipeline-editor-applied-notice")).toBeNull();
+
+    act(() => {
+      usePipelineUIStore.getState().markPipelineApplied();
+    });
+
+    expect(usePipelineUIStore.getState().mode).toBe("editor");
+    expect(screen.getByTestId("pipeline-editor-tab-editor").getAttribute("aria-selected")).toBe(
+      "true",
+    );
+    expect(screen.getByTestId("pipeline-editor-applied-notice")).toBeTruthy();
+  });
+});

--- a/tests/ts/components/nodes/AddBondNode.test.tsx
+++ b/tests/ts/components/nodes/AddBondNode.test.tsx
@@ -55,9 +55,9 @@ describe("AddBondNode", () => {
     const seeded = seedPipelineStore("add_bond", { id: "ab1" });
     render(<AddBondNode {...nodeProps("ab1", seeded.data.params as AddBondParams)} />);
 
-    expect(screen.getByRole("button", { name: "File" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "VDW" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Topology" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "File" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "VDW" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Topology" })).toBeInTheDocument();
   });
 
   it("clicking a tab calls updateNodeParams with the new bondSource", () => {
@@ -69,10 +69,10 @@ describe("AddBondNode", () => {
     usePipelineStore.setState({ updateNodeParams });
     render(<AddBondNode {...nodeProps("ab1", seeded.data.params as AddBondParams)} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "File" }));
+    fireEvent.click(screen.getByRole("tab", { name: "File" }));
     expect(updateNodeParams).toHaveBeenCalledWith("ab1", { bondSource: "structure" });
 
-    fireEvent.click(screen.getByRole("button", { name: "Topology" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Topology" }));
     expect(updateNodeParams).toHaveBeenCalledWith("ab1", { bondSource: "file" });
   });
 

--- a/tests/ts/components/nodes/LabelGeneratorNode.test.tsx
+++ b/tests/ts/components/nodes/LabelGeneratorNode.test.tsx
@@ -33,9 +33,9 @@ describe("LabelGeneratorNode", () => {
       <LabelGeneratorNode {...nodeProps("lg1", seeded.data.params as LabelGeneratorParams)} />,
     );
 
-    expect(screen.getByRole("button", { name: "Element" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Resname" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Index" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Element" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Resname" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Index" })).toBeInTheDocument();
   });
 
   it("renders inside a NodeShell with the Labels title", () => {
@@ -57,10 +57,10 @@ describe("LabelGeneratorNode", () => {
       <LabelGeneratorNode {...nodeProps("lg1", seeded.data.params as LabelGeneratorParams)} />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Resname" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Resname" }));
     expect(updateNodeParams).toHaveBeenCalledWith("lg1", { source: "resname" });
 
-    fireEvent.click(screen.getByRole("button", { name: "Index" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Index" }));
     expect(updateNodeParams).toHaveBeenCalledWith("lg1", { source: "index" });
   });
 
@@ -75,7 +75,7 @@ describe("LabelGeneratorNode", () => {
       <LabelGeneratorNode {...nodeProps("lg1", seeded.data.params as LabelGeneratorParams)} />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Element" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Element" }));
     expect(updateNodeParams).not.toHaveBeenCalled();
   });
 
@@ -88,8 +88,8 @@ describe("LabelGeneratorNode", () => {
       <LabelGeneratorNode {...nodeProps("lg1", seeded.data.params as LabelGeneratorParams)} />,
     );
 
-    const active = screen.getByRole("button", { name: "Resname" });
-    const inactive = screen.getByRole("button", { name: "Element" });
+    const active = screen.getByRole("tab", { name: "Resname" });
+    const inactive = screen.getByRole("tab", { name: "Element" });
     // Active tab uses the primary CSS variable; inactive uses the muted variable
     expect(active.style.color).toBe("var(--megane-primary)");
     expect(inactive.style.color).toBe("var(--megane-text-muted)");

--- a/tests/ts/components/ui.test.tsx
+++ b/tests/ts/components/ui.test.tsx
@@ -92,4 +92,32 @@ describe("TabSelector", () => {
     fireEvent.click(gamma);
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it("exposes tablist/tab roles with aria-selected reflecting the active option", () => {
+    render(
+      <TabSelector
+        options={options}
+        value="b"
+        onChange={() => {}}
+        ariaLabel="Choose"
+        tabIdFor={(v) => `t-${v}`}
+        panelIdFor={(v) => `p-${v}`}
+        testIdFor={(v) => `tab-${v}`}
+      />,
+    );
+
+    const tablist = screen.getByRole("tablist", { name: "Choose" });
+    expect(tablist).toBeTruthy();
+
+    const beta = screen.getByTestId("tab-b");
+    expect(beta.getAttribute("role")).toBe("tab");
+    expect(beta.getAttribute("aria-selected")).toBe("true");
+    expect(beta.getAttribute("aria-controls")).toBe("p-b");
+    expect(beta.getAttribute("id")).toBe("t-b");
+    expect(beta.getAttribute("tabindex")).toBe("0");
+
+    const alpha = screen.getByTestId("tab-a");
+    expect(alpha.getAttribute("aria-selected")).toBe("false");
+    expect(alpha.getAttribute("tabindex")).toBe("-1");
+  });
 });

--- a/tests/ts/stores/usePipelineUIStore.test.ts
+++ b/tests/ts/stores/usePipelineUIStore.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { usePipelineUIStore } from "@/stores/usePipelineUIStore";
+
+const STORAGE_KEY = "megane-pipeline-ui";
+
+function resetStore() {
+  usePipelineUIStore.setState({ mode: "editor", pendingNotice: null });
+}
+
+describe("usePipelineUIStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetStore();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to the editor tab and no pending notice", () => {
+    expect(usePipelineUIStore.getState().mode).toBe("editor");
+    expect(usePipelineUIStore.getState().pendingNotice).toBeNull();
+  });
+
+  it("setMode persists the chosen tab to localStorage", () => {
+    usePipelineUIStore.getState().setMode("chat");
+
+    expect(usePipelineUIStore.getState().mode).toBe("chat");
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual({ mode: "chat" });
+
+    usePipelineUIStore.getState().setMode("editor");
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual({ mode: "editor" });
+  });
+
+  it("setMode tolerates a localStorage that throws", () => {
+    const setItem = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("quota exceeded");
+      });
+
+    expect(() => usePipelineUIStore.getState().setMode("chat")).not.toThrow();
+    expect(usePipelineUIStore.getState().mode).toBe("chat");
+    setItem.mockRestore();
+  });
+
+  it("markPipelineApplied switches to the editor tab and stamps a notice", () => {
+    usePipelineUIStore.setState({ mode: "chat", pendingNotice: null });
+
+    usePipelineUIStore.getState().markPipelineApplied();
+
+    expect(usePipelineUIStore.getState().mode).toBe("editor");
+    expect(usePipelineUIStore.getState().pendingNotice).toMatchObject({ kind: "applied" });
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual({ mode: "editor" });
+  });
+
+  it("each markPipelineApplied call yields a fresh notice id", () => {
+    usePipelineUIStore.getState().markPipelineApplied();
+    const first = usePipelineUIStore.getState().pendingNotice!.id;
+
+    usePipelineUIStore.getState().markPipelineApplied();
+    const second = usePipelineUIStore.getState().pendingNotice!.id;
+
+    expect(second).toBeGreaterThan(first);
+  });
+
+  it("dismissNotice clears the pending notice", () => {
+    usePipelineUIStore.getState().markPipelineApplied();
+    expect(usePipelineUIStore.getState().pendingNotice).not.toBeNull();
+
+    usePipelineUIStore.getState().dismissNotice();
+    expect(usePipelineUIStore.getState().pendingNotice).toBeNull();
+  });
+});
+
+describe("usePipelineUIStore initial load", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("hydrates the mode from localStorage when a valid value is stored", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ mode: "chat" }));
+    const mod = await import("@/stores/usePipelineUIStore");
+    expect(mod.usePipelineUIStore.getState().mode).toBe("chat");
+  });
+
+  it("falls back to 'editor' when the stored payload is malformed", async () => {
+    localStorage.setItem(STORAGE_KEY, "not-json");
+    const mod = await import("@/stores/usePipelineUIStore");
+    expect(mod.usePipelineUIStore.getState().mode).toBe("editor");
+  });
+
+  it("falls back to 'editor' when the stored mode is unknown", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ mode: "neon" }));
+    const mod = await import("@/stores/usePipelineUIStore");
+    expect(mod.usePipelineUIStore.getState().mode).toBe("editor");
+  });
+
+  it("falls back to 'editor' when localStorage.getItem throws", async () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    const mod = await import("@/stores/usePipelineUIStore");
+    expect(mod.usePipelineUIStore.getState().mode).toBe("editor");
+  });
+});


### PR DESCRIPTION
## Summary

The Pipeline panel previously stacked the ReactFlow editor and the AI chat box together, with chat occupying a fixed bottom strip. This crowded the graph during editing and gave chat-driven workflows very little vertical space. This PR introduces a tabbed UI inside the panel.

- **Editor tab**: ReactFlow graph + Pipeline-only buttons (Add Node / Layout / Templates).
- **Chat tab**: full-height `PipelineChatBox` (placeholder when empty).
- **Shared header**: I/O (Export / Import / Share / Render) and Others (Guide / Tutorial / Theme) rows stay visible from both tabs, with a `TabSelector` on the bottom of the header.
- New `usePipelineUIStore` persists the active tab to `localStorage` (`megane-pipeline-ui`) and surfaces a one-shot "Pipeline updated from chat" banner.
- When chat applies a generated pipeline, `markPipelineApplied()` auto-switches to the Editor tab; a `useEffect([mode])` re-runs `fitView` after the editor pane becomes visible so ReactFlow picks up the un-hidden dimensions.
- Both panes stay mounted (`display:none` toggle) so chat history, in-flight `AbortController`, and the ReactFlow viewport survive switches.
- `TabSelector` gains optional ARIA props (`role=tablist/tab`, `aria-selected`, `aria-controls`, id/test-id generators). Existing call sites are unchanged; node-level tests that previously used `getByRole("button")` to find tab buttons now use `getByRole("tab")`.

Hosts: webapp, VSCode extension, JupyterLab DocWidget and the JupyterLab pipeline-doc widget all consume the same `PipelineEditor` via `MeganeViewer`, so the change propagates without per-host wiring. The Jupyter `MolecularViewer` anywidget intentionally does not mount the visual editor (CLAUDE.md rule #7) and is unaffected.

## Test plan

- [x] `npm test` — 1209/1209 passing
- [x] `usePipelineUIStore` covered to 100% by new store unit tests
- [x] New `PipelineEditor.tabs.test.tsx` exercises default state, click-to-switch, chat-applied auto-switch + notice, and shared toolbar visibility from both tabs
- [x] Updated `LabelGeneratorNode` / `AddBondNode` tests to use `getByRole("tab")`
- [x] `npm run lint` — 0 errors (24 pre-existing warnings)
- [x] `npm run format:check` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build:wasm`, `build:app`, `build:widget`, `build:lib` — all succeed
- [x] Playwright `pipeline-editor` project — 3/3 passing (added `addInitScript` to set `__MEGANE_TEST__=true` so the driver.js tour does not intercept the new tab click target)
- [ ] `render-modal` and `sidebar` Playwright projects fail with the same driver.js tour overlay issue **on `main` as well**, so they are pre-existing flakes unrelated to this change


---
_Generated by [Claude Code](https://claude.ai/code/session_01P1ubSeMyw3tjaswZj28X5p)_