### PR TITLE
docs: fix documentation inconsistencies with source code

### DIFF
--- a/docs/docs/api/index.md
+++ b/docs/docs/api/index.md
@@ -24,7 +24,7 @@ viewer = megane.view("protein.pdb")
 viewer = megane.view_traj("protein.pdb", xtc="trajectory.xtc")
 ```
 
-[Python API Reference →](/api/python/)
+See the [Python Pipeline API guide](/guide/pipeline/python) for full documentation of the Pipeline class and all node types.
 
 ## TypeScript / JavaScript
 
@@ -38,4 +38,4 @@ The TypeScript API is used for:
 import { MeganeViewer, MoleculeRenderer } from "megane-viewer/lib";
 ```
 
-[TypeScript API Reference →](/api/typescript/)
+See the [TypeScript Pipeline guide](/guide/pipeline/typescript) for full documentation of the TypeScript pipeline API and React component props.

--- a/docs/docs/guide/pipeline/index.md
+++ b/docs/docs/guide/pipeline/index.md
@@ -62,6 +62,7 @@ Use the **Templates** dropdown to load pre-built pipelines:
 | **Load Trajectory** | Load a separate trajectory file (XTC, DCD, LAMMPS `.lammpstrj` / `.dump`, AMBER NetCDF `.nc`) | particle | trajectory |
 | **Streaming** | WebSocket-based real-time data delivery (only available on the standalone `megane serve` host) | — | particle, bond, trajectory, cell |
 | **Load Vector** | Load per-atom vector data from a file | — | vector |
+| **Load Volumetric** | Load a Gaussian CUBE file for volumetric (isosurface) rendering | — | volumetric |
 
 ### Processing
 
@@ -69,6 +70,8 @@ Use the **Templates** dropdown to load pre-built pipelines:
 |------|-------------|--------|---------|
 | **Filter** | Select atoms using a query expression | particle (in) | particle (out) |
 | **Modify** | Override scale and opacity for a group of atoms | particle (in) | particle (out) |
+| **Color** | Recolor the upstream particle stream by a chosen scheme | particle (in) | particle (out) |
+| **Representation** | Tag the particle stream with a visual representation override for the Viewport | particle (in) | particle (out) |
 
 ### Overlay
 
@@ -78,6 +81,7 @@ Use the **Templates** dropdown to load pre-built pipelines:
 | **Label Generator** | Generate text labels at atom positions | particle | label |
 | **Polyhedron Generator** | Render coordination polyhedra (convex hulls) | particle | mesh |
 | **Surface Mesh** | Generate an alpha-shape surface envelope around atoms | particle | mesh |
+| **Isosurface** | Extract an isosurface from volumetric data using marching cubes | volumetric | mesh |
 | **Vector Overlay** | Configure per-atom vector visualization (e.g. forces) | vector | vector |
 
 ### Output
@@ -107,6 +111,46 @@ Requires a connection from a LoadStructure node. Frames are loaded lazily when `
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | File path | string | Path to vector data file (JSON with per-atom 3D vectors) |
+
+### Load Volumetric
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| File path | string | Path to a Gaussian CUBE file (`.cube`). The file is parsed in the browser; frames are not streamed. |
+
+**Outputs:** `volumetric` — connects to an Isosurface node.
+
+### Isosurface
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| Iso level | number | 0.05 | Contour value for the positive isosurface |
+| Color (+) | string | `#4488ff` | Hex color for the positive isosurface |
+| Opacity | number | 0.7 | Surface transparency (0–1) |
+| Show negative lobe | boolean | off | Show a second isosurface at −isoLevel (dual-contour for ESP maps) |
+| Color (−) | string | `#ff4444` | Hex color for the negative isosurface (visible when "Show negative lobe" is on) |
+
+### Color
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| Mode | `uniform` | ✓ | Single solid color |
+| | `byElement` | — | CPK element coloring |
+| | `byResidue` | — | Color by residue name |
+| | `byChain` | — | Color by chain ID |
+| | `byBFactor` | — | Color by B-factor (temperature factor) |
+| | `byProperty` | — | Color by a numeric atom property |
+| Color | string | `#ff8800` | Hex color used when mode is `uniform` |
+| Range | [number, number]? | — | Optional explicit [min, max] for `byBFactor` / `byProperty` |
+
+### Representation
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| Mode | `atoms` | ✓ | Space-filling atom spheres |
+| | `cartoon` | — | Cartoon ribbon for proteins/nucleic acids |
+| | `both` | — | Atoms + cartoon simultaneously |
+| | `surface` | — | Solvent-accessible surface |
 
 ### Add Bond
 

--- a/docs/docs/guide/pipeline/json.md
+++ b/docs/docs/guide/pipeline/json.md
@@ -161,6 +161,30 @@ handle and emits the tagged particle stream on `out`.
 | `edgeColor` | `string` | Wireframe edge color (hex) |
 | `edgeWidth` | `number` | Wireframe edge width (px) |
 
+#### `surface_mesh`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `alphaRadius` | `number` | Probe sphere radius in Å (alpha value). Larger = smoother surface, smaller = more detail. |
+| `color` | `string` | Surface color (hex, e.g. `"#4488ff"`) |
+| `opacity` | `number` | Surface transparency (0–1) |
+
+#### `load_volumetric`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fileName` | `string \| null` | Display name of the CUBE file. Volumetric data (`volumetricData`) is ephemeral and not serialized. |
+
+#### `isosurface`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `isoLevel` | `number` | Contour value for the positive isosurface |
+| `color` | `string` | Hex color for the positive isosurface |
+| `opacity` | `number` | Surface transparency (0–1) |
+| `showNegative` | `boolean` | Show a second isosurface at −isoLevel (dual-contour for ESP maps) |
+| `negativeColor` | `string` | Hex color for the negative isosurface |
+
 #### `vector_overlay`
 
 | Field | Type | Description |

