### PR TITLE
docs: fix documentation inconsistencies with source code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ npm run package     # produces vscode-megane-<version>.vsix
 code --install-extension ./vscode-megane-<version>.vsix
 ```
 
-Open any `.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf`, `.cif`, `.data`, `.lammps`, `.traj`, or `.megane.json` file in VSCode to launch the megane viewer.
+Open any supported molecular file (`.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf`, `.mol2`, `.cif`, `.mmcif`, `.data`, `.lammps`, `.prmtop`, `.traj`, `.xtc`, `.dcd`, `.nc`, `.lammpstrj`, `.dump`) or a `.megane.json` pipeline file in VSCode to launch the megane viewer.
 
 To iterate on the extension code without repackaging, open `vscode-megane/` in VSCode and press `F5` to launch the Extension Development Host (after `npm run build`).
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ One codebase, every environment.
 | Environment | How | Install |
 |---|---|---|
 | **Jupyter** | anywidget inline viewer | `pip install megane` |
-| **JupyterLab** | Open .pdb, .gro, .xyz, .mol, .sdf, .cif from the file browser | `pip install megane` |
+| **JupyterLab** | Open .pdb, .gro, .xyz, .mol, .sdf, .mol2, .cif, .mmcif, .data/.lammps, .prmtop, .traj, .xtc, .dcd, .nc, .lammpstrj/.dump from the file browser | `pip install megane` |
 | **Browser** | `megane serve` local server | `pip install megane` |
 | **React** | `<MeganeViewer />` component | `npm install megane-viewer` |
-| **VSCode** | Custom editor for .pdb, .gro, .xyz, .mol, .sdf, .mol2, .cif, .data/.lammps, .traj, .xtc, .lammpstrj, .dcd, .nc, .megane.json | Extension |
+| **VSCode** | Custom editor for .pdb, .gro, .xyz, .mol, .sdf, .mol2, .cif, .mmcif, .data/.lammps, .prmtop, .traj, .xtc, .lammpstrj, .dump, .dcd, .nc, .megane.json | Extension |
 
 For a per-platform breakdown of supported formats and UI features (including known gaps), see [Platform Support](https://hodakamori.github.io/megane/platform-support).
 
@@ -64,7 +64,7 @@ Wire nodes to build visualization workflows — no code required.
 
 **16 node types** across 5 categories: load data (structure, trajectory, streaming, vector, volumetric), bonds, process (filter, modify, color, representation), overlay (labels, polyhedra, surface meshes, isosurfaces, vectors), and display in a 3D viewport.
 
-**7 typed data channels** — particle, bond, cell, label, mesh, trajectory, vector — flow through color-coded edges. Only matching types can connect.
+**8 typed data channels** — particle, bond, cell, label, mesh, trajectory, vector, volumetric — flow through color-coded edges. Only matching types can connect.
 
 Pipelines serialize to JSON, so you can save, share, and version-control your visualization recipes.
 
@@ -166,6 +166,7 @@ function App() {
 | CIF | `.cif` | Crystallographic Information File |
 | mmCIF | `.mmcif` | Macromolecular CIF (PDBx/mmCIF) |
 | AMBER topology | `.prmtop` | AMBER parameter/topology file (atom names, elements, bonds) |
+| ASE .traj | `.traj` | ASE trajectory (ULM binary format; contains atoms + frames) |
 
 ### Trajectory formats (`LoadTrajectory` node)
 
@@ -174,7 +175,6 @@ function App() {
 | XTC | `.xtc` | GROMACS compressed trajectory |
 | DCD | `.dcd` | CHARMM/NAMD binary trajectory |
 | AMBER NetCDF | `.nc` | AMBER NetCDF trajectory |
-| ASE .traj | `.traj` | ASE trajectory (ULM binary format) |
 | LAMMPS dump | `.lammpstrj`, `.dump` | LAMMPS dump trajectory |
 
 ## Development

--- a/docs/docs/dev/architecture.md
+++ b/docs/docs/dev/architecture.md
@@ -11,7 +11,7 @@ megane's visual pipeline is built on three core principles:
 
 ### Typed Data Flow
 
-The pipeline is a directed acyclic graph where edges carry one of **7 typed data channels**: `particle`, `bond`, `cell`, `trajectory`, `label`, `mesh`, and `vector`. Nodes declare typed input/output ports via `NODE_PORTS` in `src/pipeline/types.ts`. The UI prevents connections between incompatible port types at the graph level (see `canConnect()`), so executors can trust that incoming data has the expected shape.
+The pipeline is a directed acyclic graph where edges carry one of **8 typed data channels**: `particle`, `bond`, `cell`, `trajectory`, `label`, `mesh`, `vector`, and `volumetric`. Nodes declare typed input/output ports via `NODE_PORTS` in `src/pipeline/types.ts`. The UI prevents connections between incompatible port types at the graph level (see `canConnect()`), so executors can trust that incoming data has the expected shape.
 
 ### Separation of Computation and Rendering
 
@@ -61,7 +61,7 @@ Instead of mesh-based spheres (32+ triangles each), atoms are rendered as **scre
 
 ## Pipeline Data Types
 
-Seven typed channels flow through pipeline edges. Defined in `src/pipeline/types.ts`.
+Eight typed channels flow through pipeline edges. Defined in `src/pipeline/types.ts`.
 
 | Channel | Interface | Key Fields | Produced By | Consumed By |
 |---------|-----------|------------|-------------|-------------|
@@ -70,8 +70,9 @@ Seven typed channels flow through pipeline edges. Defined in `src/pipeline/types
 | `cell` | `CellData` | `box` (3x3 Float32Array), `visible`, `axesVisible` | LoadStructure, Streaming | Viewport |
 | `trajectory` | `TrajectoryData` | `provider` (FrameProvider), `meta` | LoadStructure, LoadTrajectory, Streaming | Viewport |
 | `label` | `LabelData` | `labels[]`, `particleRef` | LabelGenerator | Viewport |
