### PR TITLE
docs: fix incomplete parser format lists across docs and docstrings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ uv sync --extra dev          # Python dependencies
 
 megane is a molecular viewer: Rust core (parsers) + TypeScript/React frontend (Three.js) + Python backend (FastAPI/anywidget) + VSCode extension.
 Rust compiles to both PyO3 (Python) and WASM (browser) via a Cargo workspace with three crates:
-- `megane-core` — Core parsers (PDB, GRO, XYZ, MOL, CIF, LAMMPS data + LAMMPS trajectory, GROMACS topology, XTC, ASE `.traj`)
+- `megane-core` — Core parsers (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, mmCIF, LAMMPS data, LAMMPS dump, AMBER topology (.prmtop), GROMACS topology (.top), PSF topology (.psf), XTC, DCD, AMBER NetCDF (.nc), ASE `.traj`)
 - `megane-wasm` — WASM bindings (wasm-bindgen)
 - `megane-python` — PyO3 Python extension
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -54,7 +54,7 @@ npm run dev
 ```
 megane/
 ├── crates/                    # Rust workspace
-│   ├── megane-core/           # Core parsers (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, LAMMPS data, XTC, ASE .traj, .lammpstrj/.dump)
+│   ├── megane-core/           # Core parsers (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, mmCIF, LAMMPS data, AMBER topology (.prmtop), XTC, DCD, AMBER NetCDF (.nc), ASE .traj, .lammpstrj/.dump)
 │   ├── megane-python/         # PyO3 bindings
 │   └── megane-wasm/           # WASM bindings
 ├── python/megane/             # Python package

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -94,7 +94,8 @@ class PipelineNode:
 class LoadStructure(PipelineNode):
     """Load a molecular structure from a file.
 
-    Supported formats: PDB, GRO, XYZ, MOL, LAMMPS data.
+    Supported formats: PDB, GRO, XYZ, MOL, SDF, MOL2, CIF, LAMMPS data
+    (.data / .lammps), and ASE .traj.
 
     Ports:
         out.particle — atom data
@@ -997,7 +998,8 @@ def view(
     returns a :class:`~megane.widget.MolecularViewer` widget.
 
     Args:
-        path: Path to a structure file (PDB, GRO, XYZ, MOL, LAMMPS data).
+        path: Path to a structure file (PDB, GRO, XYZ, MOL, SDF, MOL2, CIF,
+            LAMMPS data, ASE .traj).
         bonds: Bond detection method. ``"distance"`` (default) uses VDW radii,
             ``"structure"`` (alias ``"file"``) reads bonds from the loaded
             structure file, ``None`` disables bonds.
@@ -1053,7 +1055,7 @@ def view_traj(
 
     Args:
         path: Path to a structure or self-contained trajectory file (PDB,
-            GRO, XYZ, MOL, LAMMPS data, ASE .traj).
+            GRO, XYZ, MOL, SDF, MOL2, CIF, LAMMPS data, ASE .traj).
         xtc: Path to an XTC trajectory file.
         traj: Path to an ASE ``.traj`` file.
         xyz: Path to a multi-frame XYZ trajectory file.

--- a/src/parsers/structure.ts
+++ b/src/parsers/structure.ts
@@ -1,8 +1,8 @@
 /**
  * WASM-based structure parser wrapper.
  * Loads the Rust WASM module and converts results to megane Snapshot/Frame types.
- * Supports PDB, GRO, XYZ (single- or multi-frame), MOL/SDF, CIF,
- * LAMMPS data, and ASE .traj (binary, multi-frame) formats.
+ * Supports PDB, GRO, XYZ (single- or multi-frame), MOL/SDF, MOL2, CIF,
+ * mmCIF, LAMMPS data, AMBER topology (.prmtop), and ASE .traj (binary, multi-frame) formats.
  */
 
 import type { Snapshot, Frame, TrajectoryMeta, VectorChannel } from "../types";
@@ -154,8 +154,9 @@ export async function parseStructureText(
 /**
  * Parse a structure File object using the WASM parser.
  * Auto-detects format from file extension (.pdb, .gro, .xyz, .mol, .sdf,
- * .cif, .data/.lammps, .traj). Returns a Snapshot (first model) and optional
- * trajectory Frames (multi-frame XYZ, multi-model PDB, ASE .traj).
+ * .mol2, .cif, .mmcif, .data/.lammps, .prmtop, .traj). Returns a Snapshot
+ * (first model) and optional trajectory Frames (multi-frame XYZ, multi-model
+ * PDB, ASE .traj).
  */
 export async function parseStructureFile(file: File): Promise<StructureParseResult> {
   await ensureInit();


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: add MOL2, mmCIF, AMBER topology (.prmtop), PSF (.psf), DCD, and AMBER NetCDF (.nc) to the megane-core parser list; fix `MOL` → `MOL/SDF`
- **docs/docs/configuration.md**: add mmCIF, AMBER topology (.prmtop), DCD, and AMBER NetCDF (.nc) to the megane-core comment in the project structure tree
- **python/megane/pipeline.py**: fix three docstrings that listed only a subset of supported formats (`LoadStructure` class, `view()` path arg, `view_traj()` path arg) — all were missing SDF, MOL2, and CIF; `LoadStructure` and `view()` were also missing ASE `.traj`
- **src/parsers/structure.ts**: add MOL2, mmCIF, and `.prmtop` to both the file-level module docstring and the `parseStructureFile` JSDoc

No functional code changed — all changes are documentation (markdown, code comments, docstrings).

## Verification

Cross-referenced each documentation location against the actual source of truth:
- `crates/megane-core/src/` — module files for each parser
- `crates/megane-wasm/src/lib.rs` — `pub fn parse_*` exports
- `crates/megane-python/src/lib.rs` — `#[pyfunction]` exports
- `python/megane/pipeline.py` — `_load_structure_file` dispatch table
- `src/parsers/structure.ts` — `getParserForExtension` switch statement
- `src/components/nodes/LoadStructureNode.tsx` — `STRUCTURE_ACCEPT`

## Test plan

- [ ] No tests required — documentation-only change
- [ ] CI lint/type-check passes

https://claude.ai/code/session_01NHWfLNTd1mVZLHMKFbKNpL