### PR TITLE
docs: fix documentation discrepancies for mmCIF and AMBER prmtop

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ crates/                  Rust workspace
   megane-python/         PyO3 Python extension
   megane-wasm/           WASM bindings (wasm-bindgen)
 python/megane/           Python backend
-  parsers/               Python wrappers for all 15 supported formats
+  parsers/               Python wrappers for 13 of the 15 supported formats (mmCIF and AMBER prmtop are accessible via the raw megane_parser PyO3 extension)
   pipeline.py            Pipeline builder (NetworkX-style DAG)
   protocol.py            Binary protocol encoder
   server.py              FastAPI WebSocket server

--- a/docs/docs/guide/cli.md
+++ b/docs/docs/guide/cli.md
@@ -62,7 +62,7 @@ megane serve [PDB_FILE] [OPTIONS]
 
 | Argument | Description |
 |----------|-------------|
-| `PDB_FILE` | Path to a PDB file (optional; can upload from the browser). The CLI server only loads `.pdb` from this positional argument — to start with an ASE trajectory, use `--traj` instead. Once the browser is open, drag-and-drop in the standalone UI accepts every supported structure format (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, LAMMPS data, …). |
+| `PDB_FILE` | Path to a PDB file (optional; can upload from the browser). The CLI server only loads `.pdb` from this positional argument — to start with an ASE trajectory, use `--traj` instead. Once the browser is open, drag-and-drop in the standalone UI accepts every supported structure format (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, mmCIF, LAMMPS data, AMBER prmtop, ASE `.traj`, …). |
 
 ## Options
 

--- a/docs/docs/guide/pipeline/python.md
+++ b/docs/docs/guide/pipeline/python.md
@@ -83,7 +83,7 @@ LoadStructure(path: str)
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `path` | `str` | File path. Auto-detected by extension. Supported: `.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf` (routed through the MOL parser), `.mol2`, `.cif`, `.mmcif`, `.data`, `.lammps`, `.prmtop`, `.traj` (ASE binary). |
+| `path` | `str` | File path. Auto-detected by extension. Supported: `.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf` (routed through the MOL parser), `.mol2`, `.cif`, `.data`, `.lammps`, `.traj` (ASE binary). |
 
 **Ports:** `out.particle`, `out.traj`, `out.cell`
 

--- a/docs/docs/platform-support.md
+++ b/docs/docs/platform-support.md
@@ -35,9 +35,9 @@ Legend:
 | SDF | `.sdf` | ✓ | API | ✓ | ✓ | ✓ |
 | MOL2 | `.mol2` | ✓ | API | ✓ | ✓ | ✓ |
 | CIF | `.cif` | ✓ | API | ✓ | ✓ | ✓ |
-| mmCIF | `.mmcif` | ✓ | API | ✓ | ✓ | ✓ |
+| mmCIF | `.mmcif` | ✓ | API | ✓ | ✓ | API |
 | LAMMPS data | `.data`, `.lammps` | ✓ | API | ✓ | ✓ | ✓ |
-| AMBER topology | `.prmtop` | ✓ | API | ✓ | ✓ | ✓ |
+| AMBER topology | `.prmtop` | ✓ | API | ✓ | ✓ | API |
 
 ### Trajectory formats
 
@@ -107,7 +107,7 @@ How data gets into the viewer on each platform:
 | **Jupyter widget** | Python only — no in-cell file picker | `MolecularViewer.load(pdb_path, xtc=, traj=)` (deprecated) or `MolecularViewer.set_pipeline(Pipeline)` (recommended) |
 | **JupyterLab** | Click a registered file type in the file browser | Internally reads `context.model` (`jupyterlab-megane/src/MeganeDocWidget.tsx`) |
 | **VSCode** | Open a registered file from the explorer; extension host posts `loadFile` / `loadPipeline` to the webview | `postMessage({ type: "loadFile", … })` (`vscode-megane/webview/main.tsx`) |
-| **Python** | `from megane import …` or `from megane.parsers import …` | Top-level `megane`: `load_pdb`, `load_cif`, `load_lammps_data`, `load_traj`, `load_trajectory` (XTC), `load_xyz_trajectory`. Full set via `megane.parsers`: additionally `load_gro`, `load_mol`, `load_sdf`, `load_mol2`, `load_dcd`, `load_netcdf`, `load_lammpstrj`, and the raw `parse_*` PyO3 functions. |
+| **Python** | `from megane import …` or `from megane.parsers import …` | Top-level `megane`: `load_pdb`, `load_cif`, `load_lammps_data`, `load_traj`, `load_trajectory` (XTC), `load_xyz_trajectory`. Full set via `megane.parsers`: additionally `load_gro`, `load_mol`, `load_sdf`, `load_mol2`, `load_dcd`, `load_netcdf`, `load_lammpstrj`. Raw PyO3 functions (all formats including mmCIF and AMBER prmtop) are in the native extension `megane_parser`: `from megane import megane_parser; megane_parser.parse_mmcif(text)`, `megane_parser.parse_prmtop(text)`, etc. |
 
 ## Known gaps
 

--- a/vscode-megane/package.json
+++ b/vscode-megane/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-megane",
   "displayName": "megane - Molecular Viewer",
-  "description": "View molecular structure files (PDB, GRO, XYZ, MOL, SDF, MOL2, CIF, LAMMPS data, AMBER prmtop, ASE traj, XTC, LAMMPS dump, DCD, AMBER NetCDF) with megane",
+  "description": "View molecular structure files (PDB, GRO, XYZ, MOL, SDF, MOL2, CIF, mmCIF, LAMMPS data, AMBER prmtop, ASE traj, XTC, LAMMPS dump, DCD, AMBER NetCDF) with megane",
   "version": "0.7.0",
   "publisher": "hodakamori",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- **`docs/guide/pipeline/python.md`**: Removed `.mmcif` and `.prmtop` from the `LoadStructure` supported extensions list — `_load_structure_file()` in `python/megane/pipeline.py` does not dispatch these extensions, so the docs were claiming support that does not exist.
- **`docs/platform-support.md`**: Changed Python column for mmCIF and AMBER topology from ✓ to API — neither format is reachable via `LoadStructure` or `megane.parsers`; only accessible through the raw `megane_parser` PyO3 extension (`parse_mmcif` / `parse_prmtop`).
- **`docs/platform-support.md`**: Clarified in "Load methods / APIs" that raw `parse_*` PyO3 functions live in `megane_parser` (not `megane.parsers`), and explicitly name `parse_mmcif` / `parse_prmtop` as the access path for those two formats.
- **`docs/guide/cli.md`**: Expanded the partial format list to include mmCIF and AMBER prmtop — drag-and-drop in the standalone UI does accept both (they appear in `STRUCTURE_ACCEPT` in `LoadStructureNode.tsx`).
- **`vscode-megane/package.json`**: Added "mmCIF" to the extension description — `*.mmcif` was already registered as a `customEditor` but omitted from the human-readable description.
- **`README.md`**: Corrected "Python wrappers for all 15 supported formats" — `megane.parsers` is missing wrappers for mmCIF and AMBER prmtop.

## Test plan

- [ ] Docs-only change — no tests required
- [ ] Verified all edits match the current source code behaviour (`_load_structure_file`, `megane.parsers.__init__`, `LoadStructureNode.tsx`, `jupyterlab-megane/src/filetypes.ts`, `vscode-megane/package.json` customEditors)

https://claude.ai/code/session_01DMwDvWPsp4bpfEaHK2KsRu