### PR TITLE
docs: fix PSF Python support and dev setup order

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -19,11 +19,14 @@ sidebar_position: 2
 git clone https://github.com/hodakamori/megane.git
 cd megane
 
-# Install Python dependencies and build Rust extension
-make dev
-
-# Install Node.js dependencies
+# Install Node.js dependencies (must come first — make dev depends on them)
 npm install
+
+# Install Python dependencies (test tools, notebook support, etc.)
+uv sync --extra dev
+
+# Build frontend assets and install the megane Python extension
+make dev
 ```
 
 ### Development Mode

--- a/docs/docs/platform-support.md
+++ b/docs/docs/platform-support.md
@@ -64,7 +64,9 @@ with a GROMACS `.top`).
 | Format | Extensions | Standalone (Add Bond node) | Python |
 |---|---|:---:|:---:|
 | GROMACS topology | `.top` | ✓ | ✓ |
-| CHARMM/NAMD PSF | `.psf` | ✓ | ✓ |
+| CHARMM/NAMD PSF | `.psf` | ✓ | API² |
+
+² Python `AddBonds` only wires GROMACS `.top` topology via the `top=` parameter. PSF bonds are accessible programmatically via `megane.parsers.psf.parse_psf_bonds(path)` or `megane_parser.parse_psf_bonds(text)`, but cannot be passed directly to an `AddBonds` pipeline node.
 
 Sources of truth: `crates/megane-wasm/src/lib.rs` (browser parsers), `crates/megane-python/src/lib.rs` (Python parsers), `src/components/nodes/LoadStructureNode.tsx` and `src/components/nodes/LoadTrajectoryNode.tsx` (standalone accept lists), `src/components/nodes/AddBondNode.tsx` (topology accept list), `jupyterlab-megane/src/filetypes.ts` (JupyterLab `IFileType` registrations), `vscode-megane/package.json` (VSCode `customEditors`).
 


### PR DESCRIPTION
## Summary

- **platform-support.md**: Correct the CHARMM/NAMD PSF topology Python column from `✓` to `API²`. Python `AddBonds` only supports GROMACS `.top` via the `top=` parameter; PSF bonds are only accessible via `megane.parsers.psf.parse_psf_bonds()` or `megane_parser.parse_psf_bonds()`, not through the `AddBonds` pipeline node. Added a footnote explaining the limitation.

- **configuration.md**: Fix the "Clone and Install" step order — `npm install` must precede `make dev` (which internally calls `npm run build`). Also add the missing `uv sync --extra dev` step for Python test dependencies (`pytest`, etc.).

## Test plan

- [ ] No source code changed — documentation-only fixes
- [ ] Verified Python `AddBonds` implementation in `python/megane/pipeline.py` (`_parse_top_bonds` only calls `parse_top_bonds`, no PSF handling)
- [ ] Verified `AddBondNode.tsx` supports both `.top` and `.psf` on the browser side (confirming Standalone `✓` is correct)
- [ ] Verified `make dev` Makefile target calls `npm run build` first (requires `node_modules`)
- [ ] Verified `uv sync --extra dev` is the correct way to install Python test dependencies

https://claude.ai/code/session_01CGjBTVfYF13stBCiUxGyEm