### PR TITLE
Add adjustable VDW bond threshold slider to AddBond node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **Adjustable VDW bond threshold.** The AddBond node's distance (VDW) mode now exposes a "Threshold" slider that scales the bonding cutoff `(vdw_i + vdw_j) * scale`. Loosen it to capture longer bonds or tighten it to drop spurious ones, per system. Defaults to 0.6, so existing pipelines render identically unless adjusted (#459)
+
 ### Changed
 
 - **Atom coloring moved out of the Viewport node and into the Modify node.** The Viewport "Color scheme" dropdown is gone; coloring is now a pipeline-edge concern. The Modify node has a new `Color` toggle plus a mode selector (uniform hex, byElement, byResidue, byChain, byBFactor, byProperty), and the chosen palette applies **only** to the upstream selection — so "color residues on chain A only" is now expressible by chaining Filter → Modify. A Modify node wired without a Filter still colors the whole structure (the previous single-mode workflow). Legacy serialized pipelines carrying `viewport.colorScheme` are silently stripped on load; they render in CPK until a Modify color rule is added.

--- a/docs/docs/guide/pipeline/json.md
+++ b/docs/docs/guide/pipeline/json.md
@@ -142,6 +142,7 @@ handle and emits the tagged particle stream on `out`.
 | Field | Type | Description |
 |-------|------|-------------|
 | `bondSource` | `string` | `"distance"` or `"structure"` |
+| `vdwScale` | `number` | Optional. Threshold scale for `"distance"` mode: atoms bond when their separation is `≤ (vdw_i + vdw_j) * vdwScale`. Higher loosens (more bonds), lower tightens. Defaults to `0.6`. |
 
 #### `label_generator`
 

--- a/src/components/MeganeViewer.tsx
+++ b/src/components/MeganeViewer.tsx
@@ -16,7 +16,7 @@ import { Tooltip } from "./Tooltip";
 import { MeasurementPanel } from "./MeasurementPanel";
 import { MeasurementListPanel } from "./MeasurementListPanel";
 import { MoleculeRenderer } from "../renderer/MoleculeRenderer";
-import { inferBondsVdwJS } from "../parsers/inferBondsJS";
+import { inferBondsVdwJS, DEFAULT_VDW_BOND_FACTOR } from "../parsers/inferBondsJS";
 import { processPbcBonds } from "../pipeline/executors/addBond";
 import { usePipelineStore } from "../pipeline/store";
 import { usePlaybackStore } from "../stores/usePlaybackStore";