--- a/docs/docs/guide/pipeline/python.md
+++ b/docs/docs/guide/pipeline/python.md
@@ -58,6 +58,7 @@ from megane import (
     LoadTrajectory,
     Streaming,
     LoadVector,
+    LoadVolumetric,
     Filter,
     Modify,
     Color,
@@ -65,6 +66,7 @@ from megane import (
     AddBonds,
     AddLabels,
     AddPolyhedra,
+    Isosurface,
     VectorOverlay,
     Viewport,
     Pipeline,
@@ -135,6 +137,45 @@ LoadVector(path: str)
 | `path` | `str` | Path to vector data file |
 
 **Ports:** `out.vector`
+
+### LoadVolumetric
+
+Load a Gaussian CUBE file and output volumetric data for isosurface rendering.
+
+```python
+LoadVolumetric(path: str = "")
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `path` | `str` | File path to a Gaussian CUBE file (`.cube`). Parsed in the browser; the Python object only tracks the filename. |
+
+**Ports:** `out.volumetric`
+
+### Isosurface
+
+Extract an isosurface from volumetric data using marching cubes.
+
+```python
+Isosurface(
+    *,
+    iso_level: float = 0.05,
+    color: str = "#4488ff",
+    opacity: float = 0.7,
+    show_negative: bool = False,
+    negative_color: str = "#ff4444",
+)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `iso_level` | `float` | `0.05` | Contour value for the positive isosurface |
+| `color` | `str` | `"#4488ff"` | Hex color for the positive isosurface |
+| `opacity` | `float` | `0.7` | Surface transparency (0–1) |
+| `show_negative` | `bool` | `False` | Show a second isosurface at −iso_level (dual-contour for ESP maps) |
+| `negative_color` | `str` | `"#ff4444"` | Hex color for the negative isosurface |
+
+**Ports:** `inp.volumetric`, `out.mesh`
 
 ### Filter
 

--- a/docs/docs/platform-support.md
+++ b/docs/docs/platform-support.md
@@ -107,7 +107,7 @@ How data gets into the viewer on each platform:
 | **Jupyter widget** | Python only — no in-cell file picker | `MolecularViewer.load(pdb_path, xtc=, traj=)` (deprecated) or `MolecularViewer.set_pipeline(Pipeline)` (recommended) |
 | **JupyterLab** | Click a registered file type in the file browser | Internally reads `context.model` (`jupyterlab-megane/src/MeganeDocWidget.tsx`) |
 | **VSCode** | Open a registered file from the explorer; extension host posts `loadFile` / `loadPipeline` to the webview | `postMessage({ type: "loadFile", … })` (`vscode-megane/webview/main.tsx`) |
-| **Python** | `from megane import …` or `from megane.parsers import …` | `load_pdb`, `load_gro`, `load_mol`, `load_sdf`, `load_mol2`, `load_cif`, `load_lammps_data`, `load_traj`, `load_trajectory` (XTC), `load_xyz_trajectory`, `load_dcd`, `load_netcdf`, `load_lammpstrj`, and the `parse_*` PyO3 functions |
+| **Python** | `from megane import …` or `from megane.parsers import …` | Top-level `megane`: `load_pdb`, `load_cif`, `load_lammps_data`, `load_traj`, `load_trajectory` (XTC), `load_xyz_trajectory`. Full set via `megane.parsers`: additionally `load_gro`, `load_mol`, `load_sdf`, `load_mol2`, `load_dcd`, `load_netcdf`, `load_lammpstrj`, and the raw `parse_*` PyO3 functions. |
 
 ## Known gaps
 


### PR DESCRIPTION
## Summary

- **platform-support.md**: Corrected the Python load function API surface — top-level `megane` exports 6 load functions (`load_pdb`, `load_cif`, `load_lammps_data`, `load_traj`, `load_trajectory`, `load_xyz_trajectory`), while the full set of 13 is available via `megane.parsers`
- **pipeline/index.md**: Added `Color`, `Representation` (Processing), `Load Volumetric` (Data Loading), and `Isosurface` (Overlay) nodes to the Node Reference tables and Node Parameters sections
- **pipeline/json.md**: Added `surface_mesh`, `load_volumetric`, and `isosurface` node type sections with their serializable fields
- **pipeline/python.md**: Added `LoadVolumetric` and `Isosurface` class documentation (constructor signatures, parameters, ports); added both to the module import example
- **api/index.md**: Replaced broken links to non-existent `/api/python/` and `/api/typescript/` pages with links to the existing pipeline guide pages

## Test plan

- [ ] Documentation-only change — no code modified, no tests required
- [ ] All referenced node types (`isosurface`, `load_volumetric`, `surface_mesh`, `color`, `representation`) verified to exist in `src/pipeline/types.ts` and corresponding `src/components/nodes/` files
- [ ] `LoadVolumetric` and `Isosurface` Python classes verified in `python/megane/pipeline.py`
- [ ] Python export list verified against `python/megane/__init__.py` and `python/megane/parsers/__init__.py`

https://claude.ai/code/session_01WDfeXDvsewCyHyU9MhG7yE