### PR TITLE
docs: fix doc/source discrepancies in format lists and React API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 ## Features
 
 - **1M+ Atoms at 60fps** — Billboard impostor rendering scales from small molecules to massive complexes in real time. InstancedMesh for small systems auto-switches to GPU-accelerated billboard impostors for large systems. Stream XTC trajectories over WebSocket.
-- **Runs Everywhere** — Jupyter widget, CLI server, React component, and VSCode extension. Rust-based PDB, GRO, XYZ, MOL, CIF, XTC, DCD, LAMMPS, and ASE .traj parsers shared between Python (PyO3) and browser (WASM) — parse once, run anywhere.
+- **Runs Everywhere** — Jupyter widget, CLI server, React component, and VSCode extension. Rust-based parsers for 15 formats (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, mmCIF, LAMMPS data, AMBER topology, XTC, DCD, ASE .traj, LAMMPS dump, AMBER NetCDF) shared between Python (PyO3) and browser (WASM) — parse once, run anywhere.
 - **Visual Pipeline Editor** — Build visualization workflows by wiring nodes or let the AI generator build them from natural language. 11 node types with 7 typed data channels flowing through color-coded edges. Load multiple structures with layer-based rendering to compare systems side by side.
 - **Embed & Integrate** — Control the viewer from Plotly via ipywidgets events. Embed in MDX / Next.js docs. React to `frame_change`, `selection_change`, and `measurement` events. Use the framework-agnostic renderer from Vue, Svelte, or vanilla JS.
 
