### PR TITLE
docs: add mmCIF and AMBER topology to format tables

### DIFF
--- a/docs/docs/dev/architecture.md
+++ b/docs/docs/dev/architecture.md
@@ -29,8 +29,9 @@ Instead of mesh-based spheres (32+ triangles each), atoms are rendered as **scre
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │  Rust / WASM Parsers  (crates/megane-wasm/)                 │
-│  PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, LAMMPS data,            │
-│  XTC, DCD, AMBER NetCDF, ASE .traj, .lammpstrj/.dump        │
+│  PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, mmCIF, LAMMPS data,    │
+│  AMBER prmtop, XTC, DCD, AMBER NetCDF, ASE .traj,           │
+│  .lammpstrj/.dump                                           │
 │  → Snapshot { positions, elements, bonds, box }             │
 └────────────────────────────┬────────────────────────────────┘
                              │  wasm-bindgen FFI

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -104,7 +104,9 @@ For multiple independent viewers per page (e.g. embedding in MDX docs), use
 | SDF | `.sdf` | MDL SDfile — uses the MOL V2000 parser |
 | MOL2 | `.mol2` | Tripos MOL2 |
 | CIF | `.cif` | Crystallographic Information File |
+| mmCIF | `.mmcif` | Macromolecular CIF (PDBx/mmCIF) — large structure databases |
 | LAMMPS data | `.data`, `.lammps` | LAMMPS data file |
+| AMBER topology | `.prmtop` | AMBER parameter/topology file (no coordinates) |
 | XTC | `.xtc` | GROMACS compressed trajectory |
 | DCD | `.dcd` | CHARMM/NAMD binary trajectory |
 | ASE .traj | `.traj` | ASE trajectory (ULM binary format) |

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 ## What can megane do?
 
 - **Render 1M+ atoms at 60 fps** in the browser using billboard impostor rendering
-- **Load 13 file formats**: PDB, GRO, XYZ, MOL, SDF, MOL2, CIF, LAMMPS data, XTC, DCD, ASE `.traj`, LAMMPS dump, AMBER NetCDF
+- **Load 15 file formats**: PDB, GRO, XYZ, MOL, SDF, MOL2, CIF, mmCIF, LAMMPS data, AMBER topology, XTC, DCD, ASE `.traj`, LAMMPS dump, AMBER NetCDF
 - **Stream XTC trajectories from the `megane serve` CLI** over WebSocket — scrub multi-GB files without loading every frame into memory (browser/Jupyter without the CLI load full trajectories)
 - **Build visual pipelines** with a drag-and-drop node editor, or write them as Python/TypeScript code
 - **Integrate with Plotly**, MDX/Next.js, ipywidgets, and any framework via the framework-agnostic renderer
@@ -37,7 +37,9 @@ For a side-by-side comparison of which formats and UI features each environment 
 | MDL SDfile (parsed via the V2000 Molfile reader) | `.sdf` |
 | Tripos MOL2 | `.mol2` |
 | Crystallographic Information File | `.cif` |
+| Macromolecular CIF (mmCIF/PDBx) | `.mmcif` |
 | LAMMPS data | `.data`, `.lammps` |
+| AMBER topology | `.prmtop` |
 | GROMACS trajectory | `.xtc` |
 | CHARMM/NAMD DCD trajectory | `.dcd` |
 | ASE trajectory | `.traj` |


### PR DESCRIPTION
## Summary

- `introduction.md` listed 13 file formats and omitted **mmCIF** (`.mmcif`) and **AMBER topology** (`.prmtop`); updated count to 15 and added both rows to the format table.
- `getting-started.md` had the same 13-format table; added the two missing rows with descriptions.
- `architecture.md` system overview comment also lacked mmCIF and AMBER prmtop in its inline parser list; updated accordingly.

Both formats have full cross-host support already wired in the source code:
- WASM parsers: `parse_mmcif`, `parse_prmtop` in `crates/megane-wasm/src/lib.rs`
- PyO3 bindings: `parse_mmcif`, `parse_prmtop` in `crates/megane-python/src/lib.rs`
- Standalone accept list: `.mmcif`, `.prmtop` in `LoadStructureNode.tsx`
- JupyterLab `IFileType`: `megane-mmcif`, `megane-amber-prmtop` in `jupyterlab-megane/src/filetypes.ts`
- VSCode `customEditors`: `*.mmcif`, `*.prmtop` in `vscode-megane/package.json`
- `platform-support.md` already listed both formats correctly

The only gap was the introductory and getting-started documentation.

## Test plan

- [ ] Docs-only change — no code paths modified, no tests required.
- [ ] Verified format counts and table rows match the source-of-truth files listed above.