### PR TITLE
docs: fix AddPolyhedra API docs and PSF Python support

### DIFF
--- a/docs/docs/guide/pipeline/index.md
+++ b/docs/docs/guide/pipeline/index.md
@@ -50,7 +50,7 @@ LoadStructure → AddBond → Viewport
 Use the **Templates** dropdown to load pre-built pipelines:
 
 - **Molecule** — Caffeine (`caffeine_water.pdb`) with structure-based bonds and a vibration trajectory (`caffeine_water_vibration.xtc`). Nodes: `LoadStructure → AddBond → Viewport`, `LoadTrajectory → Viewport`.
-- **Solid** — Perovskite SrTiO₃ 3×3×3 supercell with distance-based bonds and TiO₆ coordination polyhedra. Nodes: `LoadStructure → AddBond → Viewport`, `PolyhedronGenerator → Viewport`. Center = Ti (22), Ligand = O (8), max distance = 2.5 Å.
+- **Solid** — Perovskite SrTiO₃ 3×3×3 supercell with distance-based bonds and TiO₆ coordination polyhedra. Nodes: `LoadStructure → AddBond → Viewport`, `PolyhedronGenerator → Viewport`. Auto-detects metal centers and anion-former ligands (VESTA-style); Sr is excluded from centers so only TiO₆ polyhedra are shown.
 
 ## Node Reference
 
@@ -187,11 +187,13 @@ The **Query** field filters which atoms pass through when the Filter node is con
 
 ### Polyhedron Generator
 
+Polyhedra are auto-detected using VESTA-style heuristics: a polyhedron is drawn for every metal/metalloid center coordinated to every typical anion-former ligand present in the structure. Use the exclusion lists to opt out specific elements.
+
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| Center elements | number[] | — | Atomic numbers of center atoms (e.g., Ti=22, Si=14) |
-| Ligand elements | number[] | O (8) | Atomic numbers of ligand atoms |
-| Max distance | number | 2.5 Å | Maximum center–ligand distance |
+| Excluded centers | number[] | `[]` | Atomic numbers to exclude from the auto-detected center set (e.g., 38 to skip Sr) |
+| Excluded ligands | number[] | `[]` | Atomic numbers to exclude from the auto-detected ligand set |
+| Cutoff tolerance | number | 1.15 | Multiplier on `r_cov[center] + r_cov[ligand]` used to determine contacts (~1.0 = ideal contact, VESTA default ~1.15) |
 | Opacity | number | 0.5 | Face transparency (0–1) |
 | Show edges | boolean | off | Display wireframe edges |
 | Edge color | string | `#dddddd` | Wireframe edge color (hex) |
@@ -317,7 +319,7 @@ The bond query selects which bonds a downstream **Modify** node applies opacity 
 
 1. Load a perovskite structure (`LoadStructure`)
 2. Add a `PolyhedronGenerator` node
-3. Set center = Ti (22), ligand = O (8), max distance = 2.5 Å
+3. In "Excluded centers", add Sr (38) so only TiO₆ polyhedra are shown (Ti and O are auto-detected)
 4. Connect `LoadStructure.particle → PolyhedronGenerator.particle`
 5. Connect `PolyhedronGenerator.mesh → Viewport.mesh`
 

--- a/src/ai/skills/solid-template.md
+++ b/src/ai/skills/solid-template.md
@@ -33,9 +33,9 @@ Structure: LoadStructure -> AddBond (distance) -> Viewport, plus PolyhedronGener
       "id": "polyhedron-1",
       "type": "polyhedron_generator",
       "position": { "x": 680, "y": 310 },
-      "centerElements": [22],
-      "ligandElements": [8],
-      "maxDistance": 2.5,
+      "excludedCenters": [],
+      "excludedLigands": [],
+      "cutoffTolerance": 1.15,
       "opacity": 0.5,
       "showEdges": false,
       "edgeColor": "#dddddd",
@@ -94,8 +94,8 @@ Structure: LoadStructure -> AddBond (distance) -> Viewport, plus PolyhedronGener
 
 ## Customization Notes
 
-- Adjust `centerElements` and `ligandElements` to match the target material.
+- The polyhedron generator auto-detects metal/metalloid centers and typical anion-former ligands (VESTA-style). Use `excludedCenters` / `excludedLigands` to opt out specific atomic numbers.
 - Common atomic numbers: Ti=22, O=8, Sr=38, Fe=26, Al=13, Si=14, Mg=12, Ca=20, Zn=30.
-- Adjust `maxDistance` based on the expected bond length for the center-ligand pair.
+- Adjust `cutoffTolerance` to widen or narrow the center–ligand contact criterion (multiplier on `r_cov[c] + r_cov[l]`; VESTA default is ~1.15).
 - Use `bondSource: "distance"` for crystal structures (XYZ, GRO) that lack explicit bond info.
 - Set `hasCell: true` and `cellAxesVisible: true` to show the unit cell.


### PR DESCRIPTION
## Summary

- **AddPolyhedra API mismatch**: The `AddPolyhedra` node was refactored from an explicit include-list API (`center_elements`, `ligand_elements`, `max_distance`) to a VESTA-style auto-detection API (`excluded_centers`, `excluded_ligands`, `cutoff_tolerance`). Four docs files still referenced the old (now-deleted) parameter names — code using them would raise `TypeError`.
- **PSF Python support correction**: `platform-support.md` marked Python as `✓` for CHARMM/NAMD PSF topology, but the `AddBonds` pipeline class only accepts GROMACS `.top` via the `top=` parameter. PSF is accessible only via the raw `parse_psf_bonds()` function, so the column is now `API⁵` with an explanatory footnote.
- **AI skill template**: `src/ai/skills/solid-template.md` contained the old JSON field names (`centerElements`, `ligandElements`, `maxDistance`) which the pipeline serializer strips and discards; updated to current field names.

## Files changed

| File | Change |
|---|---|
| `docs/docs/guide/pipeline/python.md` | `AddPolyhedra` signature, parameter table, TiO₆ example |
| `docs/docs/guide/pipeline/typescript.md` | `AddPolyhedra` comparison-table row, TiO₆ example |
| `docs/docs/guide/pipeline/index.md` | Polyhedron Generator parameter table, Solid template description, TiO₆ editor example steps |
| `docs/docs/platform-support.md` | PSF Python column `✓` → `API⁵` + footnote |
| `src/ai/skills/solid-template.md` | JSON template and customization notes use new field names |

## Test plan

- [ ] Docs-only and AI skill Markdown changes — no runtime code modified, no unit/E2E tests required
- [ ] Verified new parameter names against `python/megane/pipeline.py` (`AddPolyhedra.__init__`), `src/pipeline/builder.ts` (`AddPolyhedra` class), and `src/pipeline/types.ts` (`PolyhedronGeneratorParams`)
- [ ] Verified PSF raw parser exists at `python/megane/parsers/psf.py` (`parse_psf_bonds`) and that `AddBonds` has no `psf` parameter

https://claude.ai/code/session_01HcjejSwkWrzEpsFANegvd2