-| `mesh` | `MeshData` | `positions`, `indices`, `normals`, `colors` | PolyhedronGenerator | Viewport |
+| `mesh` | `MeshData` | `positions`, `indices`, `normals`, `colors` | PolyhedronGenerator, SurfaceMesh, Isosurface | Viewport |
 | `vector` | `VectorData` | `frames` (VectorFrame[]), `scale` | LoadVector, VectorOverlay | VectorOverlay, Viewport |
+| `volumetric` | `VolumetricData` | `nx`, `ny`, `nz`, `origin`, `step`, `data` | LoadVolumetric | Isosurface |
 
 Each edge in the UI is color-coded by data type (`DATA_TYPE_COLORS`). Filter and Modify nodes are generic — they accept both `particle` and `bond` inputs via `GENERIC_NODE_ACCEPTS`. The Color and Representation nodes are particle-only modifiers that share the same Modify category in the toolbar (Ovito-style stack: each modifier owns one visual property — Modify = scale & opacity, Color = per-atom palette, Representation = atoms/cartoon/both/surface).
 
@@ -242,7 +243,7 @@ Wire it into `MoleculeRenderer` by replacing the renderer construction. See `Imp
 
 ### Adding a New Data Channel Type
 
-If the existing 7 channels don't cover your needs:
+If the existing 8 channels don't cover your needs:
 
 1. Add to `PipelineDataType` union and `DATA_TYPE_COLORS` in `src/pipeline/types.ts`
 2. Create the data interface (e.g., `SurfaceData`)

--- a/docs/docs/guide/pipeline/index.md
+++ b/docs/docs/guide/pipeline/index.md
@@ -15,7 +15,7 @@ For real-world examples, see the [Gallery](/gallery).
 
 A pipeline is a directed graph of **nodes** connected by **edges**. Data flows from source nodes (like Load Structure) through processing nodes (like Filter or Modify) and into a Viewport node for rendering.
 
-Each edge carries a specific **data type** — particle, bond, cell, label, mesh, trajectory, or vector — and only matching types can connect.
+Each edge carries a specific **data type** — particle, bond, cell, label, mesh, trajectory, vector, or volumetric — and only matching types can connect.
 
 When a node encounters an error — for example, a parse failure in LoadStructure — an error icon appears on the node with a tooltip showing the details.
 

--- a/docs/docs/platform-support.md
+++ b/docs/docs/platform-support.md
@@ -38,6 +38,7 @@ Legend:
 | mmCIF | `.mmcif` | ✓ | API | ✓ | ✓ | API |
 | LAMMPS data | `.data`, `.lammps` | ✓ | API | ✓ | ✓ | ✓ |
 | AMBER topology | `.prmtop` | ✓ | API | ✓ | ✓ | API |
+| ASE trajectory | `.traj` | ✓ | API | ✓ | ✓ | ✓ |
 
 ### Trajectory formats
 
@@ -45,7 +46,6 @@ Legend:
 |---|---|:---:|:---:|:---:|:---:|:---:|
 | XTC | `.xtc` | ✓ | API | ✓¹ | ✓¹ | ✓ |
 | DCD | `.dcd` | ✓ | API | ✓¹ | ✓¹ | ✓ |
-| ASE trajectory | `.traj` | ✓ | API | ✓ | ✓ | ✓ |
 | LAMMPS dump | `.lammpstrj`, `.dump` | ✓ | API | ✓¹ | ✓¹ | ✓ |
 | AMBER NetCDF | `.nc` | ✓ | API | ✓¹ | ✓¹ | ✓ |
 


### PR DESCRIPTION
## Summary

- **ASE `.traj` recategorized as Structure format** in `README.md` and `platform-support.md` — `LoadStructureNode.tsx` lists `.traj` in `STRUCTURE_ACCEPT`; `LoadTrajectoryNode.tsx` does not include it at all
- **JupyterLab format list corrected** in `README.md` "Anywhere" table — was missing `.mol2`, `.mmcif`, `.data/.lammps`, `.prmtop`, `.traj`, `.xtc`, `.dcd`, `.nc`, `.lammpstrj/.dump` (all registered in `jupyterlab-megane/src/filetypes.ts`)
- **VSCode format list corrected** in `README.md` "Anywhere" table — was missing `.mmcif`, `.prmtop`, `.dump` (all in `vscode-megane/package.json` `customEditors`)
- **CONTRIBUTING.md VSCode format list expanded** to include all 18 extensions registered in `vscode-megane/package.json`
- **Data channel count corrected from 7 to 8** in `README.md`, `architecture.md`, and `pipeline/index.md` — `volumetric` type defined in `src/pipeline/types.ts` was missing from all counts and lists
- **`volumetric` channel added** to the pipeline data types table in `architecture.md`
- **`mesh` channel "Produced By" corrected** in `architecture.md` — `SurfaceMesh` and `Isosurface` both produce mesh data but were missing; only `PolyhedronGenerator` was listed

## Test plan

- [ ] Documentation-only changes — no source code modified, no tests required
- [ ] Verified all changes against sources of truth: `LoadStructureNode.tsx`, `LoadTrajectoryNode.tsx`, `jupyterlab-megane/src/filetypes.ts`, `vscode-megane/package.json`, `src/pipeline/types.ts`, `src/pipeline/executors/`

https://claude.ai/code/session_01PRq3KFa1qdEdWcNx6CMGpR