### PR TITLE
fix(renderer): replay bonds when updateBondsExt precedes loadSnapshot

### DIFF
--- a/src/renderer/MoleculeRenderer.ts
+++ b/src/renderer/MoleculeRenderer.ts
@@ -201,6 +201,19 @@ export class MoleculeRenderer {
   private snapshot: Snapshot | null = null;
   private lastExtent: ViewExtent = { maxExtent: 1, extentX: 1, extentY: 1 };
   private currentPositions: Float32Array | null = null;
+  /**
+   * Bonds pushed via updateBondsExt before a snapshot/bondRenderer existed.
+   * Replayed inside loadSnapshot. Guards against PipelineViewer's
+   * parent-before-child effect ordering, where applyViewportState calls
+   * updateBondsExt before Viewport calls loadSnapshot.
+   */
+  private pendingBonds: {
+    bonds: Uint32Array;
+    bondOrders: Uint8Array | null;
+    positions: Float32Array | null;
+    elements: Uint8Array | null;
+    nAtoms: number;
+  } | null = null;
   /** Axes-inset drag state */
   private axesDragging = false;
   private axesDragLastX = 0;
@@ -412,6 +425,10 @@ export class MoleculeRenderer {
     // Bond loading is handled exclusively by the pipeline via updateBondsExt/updateBonds
     // (called from applyViewportState). This avoids race conditions between
     // Viewport's loadSnapshot and MeganeViewer's applyViewportState effects.
+    // If updateBondsExt ran before this snapshot existed (PipelineViewer's
+    // parent-before-child effect ordering), the bonds were stashed — replay
+    // them now that this.snapshot and this.bondRenderer are ready.
+    this.flushPendingBonds();
 
     // Re-apply stored scale after loading snapshot data
     if (this.atomScale !== 1.0 && this.atomRenderer!.setScale) {
@@ -542,7 +559,16 @@ export class MoleculeRenderer {
     elements: Uint8Array | null,
     nAtoms: number,
   ): void {
-    if (!this.snapshot || !this.bondRenderer) return;
+    if (!this.snapshot || !this.bondRenderer) {
+      // Called before the snapshot/bondRenderer exist (PipelineViewer's
+      // parent-before-child effect ordering). Stash the args and replay them
+      // in loadSnapshot, since applyViewportState may never call us again
+      // (its bondIndices memo guard skips identical references).
+      this.pendingBonds = { bonds, bondOrders, positions, elements, nAtoms };
+      return;
+    }
+    // Reached the live path — any earlier stash is now superseded.
+    this.pendingBonds = null;
     const pos = positions ?? this.currentPositions ?? this.snapshot.positions;
     const elems = elements ?? this.snapshot.elements;
     const atomCount = nAtoms || this.snapshot.nAtoms;
@@ -560,6 +586,18 @@ export class MoleculeRenderer {
       this.bondRenderer.setScale(this.bondScale, this.snapshot);
     }
     this.syncBondColorsToAtoms(extSnap);
+  }
+
+  /**
+   * Replay bonds that updateBondsExt stashed because it ran before a snapshot
+   * existed. Called from loadSnapshot once this.snapshot and this.bondRenderer
+   * are ready, so the replayed updateBondsExt passes its guard.
+   */
+  private flushPendingBonds(): void {
+    if (!this.pendingBonds) return;
+    const p = this.pendingBonds;
+    this.pendingBonds = null;
+    this.updateBondsExt(p.bonds, p.bondOrders, p.positions, p.elements, p.nAtoms);
   }
 
   /** Set per-atom labels for overlay display. */

--- a/tests/ts/renderer/MoleculeRendererPendingBonds.test.ts
+++ b/tests/ts/renderer/MoleculeRendererPendingBonds.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { MoleculeRenderer } from "@/renderer/MoleculeRenderer";
+import { ImpostorAtomMesh } from "@/renderer/ImpostorAtomMesh";
+import { ImpostorBondMesh } from "@/renderer/ImpostorBondMesh";
+import type { Snapshot } from "@/types";
+
+/** Read the private instance count off a bond mesh's geometry. */
+function bondInstanceCount(bond: ImpostorBondMesh): number {
+  return (bond as unknown as { geo: { instanceCount: number } }).geo.instanceCount;
+}
+
+function makeSnapshot(): Snapshot {
+  return {
+    nAtoms: 2,
+    nBonds: 1,
+    positions: new Float32Array([0, 0, 0, 1, 0, 0]),
+    elements: new Uint8Array([6, 8]),
+    bonds: new Uint32Array([0, 1]),
+    bondOrders: null,
+  } as Snapshot;
+}
+
+/**
+ * Build a renderer with atom + bond meshes attached but no snapshot yet,
+ * skipping the WebGL-dependent mount() pipeline. Mirrors the internals-access
+ * convention used in MoleculeRendererColor.test.ts.
+ */
+function makeRendererWithMeshes(): {
+  renderer: MoleculeRenderer;
+  atom: ImpostorAtomMesh;
+  bond: ImpostorBondMesh;
+  snapshot: Snapshot;
+} {
+  const renderer = new MoleculeRenderer();
+  const snapshot = makeSnapshot();
+  const atom = new ImpostorAtomMesh(8);
+  const bond = new ImpostorBondMesh(16);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const internals = renderer as any;
+  internals.atomRenderer = atom;
+  internals.bondRenderer = bond;
+  return { renderer, atom, bond, snapshot };
+}
+
+describe("MoleculeRenderer — pending bonds (effect-ordering guard)", () => {
+  it("stashes bonds when updateBondsExt runs before a snapshot exists", () => {
+    const { renderer, bond, snapshot } = makeRendererWithMeshes();
+    // No snapshot set yet — simulates PipelineViewer's parent viewportState
+    // effect firing updateBondsExt before the child Viewport's loadSnapshot.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internals = renderer as any;
+    expect(internals.snapshot).toBeFalsy();
+
+    renderer.updateBondsExt(snapshot.bonds, null, null, null, snapshot.nAtoms);
+
+    // The bonds were not dropped — they are stashed for replay.
+    expect(internals.pendingBonds).not.toBeNull();
+    expect(internals.pendingBonds.bonds).toBe(snapshot.bonds);
+    expect(internals.pendingBonds.nAtoms).toBe(snapshot.nAtoms);
+    // Nothing was pushed into the bond mesh yet.
+    expect(bondInstanceCount(bond)).toBe(0);
+  });
+
+  it("replays stashed bonds once the snapshot is ready (flushPendingBonds)", () => {
+    const { renderer, bond, snapshot } = makeRendererWithMeshes();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internals = renderer as any;
+
+    // 1. updateBondsExt before snapshot → stash, mesh stays empty.
+    renderer.updateBondsExt(snapshot.bonds, null, null, null, snapshot.nAtoms);
+    expect(internals.pendingBonds).not.toBeNull();
+    expect(bondInstanceCount(bond)).toBe(0);
+
+    // 2. loadSnapshot would set this.snapshot and then flush. Emulate that
+    //    here (loadSnapshot itself needs a mounted WebGL scene).
+    internals.snapshot = snapshot;
+    internals.flushPendingBonds();
+
+    // 3. Bonds are now applied and the stash is cleared.
+    expect(internals.pendingBonds).toBeNull();
+    expect(bondInstanceCount(bond)).toBe(snapshot.nBonds);
+  });
+
+  it("does not stash on the live path and clears any prior stash", () => {
+    const { renderer, bond, snapshot } = makeRendererWithMeshes();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internals = renderer as any;
+    internals.snapshot = snapshot;
+
+    // Live path: snapshot + bondRenderer present → applies immediately.
+    renderer.updateBondsExt(snapshot.bonds, null, null, null, snapshot.nAtoms);
+    expect(internals.pendingBonds).toBeNull();
+    expect(bondInstanceCount(bond)).toBe(snapshot.nBonds);
+  });
+
+  it("flushPendingBonds is a no-op when nothing was stashed", () => {
+    const { renderer, bond } = makeRendererWithMeshes();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internals = renderer as any;
+    internals.snapshot = makeSnapshot();
+
+    internals.flushPendingBonds();
+    expect(internals.pendingBonds).toBeNull();
+    expect(bondInstanceCount(bond)).toBe(0);
+  });
+});


### PR DESCRIPTION
PipelineViewer drives the renderer through two effects in different
components: the parent's viewportState effect calls applyViewportState ->
updateBondsExt, and the child Viewport's snapshot effect calls loadSnapshot.
React runs parent effects before child effects, so on first execution
updateBondsExt fires while this.snapshot and this.bondRenderer are still
null. Its guard early-returned and dropped the bonds. With a stable
(memoized) pipeline, applyViewportState's bondIndices memo guard never
re-issues the call, so distance-mode bonds were lost permanently.

Make MoleculeRenderer defensive: when updateBondsExt runs before a snapshot
exists, stash the args in pendingBonds and replay them from loadSnapshot via
flushPendingBonds, once this.snapshot and this.bondRenderer are ready. The
live path clears any stale stash. This also helps embedders that drive the
renderer directly and only render once.

Add unit tests covering the stash, the replay, the live path, and the
no-op flush. The single loadSnapshot call site is not unit-covered because
loadSnapshot requires a mounted WebGL context (unavailable under jsdom); it
is exercised by the local-only E2E pipeline flows.