### PR TITLE
feat: add SVG export to snapshot modal (issue #372)

### DIFF
--- a/src/components/RenderModal.tsx
+++ b/src/components/RenderModal.tsx
@@ -262,8 +262,7 @@ export function RenderModal({
   if (!open) return null;
 
   const hasAnimation = totalFrames > 1;
-  const is3DFormat =
-    mode === "snapshot" && (snapshotFormat === "gltf" || snapshotFormat === "obj");
+  const is3DFormat = mode === "snapshot" && (snapshotFormat === "gltf" || snapshotFormat === "obj");
 
   return createPortal(
     <div

--- a/src/components/RenderModal.tsx
+++ b/src/components/RenderModal.tsx
@@ -15,7 +15,7 @@ import {
 } from "../renderer/RenderCapture";
 
 type Mode = "snapshot" | "animation";
-type SnapshotFormat = "png" | "eps" | "gltf" | "obj";
+type SnapshotFormat = "png" | "eps" | "svg" | "gltf" | "obj";
 type AnimationFormat = "gif" | "mp4";
 
 interface RenderModalProps {
@@ -202,9 +202,9 @@ export function RenderModal({
             width: finalW,
             height: finalH,
             transparent: transparent && snapshotFormat === "png",
-            format: snapshotFormat as "png" | "eps",
+            format: snapshotFormat as "png" | "eps" | "svg",
           });
-          const ext = snapshotFormat === "eps" ? "eps" : "png";
+          const ext = snapshotFormat === "eps" ? "eps" : snapshotFormat === "svg" ? "svg" : "png";
           downloadBlob(blob, `megane-render.${ext}`);
         }
       } else {
@@ -262,7 +262,8 @@ export function RenderModal({
   if (!open) return null;
 
   const hasAnimation = totalFrames > 1;
-  const is3DFormat = mode === "snapshot" && (snapshotFormat === "gltf" || snapshotFormat === "obj");
+  const is3DFormat =
+    mode === "snapshot" && (snapshotFormat === "gltf" || snapshotFormat === "obj");
 
   return createPortal(
     <div
@@ -337,6 +338,11 @@ export function RenderModal({
                 label="EPS"
                 active={snapshotFormat === "eps"}
                 onClick={() => setSnapshotFormat("eps")}
+              />
+              <TabButton
+                label="SVG"
+                active={snapshotFormat === "svg"}
+                onClick={() => setSnapshotFormat("svg")}
               />
               <TabButton
                 label="glTF"

--- a/src/renderer/RenderCapture.ts
+++ b/src/renderer/RenderCapture.ts
@@ -99,6 +99,27 @@ showpage
   return new Blob([eps], { type: "application/postscript" });
 }
 
+/** Read a Blob as a base64-encoded data URL. */
+function blobToDataURL(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+}
+
+/** Wrap a PNG image as an SVG file with an embedded raster image element. */
+export async function wrapInSVG(pngBlob: Blob, width: number, height: number): Promise<Blob> {
+  const dataURL = await blobToDataURL(pngBlob);
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+  <title>megane export</title>
+  <image x="0" y="0" width="${width}" height="${height}" xlink:href="${dataURL}"/>
+</svg>`;
+  return new Blob([svg], { type: "image/svg+xml" });
+}
+
 /** Capture a single snapshot from the renderer. */
 export async function captureSnapshot(
   renderer: MoleculeRenderer,
@@ -106,7 +127,7 @@ export async function captureSnapshot(
     width: number;
     height: number;
     transparent: boolean;
-    format: "png" | "eps";
+    format: "png" | "eps" | "svg";
   },
 ): Promise<Blob> {
   const { width, height, transparent, format } = options;
@@ -145,6 +166,9 @@ export async function captureSnapshot(
   const pngBlob = await canvasToBlob(composited, "image/png");
   if (format === "eps") {
     return wrapInEPS(pngBlob, width, height);
+  }
+  if (format === "svg") {
+    return wrapInSVG(pngBlob, width, height);
   }
   return pngBlob;
 }

--- a/tests/ts/components/RenderModal.test.tsx
+++ b/tests/ts/components/RenderModal.test.tsx
@@ -84,7 +84,7 @@ describe("RenderModal", () => {
     expect(screen.getByTestId("render-modal")).toBeTruthy();
   });
 
-  it("shows PNG and EPS format buttons in snapshot mode", () => {
+  it("shows PNG, EPS and SVG format buttons in snapshot mode", () => {
     render(
       <RenderModal
         open
@@ -97,6 +97,7 @@ describe("RenderModal", () => {
     );
     expect(screen.getByText("PNG")).toBeTruthy();
     expect(screen.getByText("EPS")).toBeTruthy();
+    expect(screen.getByText("SVG")).toBeTruthy();
   });
 
   it("shows glTF and OBJ format buttons in snapshot mode", () => {
@@ -186,6 +187,36 @@ describe("RenderModal", () => {
     );
     fireEvent.click(screen.getByText("OBJ"));
     expect(screen.getByText("Export OBJ")).toBeTruthy();
+  });
+
+  it("shows resolution controls for SVG format", () => {
+    render(
+      <RenderModal
+        open
+        onClose={() => {}}
+        rendererRef={makeRendererRef()}
+        totalFrames={1}
+        currentFrame={0}
+        onSeek={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByText("SVG"));
+    expect(screen.getByText("Resolution")).toBeTruthy();
+  });
+
+  it("shows 'Export SVG' on the button when SVG is selected", () => {
+    render(
+      <RenderModal
+        open
+        onClose={() => {}}
+        rendererRef={makeRendererRef()}
+        totalFrames={1}
+        currentFrame={0}
+        onSeek={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByText("SVG"));
+    expect(screen.getByText("Export SVG")).toBeTruthy();
   });
 
   it("calls onClose when the backdrop is clicked", () => {

--- a/tests/ts/renderer/RenderCapture.test.ts
+++ b/tests/ts/renderer/RenderCapture.test.ts
@@ -26,6 +26,8 @@ import {
   downloadBlob,
   captureGltf,
   captureObj,
+  wrapInSVG,
+  captureSnapshot,
 } from "@/renderer/RenderCapture";
 import type { MoleculeRenderer } from "@/renderer/MoleculeRenderer";
 
@@ -162,6 +164,108 @@ describe("captureGltf", () => {
     const getScene = vi.spyOn(renderer, "getScene");
     await captureGltf(renderer);
     expect(getScene).toHaveBeenCalledOnce();
+  });
+});
+
+/** Helper to read a Blob as text via FileReader (works in jsdom). */
+function readBlobText(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(blob);
+  });
+}
+
+describe("wrapInSVG", () => {
+  it("returns a Blob with image/svg+xml MIME type", async () => {
+    const png = new Blob([new Uint8Array([137, 80, 78, 71])], { type: "image/png" });
+    const result = await wrapInSVG(png, 100, 80);
+    expect(result).toBeInstanceOf(Blob);
+    expect(result.type).toBe("image/svg+xml");
+  });
+
+  it("returns a non-empty Blob", async () => {
+    const png = new Blob([new Uint8Array([137, 80, 78, 71])], { type: "image/png" });
+    const result = await wrapInSVG(png, 100, 80);
+    expect(result.size).toBeGreaterThan(0);
+  });
+
+  it("embeds correct width and height in the SVG", async () => {
+    const png = new Blob([new Uint8Array([0, 1, 2])], { type: "image/png" });
+    const result = await wrapInSVG(png, 320, 240);
+    const text = await readBlobText(result);
+    expect(text).toContain('width="320"');
+    expect(text).toContain('height="240"');
+  });
+
+  it("contains an <image> element with a data URI", async () => {
+    const png = new Blob([new Uint8Array([0, 1, 2])], { type: "image/png" });
+    const result = await wrapInSVG(png, 10, 10);
+    const text = await readBlobText(result);
+    expect(text).toContain("data:");
+    expect(text).toContain("<image");
+  });
+
+  it("produces valid SVG XML with correct root element", async () => {
+    const png = new Blob([new Uint8Array([0])], { type: "image/png" });
+    const result = await wrapInSVG(png, 50, 50);
+    const text = await readBlobText(result);
+    expect(text).toContain('<svg xmlns="http://www.w3.org/2000/svg"');
+    expect(text).toContain("</svg>");
+  });
+
+  it("includes viewBox matching width and height", async () => {
+    const png = new Blob([new Uint8Array([0])], { type: "image/png" });
+    const result = await wrapInSVG(png, 400, 300);
+    const text = await readBlobText(result);
+    expect(text).toContain('viewBox="0 0 400 300"');
+  });
+});
+
+describe("captureSnapshot (svg format)", () => {
+  let restore2d: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    const ctx = {
+      drawImage: vi.fn(),
+      getImageData: vi.fn().mockReturnValue({ data: new Uint8ClampedArray(16) }),
+    };
+    restore2d = vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+      ctx as unknown as CanvasRenderingContext2D,
+    ) as ReturnType<typeof vi.fn>;
+
+    // Mock toBlob to return a minimal PNG blob
+    vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation(function (
+      this: HTMLCanvasElement,
+      callback: BlobCallback,
+    ) {
+      callback(new Blob([new Uint8Array([137, 80, 78, 71])], { type: "image/png" }));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns an SVG blob when format is svg", async () => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 8;
+    canvas.height = 8;
+    const renderer = {
+      ...makeMockRenderer(),
+      getCanvas: () => canvas,
+    } as unknown as MoleculeRenderer;
+
+    const blob = await captureSnapshot(renderer, {
+      width: 8,
+      height: 8,
+      transparent: false,
+      format: "svg",
+    });
+
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe("image/svg+xml");
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `wrapInSVG()` to `src/renderer/RenderCapture.ts`: reads the composited canvas PNG via `FileReader.readAsDataURL`, embeds it as a base64 data URI inside a valid `<svg>` document with correct `width`, `height`, and `viewBox` attributes.
- Extends `captureSnapshot()` to accept `format: "png" | "eps" | "svg"` and dispatch to `wrapInSVG()` for SVG output.
- Adds an **SVG** format tab to `src/components/RenderModal.tsx` alongside the existing PNG / EPS / glTF / OBJ tabs; resolution controls remain visible (same behaviour as PNG/EPS); the export button shows "Export SVG" and downloads `megane-render.svg`.

## Tests

- **`tests/ts/renderer/RenderCapture.test.ts`**: 6 new tests for `wrapInSVG` (MIME type, non-empty, width/height, `<image>` element, SVG root, `viewBox`); 1 new test for `captureSnapshot` with `format: "svg"`.
- **`tests/ts/components/RenderModal.test.tsx`**: 2 new tests (SVG button visible, "Export SVG" button label).

All 20 `RenderCapture` tests and all 14 `RenderModal` tests pass locally.

## E2E

The `render-modal` Playwright project was run locally. The single failing test (`opens with snapshot mode by default`) is a **pre-existing failure** unrelated to this PR — it fails identically on the `main` branch due to the Welcome dialog blocking the Render button click. No new regression was introduced by this change.

No baseline PNGs were updated (the pre-existing failure had no baseline).

## Platforms

This change is webapp-only (the SVG export path lives entirely in the browser-side `RenderCapture.ts` and the `RenderModal` React component). No VSCode, JupyterLab, or Jupyter widget changes are needed for this feature.

Closes #372

https://claude.ai/code/session_01WtfbBRtS5UpkJa8KXoTvEx