@@ -283,7 +283,7 @@ export function MeganeViewer({
       frame.positions,
       snapshot.elements,
       snapshot.nAtoms,
-      0.6,
+      (params as AddBondParams).vdwScale ?? DEFAULT_VDW_BOND_FACTOR,
       snapshot.box,
     );
 

--- a/src/components/PipelineViewer.tsx
+++ b/src/components/PipelineViewer.tsx
@@ -38,7 +38,7 @@ import { deserializePipeline } from "../pipeline/serialize";
 import { executePipeline } from "../pipeline/execute";
 import { applyViewportState, applyVectorsForFrame } from "../pipeline/apply";
 import { parseStructureFile } from "../parsers/structure";
-import { inferBondsVdwJS } from "../parsers/inferBondsJS";
+import { inferBondsVdwJS, DEFAULT_VDW_BOND_FACTOR } from "../parsers/inferBondsJS";
 import { processPbcBonds } from "../pipeline/executors/addBond";
 import type { PipelineNodeData, NodeSnapshotData } from "../pipeline/execute";
 import type {
@@ -251,6 +251,16 @@ export function PipelineViewer({ pipeline, width = "100%", height = 500 }: Pipel
     [nodes],
   );
 
+  // VDW threshold scale for the active distance-bond node (default 0.6).
+  const distanceBondScale = useMemo(() => {
+    const node = nodes.find(
+      (n) => n.type === "add_bond" && (n.data.params as AddBondParams).bondSource === "distance",
+    );
+    return node
+      ? ((node.data.params as AddBondParams).vdwScale ?? DEFAULT_VDW_BOND_FACTOR)
+      : DEFAULT_VDW_BOND_FACTOR;
+  }, [nodes]);
+
   useEffect(() => {
     if (!hasDistanceBond) return;
     if (!currentFrameData || !primarySnapshot) return;
@@ -261,7 +271,7 @@ export function PipelineViewer({ pipeline, width = "100%", height = 500 }: Pipel
       currentFrameData.positions,
       primarySnapshot.elements,
       primarySnapshot.nAtoms,
-      0.6,
+      distanceBondScale,
       primarySnapshot.box,
     );
     const result = processPbcBonds(
@@ -279,7 +289,7 @@ export function PipelineViewer({ pipeline, width = "100%", height = 500 }: Pipel
       result.elements,
       result.nAtoms,
     );
-  }, [currentFrameData, primarySnapshot, hasDistanceBond]);
+  }, [currentFrameData, primarySnapshot, hasDistanceBond, distanceBondScale]);
 
   // ─── Playback ────────────────────────────────────────────────────
 

--- a/src/components/WidgetViewer.tsx
+++ b/src/components/WidgetViewer.tsx
@@ -16,7 +16,7 @@ import { Tooltip } from "./Tooltip";
 import { MeasurementPanel } from "./MeasurementPanel";
 import { MoleculeRenderer, type MeganeCameraState } from "../renderer/MoleculeRenderer";
 import { useAtomSelection } from "../hooks/useAtomSelection";
-import { inferBondsVdwJS } from "../parsers/inferBondsJS";
+import { inferBondsVdwJS, DEFAULT_VDW_BOND_FACTOR } from "../parsers/inferBondsJS";
 import { processPbcBonds } from "../pipeline/executors/addBond";
 import { createPipelineStore, type PipelineStore } from "../pipeline/store";
 import { applyViewportState } from "../pipeline/apply";
@@ -236,7 +236,7 @@ export function WidgetViewer({
       frame.positions,
       effectiveSnapshot.elements,
       effectiveSnapshot.nAtoms,
-      0.6,
+      (params as AddBondParams).vdwScale ?? DEFAULT_VDW_BOND_FACTOR,
       effectiveSnapshot.box,
     );
 

--- a/src/components/nodes/AddBondNode.tsx
+++ b/src/components/nodes/AddBondNode.tsx
@@ -11,6 +11,7 @@ import { usePipelineStore } from "../../pipeline/store";
 import { NodeShell } from "./NodeShell";
 import { TabSelector, smallBtnStyle, fileNameStyle } from "../ui";
 import { parseTopBonds, parsePsfBonds } from "../../parsers/structure";
+import { DEFAULT_VDW_BOND_FACTOR } from "../../parsers/inferBondsJS";
 import type { BondSource } from "../../types";
 import { useRef, useCallback } from "react";
 
@@ -26,6 +27,38 @@ const sectionLabelStyle: React.CSSProperties = {
 
 const TOPOLOGY_ACCEPT = ".top,.psf";
 const TOPOLOGY_EXTS = [".top", ".psf"];
+
+// Allowed range for the VDW distance threshold scale. Lower tightens (fewer
+// bonds), higher loosens (more bonds). 0.6 is the default used elsewhere.
+const VDW_SCALE_MIN = 0.3;
+const VDW_SCALE_MAX = 1.2;
+const VDW_SCALE_STEP = 0.05;
+
+const thresholdRowStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  marginTop: 8,
+};
+
+const thresholdLabelStyle: React.CSSProperties = {
+  fontSize: 16,
+  fontWeight: 500,
+  color: "#64748b",
+  flex: 1,
+};
+
+const thresholdSliderStyle: React.CSSProperties = {
+  width: 110,
+  accentColor: "#06b6d4",
+};
+
+const thresholdValueStyle: React.CSSProperties = {
+  fontSize: 15,
+  color: "#64748b",
+  minWidth: 30,
+  textAlign: "right",
+};
 
 export function AddBondNode({ id, data }: NodeProps<Node<PipelineNodeData>>) {
   const updateNodeParams = usePipelineStore((s) => s.updateNodeParams);
@@ -62,6 +95,25 @@ export function AddBondNode({ id, data }: NodeProps<Node<PipelineNodeData>>) {
         value={params.bondSource}
         onChange={(v) => updateNodeParams(id, { bondSource: v })}
       />
+      {params.bondSource === "distance" && (
+        <div style={thresholdRowStyle}>
+          <span style={thresholdLabelStyle}>Threshold</span>
+          <input
+            type="range"
+            className="nodrag"
+            data-testid="add-bond-vdw-scale"
+            min={VDW_SCALE_MIN}
+            max={VDW_SCALE_MAX}
+            step={VDW_SCALE_STEP}
+            value={params.vdwScale ?? DEFAULT_VDW_BOND_FACTOR}
+            style={thresholdSliderStyle}
+            onChange={(e) => updateNodeParams(id, { vdwScale: parseFloat(e.target.value) })}
+          />
+          <span style={thresholdValueStyle}>
+            {(params.vdwScale ?? DEFAULT_VDW_BOND_FACTOR).toFixed(2)}
+          </span>
+        </div>
+      )}
       {params.bondSource === "file" && (
         <div style={{ marginTop: 4 }}>
           {params.bondFileName ? (

--- a/src/parsers/inferBondsJS.ts
+++ b/src/parsers/inferBondsJS.ts
@@ -16,7 +16,7 @@
 import { VDW_RADII, DEFAULT_RADIUS } from "../constants";
 import { invert3x3 } from "../pipeline/executors/mathUtils";
 
-const DEFAULT_VDW_BOND_FACTOR = 0.6;
+export const DEFAULT_VDW_BOND_FACTOR = 0.6;
 const MIN_BOND_DIST = 0.4;
 const CELL_SIZE = 2.0;
 

--- a/src/pipeline/executors/addBond.ts
+++ b/src/pipeline/executors/addBond.ts
@@ -1,5 +1,5 @@
 import type { PipelineData, ParticleData, BondData, AddBondParams } from "../types";
-import { inferBondsVdwJS } from "../../parsers/inferBondsJS";
+import { inferBondsVdwJS, DEFAULT_VDW_BOND_FACTOR } from "../../parsers/inferBondsJS";
 import { invert3x3 } from "./mathUtils";
 
 /**
@@ -294,7 +294,7 @@ export function executeAddBond(
       snapshot.positions,
       snapshot.elements,
       snapshot.nAtoms,
-      0.6,
+      params.vdwScale ?? DEFAULT_VDW_BOND_FACTOR,
       snapshot.box,
     );
 

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -404,6 +404,13 @@ export interface AddBondParams {
   bondFileName?: string | null;
   /** Ephemeral: parsed bond indices from topology file. Not serialized. */
   bondFileData?: Uint32Array | null;
+  /**
+   * VDW threshold scale for distance-based bond inference. Two atoms bond when
+   * their distance is <= (vdw_i + vdw_j) * vdwScale. Higher loosens (more
+   * bonds), lower tightens (fewer bonds). Defaults to DEFAULT_VDW_BOND_FACTOR
+   * (0.6) when unset.
+   */
+  vdwScale?: number;
 }
 
 /**

--- a/tests/ts/components/MeganeViewer.frameChange.test.tsx
+++ b/tests/ts/components/MeganeViewer.frameChange.test.tsx
@@ -8,6 +8,7 @@ vi.mock("@/components/Timeline", () => ({ Timeline: vi.fn(() => null) }));
 vi.mock("@/components/PipelineEditor", () => ({ PipelineEditor: vi.fn(() => null) }));
 vi.mock("@/parsers/inferBondsJS", () => ({
   inferBondsVdwJS: vi.fn(() => new Uint32Array(0)),
+  DEFAULT_VDW_BOND_FACTOR: 0.6,
 }));
 vi.mock("@/pipeline/executors/addBond", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/pipeline/executors/addBond")>();

--- a/tests/ts/components/MeganeViewer.selectionEvents.test.tsx
+++ b/tests/ts/components/MeganeViewer.selectionEvents.test.tsx
@@ -9,6 +9,7 @@ vi.mock("@/components/Timeline", () => ({ Timeline: vi.fn(() => null) }));
 vi.mock("@/components/PipelineEditor", () => ({ PipelineEditor: vi.fn(() => null) }));
 vi.mock("@/parsers/inferBondsJS", () => ({
   inferBondsVdwJS: vi.fn(() => new Uint32Array(0)),
+  DEFAULT_VDW_BOND_FACTOR: 0.6,
 }));
 vi.mock("@/pipeline/executors/addBond", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/pipeline/executors/addBond")>();

--- a/tests/ts/components/WidgetViewer.test.tsx
+++ b/tests/ts/components/WidgetViewer.test.tsx
@@ -16,6 +16,7 @@ vi.mock("@/components/MeasurementPanel", () => ({
 // Spy on bond inference so we can assert the per-frame effect fires.
 vi.mock("@/parsers/inferBondsJS", () => ({
   inferBondsVdwJS: vi.fn(() => new Uint32Array(0)),
+  DEFAULT_VDW_BOND_FACTOR: 0.6,
 }));
 // Stub PBC post-processing only — preserve other exports (executeAddBond etc.)
 // that the pipeline store's execute() depends on.

--- a/tests/ts/components/nodes/AddBondNode.test.tsx
+++ b/tests/ts/components/nodes/AddBondNode.test.tsx
@@ -144,6 +144,53 @@ describe("AddBondNode", () => {
     expect(Array.from(dispatchedData)).toEqual([0, 1, 2, 3]);
   });
 
+  it("shows the VDW threshold slider only when bondSource='distance'", () => {
+    const distance = seedPipelineStore("add_bond", {
+      id: "ab1",
+      params: { bondSource: "distance" },
+    });
+    const { rerender } = render(
+      <AddBondNode {...nodeProps("ab1", distance.data.params as AddBondParams)} />,
+    );
+    expect(screen.getByTestId("add-bond-vdw-scale")).toBeInTheDocument();
+
+    const file = seedPipelineStore("add_bond", {
+      id: "ab2",
+      params: { bondSource: "file" },
+    });
+    rerender(<AddBondNode {...nodeProps("ab2", file.data.params as AddBondParams)} />);
+    expect(screen.queryByTestId("add-bond-vdw-scale")).toBeNull();
+  });
+
+  it("defaults the threshold slider to 0.6 and displays the value", () => {
+    const seeded = seedPipelineStore("add_bond", {
+      id: "ab1",
+      params: { bondSource: "distance" },
+    });
+    render(<AddBondNode {...nodeProps("ab1", seeded.data.params as AddBondParams)} />);
+
+    const slider = screen.getByTestId("add-bond-vdw-scale") as HTMLInputElement;
+    expect(slider.value).toBe("0.6");
+    expect(screen.getByText("0.60")).toBeInTheDocument();
+  });
+
+  it("reflects an explicit vdwScale and dispatches changes via updateNodeParams", () => {
+    const updateNodeParams = vi.fn();
+    const seeded = seedPipelineStore("add_bond", {
+      id: "ab1",
+      params: { bondSource: "distance", vdwScale: 0.9 },
+    });
+    usePipelineStore.setState({ updateNodeParams });
+    render(<AddBondNode {...nodeProps("ab1", seeded.data.params as AddBondParams)} />);
+
+    const slider = screen.getByTestId("add-bond-vdw-scale") as HTMLInputElement;
+    expect(slider.value).toBe("0.9");
+    expect(screen.getByText("0.90")).toBeInTheDocument();
+
+    fireEvent.change(slider, { target: { value: "0.75" } });
+    expect(updateNodeParams).toHaveBeenCalledWith("ab1", { vdwScale: 0.75 });
+  });
+
   it("uploading a non-.top file does not call the parser or dispatch", async () => {
     const updateNodeParams = vi.fn();
     const seeded = seedPipelineStore("add_bond", {

--- a/tests/ts/parsers/inferBondsJS.test.ts
+++ b/tests/ts/parsers/inferBondsJS.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { inferBondsVdwJS } from "@/parsers/inferBondsJS";
+import { inferBondsVdwJS, DEFAULT_VDW_BOND_FACTOR } from "@/parsers/inferBondsJS";
 
 describe("inferBondsVdwJS", () => {
   it("returns empty array for 0 atoms", () => {
@@ -90,6 +90,30 @@ describe("inferBondsVdwJS", () => {
 
     // Each water should have 2 O-H bonds = 6 total
     expect(bonds.length / 2).toBe(6);
+  });
+
+  it("exposes a default VDW factor of 0.6", () => {
+    expect(DEFAULT_VDW_BOND_FACTOR).toBe(0.6);
+  });
+
+  it("tightening the threshold removes borderline bonds", () => {
+    // Two carbons at 1.9 Å: bonded at the default 0.6 ((1.7+1.7)*0.6 = 2.04),
+    // but not at a tighter 0.5 scale ((1.7+1.7)*0.5 = 1.7).
+    const positions = new Float32Array([0, 0, 0, 1.9, 0, 0]);
+    const elements = new Uint8Array([6, 6]);
+
+    expect(inferBondsVdwJS(positions, elements, 2, 0.6).length).toBe(2);
+    expect(inferBondsVdwJS(positions, elements, 2, 0.5).length).toBe(0);
+  });
+
+  it("loosening the threshold adds bonds beyond the default range", () => {
+    // Two carbons at 2.3 Å: not bonded at 0.6 (threshold 2.04) but bonded at
+    // a looser 0.8 scale ((1.7+1.7)*0.8 = 2.72).
+    const positions = new Float32Array([0, 0, 0, 2.3, 0, 0]);
+    const elements = new Uint8Array([6, 6]);
+
+    expect(inferBondsVdwJS(positions, elements, 2, 0.6).length).toBe(0);
+    expect(inferBondsVdwJS(positions, elements, 2, 0.8).length).toBe(2);
   });
 
   it("bonds carbon atoms at covalent-like distance", () => {


### PR DESCRIPTION
## Summary

Exposes a "Threshold" slider in the AddBond node's distance (VDW) mode that scales the bonding cutoff distance. Users can now tighten the threshold to drop spurious bonds or loosen it to capture longer bonds, per system. The scale factor multiplies the sum of van der Waals radii: `(vdw_i + vdw_j) * scale`. Defaults to 0.6, so existing pipelines render identically unless adjusted.

### Changes

- **AddBondNode UI**: Added a range slider (0.3–1.2, step 0.05) that appears only when `bondSource === "distance"`. Displays the current value to two decimal places.
- **AddBondParams type**: Added optional `vdwScale` field to persist the user's threshold choice.
- **Bond inference**: Updated all call sites (`PipelineViewer`, `MeganeViewer`, `WidgetViewer`, `addBond` executor) to use `params.vdwScale ?? DEFAULT_VDW_BOND_FACTOR` instead of hardcoded 0.6.
- **Export constant**: Made `DEFAULT_VDW_BOND_FACTOR` (0.6) a public export from `inferBondsJS.ts` for consistent defaults across the codebase.
- **Documentation**: Updated JSON schema docs to describe the new `vdwScale` field.
- **CHANGELOG**: Documented the feature.

### Test Coverage

- Added three new unit tests in `AddBondNode.test.tsx`:
  - Slider visibility conditional on `bondSource === "distance"`
  - Default value (0.6) and display formatting
  - Explicit `vdwScale` persistence and `updateNodeParams` dispatch on change
- Added two new tests in `inferBondsJS.test.ts`:
  - Tightening threshold (0.5) removes borderline bonds
  - Loosening threshold (0.8) adds bonds beyond default range
- Existing tests pass; mocks updated to export `DEFAULT_VDW_BOND_FACTOR`.

## Test Plan

- [x] `npm test` passes (new unit tests + existing suite)
- [x] `cargo test -p megane-core` passes (no Rust changes)
- [x] Manually verified the slider appears only in distance mode, defaults to 0.6, and updates the node params on change

https://claude.ai/code/session_01H4WxFL2QuEdaXh7tscxygz