### PR TITLE
fix: sync docs and code for AddBond topology, SurfaceMesh, and LoadStructure formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ dev-preview/
 coverage/
 .coverage
 lcov.info
+coverage.xml

--- a/docs/docs/guide/pipeline/index.md
+++ b/docs/docs/guide/pipeline/index.md
@@ -158,6 +158,7 @@ Requires a connection from a LoadStructure node. Frames are loaded lazily when `
 |-----------|--------|---------|-------------|
 | Bond source | `structure` | — | Read bonds from the structure file (CONECT records in PDB, etc.) |
 | | `distance` | ✓ | Infer bonds from van der Waals radii |
+| | `file` | — | Read bonds from a topology file (GROMACS `.top` or CHARMM/NAMD `.psf`). Click **Load .top / .psf…** to select the file. |
 
 ### Filter
 
@@ -198,6 +199,10 @@ The **Query** field filters which atoms pass through when the Filter node is con
 | Edge width | number | 3.0 | Wireframe edge width (px) |
 
 ### Surface Mesh
+
+:::note
+Surface Mesh is available in the visual pipeline editor (standalone app, JupyterLab, VSCode) but does not have a corresponding Python class in the `megane` package. Build pipelines that use this node as JSON files or by editing them in the visual editor.
+:::
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/docs/docs/guide/pipeline/python.md
+++ b/docs/docs/guide/pipeline/python.md
@@ -73,6 +73,10 @@ from megane import (
 )
 ```
 
+:::note
+The **Surface Mesh** node (alpha-shape envelope) is available in the visual pipeline editor but does not have a Python class. Use the standalone app, JupyterLab, or VSCode to add it interactively, or author the pipeline JSON directly.
+:::
+
 ### LoadStructure
 
 Load a molecular structure file.
@@ -83,7 +87,7 @@ LoadStructure(path: str)
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `path` | `str` | File path. Auto-detected by extension. Supported: `.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf` (routed through the MOL parser), `.mol2`, `.cif`, `.mmcif`, `.data`, `.lammps`, `.prmtop` (AMBER topology), `.traj` (ASE binary). |
+| `path` | `str` | File path. Auto-detected by extension. Supported by the Python-side parser: `.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf` (routed through the MOL parser), `.mol2`, `.cif`, `.data`, `.lammps`, `.traj` (ASE binary). The browser-side (WASM) parser additionally accepts `.mmcif` and `.prmtop` (AMBER topology) when the pipeline runs inside `MolecularViewer`. |
 
 **Ports:** `out.particle`, `out.traj`, `out.cell`
 
