### PR TITLE
fix(pipeline-editor): stop Pipeline toolbar row from eating the canvas height

### DIFF
--- a/src/components/PipelineEditor.tsx
+++ b/src/components/PipelineEditor.tsx
@@ -745,8 +745,22 @@ function PipelineEditorInner({
 
   // Toolbar row that lives inside the Editor tab — its actions only make
   // sense while the user can see the graph. Hidden on the Chat tab.
+  // `toolbarRowStyle.flexBasis: "100%"` exists for the wrap-row parent in
+  // the panel header; here the parent is `flex-direction: column`, so a
+  // 100% basis would claim the entire column main axis (height) and leave
+  // a tall band of empty space around the buttons. Override to `auto` and
+  // pin `flexShrink: 0` so the toolbar takes only its content height and
+  // the ReactFlow canvas keeps the rest.
   const editorToolbar = (
-    <div style={{ ...toolbarRowStyle, padding: "5px 8px" }}>
+    <div
+      data-testid="pipeline-editor-row"
+      style={{
+        ...toolbarRowStyle,
+        padding: "5px 8px",
+        flexBasis: "auto",
+        flexShrink: 0,
+      }}
+    >
       <span style={toolbarCategoryLabelStyle}>Pipeline</span>
       <div style={{ position: "relative" }}>
         <button

--- a/tests/e2e/pipeline-editor.spec.ts
+++ b/tests/e2e/pipeline-editor.spec.ts
@@ -76,6 +76,17 @@ test.describe("pipeline-editor: webapp default graph", () => {
     expect(editorBox?.width ?? 0).toBeGreaterThan(100);
     expect(editorBox?.height ?? 0).toBeGreaterThan(100);
 
+    // Regression guard: the Pipeline toolbar row (Add Node / Layout /
+    // Templates) must take only its content height. A regression in the
+    // toolbar's flex basis previously made the row claim the entire pane
+    // height, leaving the buttons stranded inside an empty band. We assert
+    // the row height is well below the pane height so the canvas dominates.
+    const toolbarBox = await page
+      .locator('[data-testid="pipeline-editor-row"]')
+      .boundingBox();
+    expect(toolbarBox?.height ?? 0).toBeGreaterThan(0);
+    expect(toolbarBox?.height ?? 0).toBeLessThan((editorBox?.height ?? 0) / 3);
+
     await chatTab.click();
     await expect(chatTab).toHaveAttribute("aria-selected", "true");
     await expect(editorTab).toHaveAttribute("aria-selected", "false");

--- a/tests/ts/components/PipelineEditor.tabs.test.tsx
+++ b/tests/ts/components/PipelineEditor.tabs.test.tsx
@@ -102,6 +102,20 @@ describe("PipelineEditor — tab switching", () => {
     expect(screen.queryByTestId("pipeline-editor-theme")).toBeNull();
   });
 
+  it("editor toolbar overrides the wrap-row flex basis so it does not eat column height", () => {
+    render(<PipelineEditor collapsed={false} onToggleCollapse={() => {}} />);
+
+    const row = screen.getByTestId("pipeline-editor-row");
+    // `toolbarRowStyle.flexBasis: 100%` is meant for the `flex-wrap: wrap`
+    // header parent. Inside the column-flex Editor tabpanel a 100% basis
+    // would claim the whole pane height and leave the buttons floating
+    // inside a tall empty band. We pin the basis to `auto` and prevent
+    // shrink so the toolbar takes its content height and ReactFlow gets
+    // the remaining space.
+    expect(row.style.flexBasis).toBe("auto");
+    expect(row.style.flexShrink).toBe("0");
+  });
+
   it("hides Pipeline-tab-only buttons (Templates) when the chat tab is active", () => {
     render(<PipelineEditor collapsed={false} onToggleCollapse={() => {}} />);
 


### PR DESCRIPTION
## Summary

After #444 the Editor pane is correctly sized, but the **Add Node / Layout / Templates** toolbar row appears with a tall band of empty space around it — visible to the user as「add node だけがやたら空白が空いている」(see screenshot in the report).

Root cause: the toolbar wrapper reuses `toolbarRowStyle`, which sets `flexBasis: "100%"`. That basis is intended for the panel-header parent (which uses `flex-wrap: wrap` and wants every row to break onto its own line). Inside the Editor tabpanel the parent is `flex-direction: column`, and there a `100%` basis claims the **entire column main axis** — i.e. the full pane height. The toolbar div therefore stretches to fill the pane, with the buttons rendering at the top and leaving the rest of the row blank, which is what the user sees as a weird empty band around the buttons.

## Changes

- `src/components/PipelineEditor.tsx`: override `flexBasis: "auto"` and pin `flexShrink: 0` on the editor-toolbar wrapper, with a comment explaining why the inherited 100% basis must be undone in this context. Also tag the row with `data-testid="pipeline-editor-row"` so tests can hold the fix down.
- `tests/ts/components/PipelineEditor.tabs.test.tsx`: assert the toolbar's inline style carries `flexBasis: "auto"` and `flexShrink: "0"` (regression guard at the unit level).
- `tests/e2e/pipeline-editor.spec.ts`: assert the toolbar's bounding-box height is `> 0` and `< editorPaneHeight / 3`, so any regression that re-introduces a column-eating basis is caught visually.

## Test plan

- [x] `npx vitest run` — full unit suite green, **1303 / 1303** passing.
- [x] Patch coverage on changed file: `PipelineEditor.tsx` ≥ 70 % (Codecov gate).
- [x] `npm run test:e2e:pipeline-editor` — 3/3, including the new toolbar-height guard.
- [x] `npm run test:e2e:webapp` — 4/4, side-effect sweep.
- [x] `npm run lint` — 0 errors (24 pre-existing warnings in unrelated files).
- [x] `npm run format:check` — clean.
- [x] No baseline PNGs moved.

https://claude.ai/code/session_011XvfSydv1Pns4HzmwR6oV5

---
_Generated by [Claude Code](https://claude.ai/code/session_011XvfSydv1Pns4HzmwR6oV5)_