### PR TITLE
docs: fix AddPolyhedra API docs and LoadStructure supported extensions

### DIFF
--- a/docs/docs/guide/pipeline/json.md
+++ b/docs/docs/guide/pipeline/json.md
@@ -151,11 +151,14 @@ handle and emits the tagged particle stream on `out`.
 
 #### `polyhedron_generator`
 
+Centers and ligands are auto-detected using VESTA-style heuristics. Use
+`excludedCenters` / `excludedLigands` to opt out specific atomic numbers.
+
 | Field | Type | Description |
 |-------|------|-------------|
-| `centerElements` | `number[]` | Atomic numbers of center atoms |
-| `ligandElements` | `number[]` | Atomic numbers of ligand atoms |
-| `maxDistance` | `number` | Maximum center–ligand distance (Å) |
+| `excludedCenters` | `number[]` | Atomic numbers excluded from center detection (default `[]`) |
+| `excludedLigands` | `number[]` | Atomic numbers excluded from ligand detection (default `[]`) |
+| `cutoffTolerance` | `number` | Bond-length tolerance multiplier applied to VDW radii sum (default `1.15`) |
 | `opacity` | `number` | Face transparency (0–1) |
 | `showEdges` | `boolean` | Display wireframe edges |
 | `edgeColor` | `string` | Wireframe edge color (hex) |
@@ -233,9 +236,9 @@ handle and emits the tagged particle stream on `out`.
       "id": "poly1",
       "type": "polyhedron_generator",
       "position": { "x": 170, "y": 310 },
-      "centerElements": [22],
-      "ligandElements": [8],
-      "maxDistance": 2.5,
+      "excludedCenters": [38],
+      "excludedLigands": [],
+      "cutoffTolerance": 1.15,
       "opacity": 0.5,
       "showEdges": true,
       "edgeColor": "#dddddd",

--- a/docs/docs/guide/pipeline/python.md
+++ b/docs/docs/guide/pipeline/python.md
@@ -83,7 +83,7 @@ LoadStructure(path: str)
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `path` | `str` | File path. Auto-detected by extension. Supported: `.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf` (routed through the MOL parser), `.mol2`, `.cif`, `.data`, `.lammps`, `.traj` (ASE binary). |
+| `path` | `str` | File path. Auto-detected by extension. Supported: `.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf` (routed through the MOL parser), `.mol2`, `.cif`, `.mmcif`, `.data`, `.lammps`, `.prmtop` (AMBER topology), `.traj` (ASE binary). |
 
 **Ports:** `out.particle`, `out.traj`, `out.cell`
 
@@ -279,14 +279,19 @@ AddLabels(*, source: Literal["element", "resname", "index"] = "element")
 
 ### AddPolyhedra
 