@@ -253,13 +257,13 @@ Representation(*, mode: Literal["atoms", "cartoon", "both", "surface"] = "atoms"
 Compute and display bonds.
 
 ```python
-AddBonds(*, source: Literal["distance", "structure"] = "distance", top: str | None = None)
+AddBonds(*, source: Literal["distance", "structure", "file"] = "distance", top: str | None = None)
 ```
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `source` | `str` | `"distance"` | `"distance"` for VDW-based inference, `"structure"` for file-based bonds |
-| `top` | `str \| None` | `None` | Path to a GROMACS `.top` topology file. When provided, `source` is ignored and bonds are read from the topology file. |
+| `source` | `str` | `"distance"` | `"distance"` for VDW-based inference; `"structure"` (alias `"file"`) to read bonds from the structure file (e.g. CONECT records in PDB) |
+| `top` | `str \| None` | `None` | Path to a topology file (GROMACS `.top` or CHARMM/NAMD `.psf`). When provided, `source` is ignored and bonds are read from the topology file. |
 
 **Ports:** `inp.particle`, `out.bond`
 

--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -320,8 +320,9 @@ class AddBonds(PipelineNode):
         source: ``"distance"`` for VDW-based inference,
                 ``"structure"`` (alias ``"file"``) to use bonds from the
                 loaded structure file.
-        top: Path to a GROMACS ``.top`` topology file.  When provided,
-             *source* is ignored and bonds are read from the topology.
+        top: Path to a topology file (GROMACS ``.top`` or CHARMM/NAMD ``.psf``).
+             When provided, *source* is ignored and bonds are read from the
+             topology.
 
     Ports:
         inp.particle — atom data
@@ -920,11 +921,19 @@ class Pipeline:
 
     @staticmethod
     def _parse_top_bonds(node: AddBonds) -> list[int]:
-        """Read a .top file and return flat bond pairs [a0, b0, a1, b1, ...]."""
-        from megane.parsers.top import parse_top_bonds
+        """Read a .top or .psf file and return flat bond pairs [a0, b0, a1, b1, ...]."""
+        import pathlib
 
         assert node.top is not None
-        bonds = parse_top_bonds(node.top)
+        ext = pathlib.Path(node.top).suffix.lower()
+        if ext == ".psf":
+            from megane.parsers.psf import parse_psf_bonds
+
+            bonds = parse_psf_bonds(node.top)
+        else:
+            from megane.parsers.top import parse_top_bonds
+
+            bonds = parse_top_bonds(node.top)
         return bonds.flatten().tolist()
 
     def _load_structure_data(self, node: LoadStructure) -> None:
@@ -1164,8 +1173,8 @@ def build_pipeline(
             ``"structure"`` (alias ``"file"``) reads bonds from the loaded
             structure file, ``None`` disables bonds. Ignored when *top* is
             provided.
-        top: Path to a GROMACS ``.top`` topology file for bond definitions.
-            When provided, overrides *bonds*.
+        top: Path to a topology file (GROMACS ``.top`` or CHARMM/NAMD ``.psf``)
+            for bond definitions.  When provided, overrides *bonds*.
         perspective: Use perspective projection instead of orthographic.
         cell_axes_visible: Show unit cell axes.
         pivot_marker_visible: Show pivot marker in viewport.

--- a/tests/python/test_pipeline.py
+++ b/tests/python/test_pipeline.py
@@ -478,6 +478,19 @@ class TestPipelineSerialization:
         assert isinstance(bond_node["bondFileData"], list)
         assert len(bond_node["bondFileData"]) > 0
 
+    def test_add_bonds_psf_serialization(self):
+        pipe = Pipeline()
+        s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))
+        b = pipe.add_node(AddBonds(top=str(FIXTURES / "water.psf")))
+        pipe.add_edge(s.out.particle, b.inp.particle)
+        result = pipe.to_dict()
+
+        bond_node = next(n for n in result["nodes"] if n["type"] == "add_bond")
+        assert bond_node["bondSource"] == "file"
+        assert bond_node["bondFileName"] == str(FIXTURES / "water.psf")
+        assert isinstance(bond_node["bondFileData"], list)
+        assert len(bond_node["bondFileData"]) > 0
+
     def test_color_serialization(self):
         pipe = Pipeline()
         s = pipe.add_node(LoadStructure(str(FIXTURES / "1crn.pdb")))


### PR DESCRIPTION
## Summary

- **Add Bond `file` option missing from docs**: `index.md` documented only `structure` and `distance` bond sources, but the visual pipeline editor exposes a third option — `file` (Topology) — for loading GROMACS `.top` / CHARMM `.psf` topology files. Added the missing row to the parameter table.
- **SurfaceMesh not available as Python class**: `SurfaceMesh` is a visual-pipeline-only node (TypeScript/WASM). Added a `:::note` admonition to both `index.md` and `python.md` so users know it cannot be instantiated in Python.
- **`LoadStructure` format split undocumented**: `python.md` listed formats supported by the Python-side parser but did not mention that `.mmcif` and `.prmtop` are additionally accepted by the browser-side (WASM) parser when the pipeline runs inside `MolecularViewer`. Clarified this distinction.
- **PSF not dispatched in `_parse_top_bonds`**: `parse_psf_bonds` existed in `megane.parsers.psf` and `platform-support.md` listed PSF as Python-supported, but `Pipeline._parse_top_bonds` only called `parse_top_bonds`. Extended the method to dispatch by file extension; updated docstrings in `pipeline.py` and `python.md` to reflect `.psf` support.

## Test plan

- [x] `uv run python -m pytest tests/python/test_pipeline.py -k "add_bonds" -v` — all 8 tests pass, including the new `test_add_bonds_psf_serialization`
- [x] New PSF serialization test covers the added `_parse_top_bonds` PSF branch
- [x] No E2E changes required (no UI code modified)

https://claude.ai/code/session_01NFs2LXzw93DNxD4VP28bLp