@@ -56,7 +56,7 @@ One codebase, every environment.
 
 For a per-platform breakdown of supported formats and UI features (including known gaps), see [Platform Support](https://hodakamori.github.io/megane/platform-support).
 
-The secret: PDB, GRO, XYZ, MOL, CIF, XTC, DCD, LAMMPS, and ASE .traj parsers are written in **Rust** and compiled to both **PyO3** (Python) and **WASM** (browser). Parse once, run anywhere.
+The secret: parsers for 15 formats (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, mmCIF, LAMMPS data, AMBER topology, XTC, DCD, ASE .traj, LAMMPS dump, AMBER NetCDF) are written in **Rust** and compiled to both **PyO3** (Python) and **WASM** (browser). Parse once, run anywhere.
 
 ### Visual Pipelines
 
@@ -133,17 +133,21 @@ docker run --rm -p 8080:8080 -v ./mydata:/data megane \
 ### React
 
 ```tsx
-import { MeganeViewer, parseStructureFile } from "megane-viewer/lib";
+import { useCallback } from "react";
+import { MeganeViewer, usePipelineStore } from "megane-viewer/lib";
 
 function App() {
-  const [snapshot, setSnapshot] = useState(null);
+  const handleUpload = useCallback((file: File) => {
+    usePipelineStore.getState().openFile(file);
+  }, []);
 
-  const handleUpload = async (file: File) => {
-    const result = await parseStructureFile(file);
-    setSnapshot(result.snapshot);
-  };
-
-  return <MeganeViewer snapshot={snapshot} mode="local" /* ... */ />;
+  return (
+    <MeganeViewer
+      onUploadStructure={handleUpload}
+      width="100%"
+      height="600px"
+    />
+  );
 }
 ```
 
@@ -160,7 +164,7 @@ function App() {
 | MOL2 | `.mol2` | Tripos MOL2 (multi-molecule, aromatic bonds) |
 | LAMMPS data | `.data`, `.lammps` | LAMMPS data file |
 | CIF | `.cif` | Crystallographic Information File |
-| mmCIF | `.mmcif`, `.cif` | Macromolecular CIF (PDBx/mmCIF) |
+| mmCIF | `.mmcif` | Macromolecular CIF (PDBx/mmCIF) |
 | AMBER topology | `.prmtop` | AMBER parameter/topology file (atom names, elements, bonds) |
 
 ### Trajectory formats (`LoadTrajectory` node)
@@ -170,7 +174,7 @@ function App() {
 | XTC | `.xtc` | GROMACS compressed trajectory |
 | DCD | `.dcd` | CHARMM/NAMD binary trajectory |
 | ASE .traj | `.traj` | ASE trajectory (ULM binary format) |
-| LAMMPS dump | `.lammpstrj` | LAMMPS dump trajectory |
+| LAMMPS dump | `.lammpstrj`, `.dump` | LAMMPS dump trajectory |
 | AMBER NetCDF | `.nc` | AMBER binary trajectory (NetCDF format) |
 
 ## Development
@@ -234,7 +238,7 @@ make test-all              # All tests
 src/                     TypeScript frontend
   renderer/              Three.js rendering (impostor, mesh, shaders)
   protocol/              Binary protocol decoder + web workers
-  parsers/               WASM-based file parsers (PDB, GRO, XYZ, MOL, CIF, XTC, LAMMPS, .traj)
+  parsers/               WASM-based file parsers (15 formats: PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, mmCIF, LAMMPS data/dump, AMBER topology/NetCDF, XTC, DCD, ASE .traj)
   logic/                 Bond / label / vector source logic
   components/            React UI components
   hooks/                 Custom React hooks
@@ -244,7 +248,7 @@ crates/                  Rust workspace
   megane-python/         PyO3 Python extension
   megane-wasm/           WASM bindings (wasm-bindgen)
 python/megane/           Python backend
-  parsers/               PDB / XTC parsers
+  parsers/               Python wrappers for all 15 supported formats
   pipeline.py            Pipeline builder (NetworkX-style DAG)
   protocol.py            Binary protocol encoder
   server.py              FastAPI WebSocket server

--- a/docs/docs/guide/pipeline/index.md
+++ b/docs/docs/guide/pipeline/index.md
@@ -29,7 +29,7 @@ The generator creates the appropriate LoadStructure, AddBond, Filter, Modify, an
 
 ## VSCode Extension Auto-Setup
 
-When you open a supported molecular file (`.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf`, `.mol2`, `.cif`, `.data`, `.lammps`, `.traj`, `.xtc`, `.dcd`, `.lammpstrj`, `.dump`, `.nc`) in the megane VSCode extension, it automatically creates a default pipeline consisting of `LoadStructure → AddBond → Viewport`. This gives you an immediate 3D view of the structure with bonds, without needing to build a pipeline manually. You can then modify the auto-generated pipeline in the editor as needed.
+When you open a supported molecular file (`.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf`, `.mol2`, `.cif`, `.mmcif`, `.data`, `.lammps`, `.prmtop`, `.traj`, `.xtc`, `.dcd`, `.lammpstrj`, `.dump`, `.nc`) in the megane VSCode extension, it automatically creates a default pipeline consisting of `LoadStructure → AddBond → Viewport`. This gives you an immediate 3D view of the structure with bonds, without needing to build a pipeline manually. You can then modify the auto-generated pipeline in the editor as needed.
 
 ## Getting Started
 
@@ -58,7 +58,7 @@ Use the **Templates** dropdown to load pre-built pipelines:
 
 | Node | Description | Inputs | Outputs |
 |------|-------------|--------|---------|
-| **Load Structure** | Load a molecular structure file (PDB, GRO, XYZ, MOL, SDF, MOL2, CIF, LAMMPS data, ASE `.traj`) | — | particle, trajectory, cell |
+| **Load Structure** | Load a molecular structure file (PDB, GRO, XYZ, MOL, SDF, MOL2, CIF, mmCIF, LAMMPS data, AMBER topology, ASE `.traj`) | — | particle, trajectory, cell |
 | **Load Trajectory** | Load a separate trajectory file (XTC, DCD, LAMMPS `.lammpstrj` / `.dump`, AMBER NetCDF `.nc`) | particle | trajectory |
 | **Streaming** | WebSocket-based real-time data delivery (only available on the standalone `megane serve` host) | — | particle, bond, trajectory, cell |
 | **Load Vector** | Load per-atom vector data from a file | — | vector |
@@ -92,7 +92,7 @@ Use the **Templates** dropdown to load pre-built pipelines:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| File path | string | Path to molecular structure file. Supported: `.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf`, `.mol2`, `.cif`, `.data` / `.lammps`, `.traj` (ASE) |
+| File path | string | Path to molecular structure file. Supported: `.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf`, `.mol2`, `.cif`, `.mmcif`, `.data` / `.lammps`, `.prmtop`, `.traj` (ASE) |
 
 ### Load Trajectory
 

--- a/docs/docs/guide/pipeline/python.md
+++ b/docs/docs/guide/pipeline/python.md
@@ -81,7 +81,7 @@ LoadStructure(path: str)
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `path` | `str` | File path. Auto-detected by extension. Supported: `.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf` (routed through the MOL parser), `.mol2`, `.cif`, `.data`, `.lammps`, `.traj` (ASE binary). |
+| `path` | `str` | File path. Auto-detected by extension. Supported: `.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf` (routed through the MOL parser), `.mol2`, `.cif`, `.mmcif`, `.data`, `.lammps`, `.prmtop`, `.traj` (ASE binary). |
 
 **Ports:** `out.particle`, `out.traj`, `out.cell`
 


### PR DESCRIPTION
## Summary

- **README.md**
  - Removed incorrect `.cif` from the mmCIF extension column — `.cif` is routed to the CIF parser (`parse_cif`), not the mmCIF parser (`parse_mmcif`); they are distinct parsers
  - Added missing `.dump` extension to the LAMMPS dump row
  - Expanded two abbreviated "PDB, GRO, XYZ, MOL, CIF, XTC, DCD, LAMMPS, and ASE .traj" parser mentions to the full 15-format list (matching `introduction.md`)
  - Fixed the React Quick Start code block: it used non-existent `snapshot` and `mode` props on `MeganeViewer`; replaced with the correct `onUploadStructure` + `usePipelineStore` pattern (matches `guide/web.md` and `MeganeViewerProps` interface)
  - Updated abbreviated project structure comments for `src/parsers/` and `python/megane/parsers/`

- **docs/guide/pipeline/index.md** — three locations were missing `.mmcif` and `.prmtop`:
  - VSCode Extension Auto-Setup file extension list
  - Load Structure node description in the Node Reference table
  - Load Structure parameter table

- **docs/guide/pipeline/python.md** — `LoadStructure` supported extensions table was missing `.mmcif` and `.prmtop`

## Sources of truth verified

| Source | Verified against |
|---|---|
| `src/components/nodes/LoadStructureNode.tsx` `STRUCTURE_ACCEPT` | includes `.mmcif`, `.prmtop` |
| `vscode-megane/package.json` `customEditors` | includes `.mmcif`, `.prmtop` |
| `src/parsers/structure.ts` | `.cif` → `parse_cif`; `.mmcif` → `parse_mmcif` (separate parsers) |
| `src/components/MeganeViewer.tsx` `MeganeViewerProps` | no `snapshot` or `mode` prop |

## Test plan

- [ ] Doc-only change — no code modified, no unit/E2E tests required
- [ ] Visually reviewed all edited markdown for correctness

https://claude.ai/code/session_015eVjnmxkjvcn5sJLgbcguw