-Generate coordination polyhedra mesh.
+Generate coordination polyhedra mesh (VESTA-style auto-detection).
+
+By default, a polyhedron is drawn for every metal/metalloid center coordinated
+to every typical anion-forming ligand present in the structure. Use
+`excluded_centers` / `excluded_ligands` to opt out specific elements, mirroring
+VESTA's checkbox UI.
 
 ```python
 AddPolyhedra(
     *,
-    center_elements: list[int],
-    ligand_elements: list[int] | None = None,  # defaults to [8] (oxygen)
-    max_distance: float = 2.5,
+    excluded_centers: list[int] | None = None,
+    excluded_ligands: list[int] | None = None,
+    cutoff_tolerance: float = 1.15,
     opacity: float = 0.5,
     show_edges: bool = False,
     edge_color: str = "#dddddd",
@@ -296,9 +301,9 @@ AddPolyhedra(
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `center_elements` | `list[int]` | *(required)* | Atomic numbers of center atoms (e.g., Ti=22) |
-| `ligand_elements` | `list[int] \| None` | `[8]` (oxygen) | Atomic numbers of ligand atoms |
-| `max_distance` | `float` | `2.5` | Maximum center–ligand distance (Å) |
+| `excluded_centers` | `list[int] \| None` | `[]` | Atomic numbers to exclude from center detection (e.g., `[38]` to skip Sr) |
+| `excluded_ligands` | `list[int] \| None` | `[]` | Atomic numbers to exclude from ligand detection |
+| `cutoff_tolerance` | `float` | `1.15` | Bond-length tolerance multiplier applied to VDW radii sum for center–ligand detection |
 | `opacity` | `float` | `0.5` | Face transparency (0–1) |
 | `show_edges` | `bool` | `False` | Display wireframe edges |
 | `edge_color` | `str` | `"#dddddd"` | Wireframe edge color (hex) |
@@ -444,10 +449,10 @@ from megane import Pipeline, LoadStructure, AddBonds, AddPolyhedra, Viewport, Mo
 pipe = Pipeline()
 s = pipe.add_node(LoadStructure("SrTiO3_supercell.pdb"))
 bonds = pipe.add_node(AddBonds(source="distance"))
+# All metal centers and anion-forming ligands are included by default (VESTA-style).
+# Exclude Sr (38) so only TiO6 polyhedra are drawn.
 polyhedra = pipe.add_node(AddPolyhedra(
-    center_elements=[22],     # Ti
-    ligand_elements=[8],      # O
-    max_distance=2.5,
+    excluded_centers=[38],    # exclude Sr; Ti (22) is kept
     opacity=0.5,
     show_edges=True,
 ))

--- a/docs/docs/guide/pipeline/typescript.md
+++ b/docs/docs/guide/pipeline/typescript.md
@@ -88,7 +88,7 @@ Constructor parameters mirror the Python API (using an options object instead of
 | `Representation(mode="cartoon")` | `new Representation({ mode: "cartoon" })` |
 | `AddBonds(source="distance")` | `new AddBonds({ source: 'distance' })` |
 | `AddLabels(source="element")` | `new AddLabels({ source: 'element' })` |
-| `AddPolyhedra(center_elements=[22])` | `new AddPolyhedra({ centerElements: [22] })` |
+| `AddPolyhedra(excluded_centers=[38])` | `new AddPolyhedra({ excludedCenters: [38] })` |
 | `VectorOverlay(scale=2.0)` | `new VectorOverlay({ scale: 2.0 })` |
 | `LoadTrajectory(xtc="traj.xtc")` | `new LoadTrajectory({ xtc: 'traj.xtc' })` |
 | `Viewport(perspective=True)` | `new ViewportNode({ perspective: true })` |
@@ -202,11 +202,11 @@ import { PipelineViewer, Pipeline, LoadStructure, AddBonds, AddPolyhedra, Viewpo
 const pipe = new Pipeline();
 const s = pipe.addNode(new LoadStructure("SrTiO3_supercell.pdb"));
 const bonds = pipe.addNode(new AddBonds());
+// All metal centers and anion-forming ligands are included by default (VESTA-style).
+// Exclude Sr (38) so only TiO6 polyhedra are drawn.
 const polyhedra = pipe.addNode(
   new AddPolyhedra({
-    centerElements: [22], // Ti
-    ligandElements: [8], // O
-    maxDistance: 2.5,
+    excludedCenters: [38], // exclude Sr; Ti (22) is kept
     opacity: 0.5,
     showEdges: true,
   })


### PR DESCRIPTION
## Summary

- **`AddPolyhedra` API mismatch fixed** in all three pipeline guides (`python.md`, `typescript.md`, `json.md`): the node was redesigned from an include-list API (`centerElements` / `ligandElements` / `maxDistance`) to a VESTA-style opt-out API (`excludedCenters` / `excludedLigands` / `cutoffTolerance`), but the docs still described the old fields. Updated parameter tables, signatures, and examples to match the current implementation in `src/pipeline/builder.ts` and `python/megane/pipeline.py`.
- **`LoadStructure` missing extensions fixed** in `python.md`: `.mmcif` and `.prmtop` were absent from the supported-extensions list despite being accepted by `LoadStructureNode.tsx`.

## Changes

| File | What changed |
|------|-------------|
| `docs/docs/guide/pipeline/python.md` | `AddPolyhedra` signature, parameter table, and TiO₆ example; `LoadStructure` extension list |
| `docs/docs/guide/pipeline/typescript.md` | `AddPolyhedra` in the Python↔TS comparison table and TiO₆ example |
| `docs/docs/guide/pipeline/json.md` | `polyhedron_generator` field table and Crystal with Polyhedra JSON example |

## Test plan

- [ ] Documentation-only change — no source code modified
- [ ] Verified `excludedCenters` / `excludedLigands` / `cutoffTolerance` match `src/pipeline/builder.ts` (lines 406–418) and `python/megane/pipeline.py` (lines 390–405)
- [ ] Verified `.mmcif` and `.prmtop` are listed in `LoadStructureNode.tsx` `STRUCTURE_ACCEPT` (line 16)

https://claude.ai/code/session_014LaUHtrkguop27iwhjhVHs