### PR TITLE
docs: fix documentation discrepancies against source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ function App() {
 | MOL2 | `.mol2` | Tripos MOL2 (multi-molecule, aromatic bonds) |
 | LAMMPS data | `.data`, `.lammps` | LAMMPS data file |
 | CIF | `.cif` | Crystallographic Information File |
+| mmCIF | `.mmcif`, `.cif` | Macromolecular CIF (PDBx/mmCIF) |
 | AMBER topology | `.prmtop` | AMBER parameter/topology file (atom names, elements, bonds) |
 
 ### Trajectory formats (`LoadTrajectory` node)
@@ -170,6 +171,7 @@ function App() {
 | DCD | `.dcd` | CHARMM/NAMD binary trajectory |
 | ASE .traj | `.traj` | ASE trajectory (ULM binary format) |
 | LAMMPS dump | `.lammpstrj` | LAMMPS dump trajectory |
+| AMBER NetCDF | `.nc` | AMBER binary trajectory (NetCDF format) |
 
 ## Development
 

--- a/docs/docs/platform-support.md
+++ b/docs/docs/platform-support.md
@@ -107,7 +107,7 @@ How data gets into the viewer on each platform:
 | **Jupyter widget** | Python only — no in-cell file picker | `MolecularViewer.load(pdb_path, xtc=, traj=)` (deprecated) or `MolecularViewer.set_pipeline(Pipeline)` (recommended) |
 | **JupyterLab** | Click a registered file type in the file browser | Internally reads `context.model` (`jupyterlab-megane/src/MeganeDocWidget.tsx`) |
 | **VSCode** | Open a registered file from the explorer; extension host posts `loadFile` / `loadPipeline` to the webview | `postMessage({ type: "loadFile", … })` (`vscode-megane/webview/main.tsx`) |
-| **Python** | `from megane.parsers import …` | `load_pdb`, `load_gro`, `load_mol`, `load_sdf`, `load_mol2`, `load_cif`, `load_lammps_data`, `load_traj`, `load_trajectory` (XTC), `load_xyz_trajectory`, `load_dcd`, `load_netcdf`, `load_lammpstrj`, and the `parse_*` PyO3 functions |
+| **Python** | `from megane import …` or `from megane.parsers import …` | `load_pdb`, `load_gro`, `load_mol`, `load_sdf`, `load_mol2`, `load_cif`, `load_lammps_data`, `load_traj`, `load_trajectory` (XTC), `load_xyz_trajectory`, `load_dcd`, `load_netcdf`, `load_lammpstrj`, and the `parse_*` PyO3 functions |
 
 ## Known gaps
 

--- a/python/megane/widget.py
+++ b/python/megane/widget.py
@@ -105,7 +105,7 @@ class MolecularViewer(anywidget.AnyWidget):
         """Load a molecular structure, optionally with a trajectory.
 
         The structure path is dispatched by extension to the appropriate
-        Rust-backed parser (PDB, GRO, XYZ, MOL, SDF, CIF, LAMMPS data, .traj).
+        Rust-backed parser (PDB, GRO, XYZ, MOL, SDF, MOL2, CIF, LAMMPS data, .traj).
         For multi-frame XYZ files the trajectory is inferred automatically.
 
         .. deprecated::


### PR DESCRIPTION
## Summary

- **README.md**: Add mmCIF (`.mmcif`) to structure formats table and AMBER NetCDF (`.nc`) to trajectory formats table. Both formats are fully supported in the Rust core and wired into all hosts, but were absent from the README format reference.
- **docs/platform-support.md**: Clarify the Python import surface in the "Load methods / APIs" table. Functions like `load_pdb`, `load_netcdf`, etc. are importable from both `megane` (top-level `__init__.py` re-exports) and `megane.parsers`, but the table previously only listed `from megane.parsers import …`.
- **python/megane/widget.py**: Add MOL2 to the format list in the deprecated `MolecularViewer.load()` docstring. MOL2 has Rust-backed parser support but was omitted from the docstring's human-readable format enumeration.

## Test plan

- [ ] Verify README.md format tables render correctly in GitHub preview
- [ ] Verify `docs/docs/platform-support.md` table is accurate against `python/megane/__init__.py` exports
- [ ] Verify `python/megane/widget.py` docstring reflects the actual formats dispatched by `_load_structure_file`
- [ ] No code logic changed — documentation-only diff, no tests required

https://claude.ai/code/session_01QQ8f9MEVx8jKKx5iw1UvAH

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQ8f9MEVx8jKKx5iw1UvAH)_