### PR TITLE
docs: fix file format lists for JupyterLab and VSCode in README

### DIFF
--- a/docs/docs/dev/architecture.md
+++ b/docs/docs/dev/architecture.md
@@ -281,8 +281,8 @@ the same PR. The full per-host registration checklist lives in the
    (VSCode `customEditors`)
 6. Wire the Python `LoadStructure` / `LoadTrajectory` dispatch in
    `python/megane/pipeline.py` (`_load_structure_file` / `_load_trajectory_data`)
-7. Update `docs/docs/platform-support.md`, `docs/docs/introduction.md`, and
-   `docs/docs/getting-started.md`
+7. Update `docs/docs/platform-support.md`, `docs/docs/introduction.md`,
+   `docs/docs/getting-started.md`, and `README.md`
 
 ## Key File Index
 


### PR DESCRIPTION
## Summary

- **README.md JupyterLab row**: Was listing only 6 formats (`.pdb, .gro, .xyz, .mol, .sdf, .cif`). Updated to reflect all 15 formats actually registered in `jupyterlab-megane/src/filetypes.ts`: `.pdb, .gro, .xyz, .mol, .sdf, .mol2, .cif, .mmcif, .data/.lammps, .prmtop, .traj, .xtc, .lammpstrj/.dump, .dcd, .nc`
- **README.md VSCode row**: Was missing `.mmcif`, `.prmtop`, and `.dump`. Updated to match `vscode-megane/package.json` `customEditors` selector list.
- **docs/docs/dev/architecture.md**: Added `README.md` to the "Adding a New File Format Parser" checklist (step 7) so future format additions keep it in sync.

## Root cause

The "Adding a New File Format Parser" checklist in `architecture.md` referenced only `platform-support.md`, `introduction.md`, and `getting-started.md` — `README.md` was omitted, so multiple format additions (mmCIF, AMBER prmtop, LAMMPS dump) updated the platform docs but not the README summary table.

## Test plan

- [x] Documentation-only change — no code, tests, or build steps needed
- [x] Verified against source of truth files: `jupyterlab-megane/src/filetypes.ts` and `vscode-megane/package.json`
- [x] `platform-support.md` remains the authoritative reference and was not changed

https://claude.ai/code/session_01NFiUEdDffSSJAs9AW3GeeA