### PR TITLE
fix(replicate): animate replicated copies during trajectory playback

### DIFF
--- a/src/pipeline/defaults.ts
+++ b/src/pipeline/defaults.ts
@@ -136,6 +136,13 @@ export function createDefaultPipeline(): {
       {
         id: "e8",
         source: "traj-1",
+        target: "replicate-1",
+        sourceHandle: "trajectory",
+        targetHandle: "trajectory",
+      },
+      {
+        id: "e9",
+        source: "replicate-1",
         target: "viewport-1",
         sourceHandle: "trajectory",
         targetHandle: "trajectory",
@@ -280,6 +287,13 @@ export function createMinimalStructurePipeline(): {
       {
         id: "e8",
         source: "traj-1",
+        target: "replicate-1",
+        sourceHandle: "trajectory",
+        targetHandle: "trajectory",
+      },
+      {
+        id: "e9",
+        source: "replicate-1",
         target: "viewport-1",
         sourceHandle: "trajectory",
         targetHandle: "trajectory",
@@ -401,6 +415,13 @@ export function createEmptyPipeline(): {
       {
         id: "e7",
         source: "loader-1",
+        target: "replicate-1",
+        sourceHandle: "trajectory",
+        targetHandle: "trajectory",
+      },
+      {
+        id: "e8",
+        source: "replicate-1",
         target: "viewport-1",
         sourceHandle: "trajectory",
         targetHandle: "trajectory",

--- a/src/pipeline/executors/replicate.ts
+++ b/src/pipeline/executors/replicate.ts
@@ -1,5 +1,12 @@
-import type { Snapshot } from "../../types";
-import type { PipelineData, ParticleData, CellData, ReplicateParams } from "../types";
+import type { Snapshot, Frame, TrajectoryMeta } from "../../types";
+import type {
+  PipelineData,
+  ParticleData,
+  CellData,
+  ReplicateParams,
+  TrajectoryData,
+  FrameProvider,
+} from "../types";
 
 /**
  * Replicate node — OVITO/VESTA-style supercell builder.
@@ -21,6 +28,7 @@ export function executeReplicate(
   const outputs = new Map<string, PipelineData>();
   const particle = inputs.get("particle")?.[0] as ParticleData | undefined;
   const cellIn = inputs.get("cell")?.[0] as CellData | undefined;
+  const trajIn = inputs.get("trajectory")?.[0] as TrajectoryData | undefined;
   if (!particle) return outputs;
 
   const nx = Math.max(1, Math.floor(params.nx));
@@ -32,6 +40,7 @@ export function executeReplicate(
   if ((nx === 1 && ny === 1 && nz === 1) || !box) {
     outputs.set("particle", particle);
     if (cellIn) outputs.set("cell", cellIn);
+    if (trajIn) outputs.set("trajectory", trajIn);
     return outputs;
   }
 
@@ -52,30 +61,42 @@ export function executeReplicate(
     cy = box[7],
     cz = box[8];
 
+  // Per-image translation offsets — the single source of truth for image
+  // placement, reused for both the static snapshot and trajectory frames.
+  // Image order: i (nx outer), j (ny), k (nz inner), matching the atom layout.
+  const offsets = new Float32Array(total * 3);
+  {
+    let m = 0;
+    for (let i = 0; i < nx; i++) {
+      for (let j = 0; j < ny; j++) {
+        for (let k = 0; k < nz; k++, m++) {
+          offsets[m * 3] = i * ax + j * bx + k * cx;
+          offsets[m * 3 + 1] = i * ay + j * by + k * cy;
+          offsets[m * 3 + 2] = i * az + j * bz + k * cz;
+        }
+      }
+    }
+  }
+
   const positions = new Float32Array(nAtomsNew * 3);
   const elements = new Uint8Array(nAtomsNew);
   const atomChainIds = src.atomChainIds ? new Uint8Array(nAtomsNew) : null;
   const atomBFactors = src.atomBFactors ? new Float32Array(nAtomsNew) : null;
 
-  let img = 0;
-  for (let i = 0; i < nx; i++) {
-    for (let j = 0; j < ny; j++) {
-      for (let k = 0; k < nz; k++, img++) {
-        const offX = i * ax + j * bx + k * cx;
-        const offY = i * ay + j * by + k * cy;
-        const offZ = i * az + j * bz + k * cz;
-        const atomBase = img * nAtomsOld;
-        for (let a = 0; a < nAtomsOld; a++) {
-          const dst = (atomBase + a) * 3;
-          const s = a * 3;
-          positions[dst] = src.positions[s] + offX;
-          positions[dst + 1] = src.positions[s + 1] + offY;
-          positions[dst + 2] = src.positions[s + 2] + offZ;
-          elements[atomBase + a] = src.elements[a];
-          if (atomChainIds) atomChainIds[atomBase + a] = src.atomChainIds![a];
-          if (atomBFactors) atomBFactors[atomBase + a] = src.atomBFactors![a];
-        }
-      }
+  for (let img = 0; img < total; img++) {
+    const offX = offsets[img * 3];
+    const offY = offsets[img * 3 + 1];
+    const offZ = offsets[img * 3 + 2];
+    const atomBase = img * nAtomsOld;
+    for (let a = 0; a < nAtomsOld; a++) {
+      const dst = (atomBase + a) * 3;
+      const s = a * 3;
+      positions[dst] = src.positions[s] + offX;
+      positions[dst + 1] = src.positions[s + 1] + offY;
+      positions[dst + 2] = src.positions[s + 2] + offZ;
+      elements[atomBase + a] = src.elements[a];
+      if (atomChainIds) atomChainIds[atomBase + a] = src.atomChainIds![a];
+      if (atomBFactors) atomBFactors[atomBase + a] = src.atomBFactors![a];
     }
   }
 
@@ -164,7 +185,73 @@ export function executeReplicate(
   };
   outputs.set("cell", newCell);
 
+  // Trajectory: wrap the upstream provider so every frame is tiled across the
+  // same image grid as the static snapshot. Without this the replicated copies
+  // would freeze at their base positions while only the original cell animates.
+  if (trajIn) {
+    const newMeta: TrajectoryMeta = {
+      ...trajIn.meta,
+      nAtoms: trajIn.meta.nAtoms * total,
+    };
+    const newTrajectory: TrajectoryData = {
+      type: "trajectory",
+      provider: new ReplicatedFrameProvider(trajIn.provider, offsets, newMeta),
+      meta: newMeta,
+      source: trajIn.source,
+    };
+    outputs.set("trajectory", newTrajectory);
+  }
+
   return outputs;
+}
+
+/**
+ * Wraps a FrameProvider and replicates each frame's positions across an
+ * `nx×ny×nz` image grid using the supplied per-image `offsets` (length
+ * `total·3`). The number of atoms per image is derived from each frame's own
+ * positions array, so the provider stays robust to frame/structure atom-count
+ * differences. Streaming semantics are preserved: `getFrame` returns `null`
+ * when the wrapped provider has no frame available yet.
+ */
+class ReplicatedFrameProvider implements FrameProvider {
+  readonly kind: "memory" | "stream";
+  readonly meta: TrajectoryMeta;
+  private readonly source: FrameProvider;
+  private readonly offsets: Float32Array;
+  private readonly total: number;
+
+  constructor(source: FrameProvider, offsets: Float32Array, meta: TrajectoryMeta) {
+    this.source = source;
+    this.offsets = offsets;
+    this.total = offsets.length / 3;
+    this.kind = source.kind;
+    this.meta = meta;
+  }
+
+  getFrame(index: number): Frame | null {
+    const frame = this.source.getFrame(index);
+    if (!frame) return null;
+    const nAtomsPerImage = frame.positions.length / 3;
+    const out = new Float32Array(nAtomsPerImage * this.total * 3);
+    for (let img = 0; img < this.total; img++) {
+      const offX = this.offsets[img * 3];
+      const offY = this.offsets[img * 3 + 1];
+      const offZ = this.offsets[img * 3 + 2];
+      const base = img * nAtomsPerImage * 3;
+      for (let a = 0; a < nAtomsPerImage; a++) {
+        const s = a * 3;
+        const dst = base + s;
+        out[dst] = frame.positions[s] + offX;
+        out[dst + 1] = frame.positions[s + 1] + offY;
+        out[dst + 2] = frame.positions[s + 2] + offZ;
+      }
+    }
+    return {
+      frameId: frame.frameId,
+      nAtoms: nAtomsPerImage * this.total,
+      positions: out,
+    };
+  }
 }
 
 /** Tile a per-atom selection index array, shifting each copy by img·nAtomsOld. */

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -338,10 +338,12 @@ export const NODE_PORTS: Record<PipelineNodeType, NodePortConfig> = {
     inputs: [
       { name: "particle", dataType: "particle", label: "Particle" },
       { name: "cell", dataType: "cell", label: "Cell" },
+      { name: "trajectory", dataType: "trajectory", label: "Trajectory" },
     ],
     outputs: [
       { name: "particle", dataType: "particle", label: "Particle" },
       { name: "cell", dataType: "cell", label: "Cell" },
+      { name: "trajectory", dataType: "trajectory", label: "Trajectory" },
     ],
   },
   color: {

--- a/tests/ts/pipeline/executors/replicate.test.ts
+++ b/tests/ts/pipeline/executors/replicate.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { executeReplicate } from "@/pipeline/executors/replicate";
-import type { ReplicateParams, ParticleData, CellData, PipelineData } from "@/pipeline/types";
-import type { Snapshot } from "@/types";
+import type {
+  ReplicateParams,
+  ParticleData,
+  CellData,
+  PipelineData,
+  TrajectoryData,
+} from "@/pipeline/types";
+import { MemoryFrameProvider } from "@/pipeline/types";
+import type { Snapshot, Frame, TrajectoryMeta } from "@/types";
 
 /** Two atoms at (1,1,1) and (2,2,2) with one bond, in a 10 Å cubic cell. */
 function makeSnapshot(box: Float32Array | null): Snapshot {
@@ -43,10 +50,33 @@ function params(nx: number, ny: number, nz: number): ReplicateParams {
   return { type: "replicate", nx, ny, nz };
 }
 
-function inputs(particle?: ParticleData, cell?: CellData): Map<string, PipelineData[]> {
+/**
+ * Two-frame trajectory of the 2-atom snapshot. Frame 0 is the base, frame 1
+ * shifts both atoms by +5 in x so we can confirm per-frame motion replicates.
+ */
+function makeTrajectory(): TrajectoryData {
+  const meta: TrajectoryMeta = { nFrames: 2, timestepPs: 1, nAtoms: 2 };
+  const frames: Frame[] = [
+    { frameId: 0, nAtoms: 2, positions: new Float32Array([1, 1, 1, 2, 2, 2]) },
+    { frameId: 1, nAtoms: 2, positions: new Float32Array([6, 1, 1, 7, 2, 2]) },
+  ];
+  return {
+    type: "trajectory",
+    provider: new MemoryFrameProvider(frames, meta),
+    meta,
+    source: "file",
+  };
+}
+
+function inputs(
+  particle?: ParticleData,
+  cell?: CellData,
+  trajectory?: TrajectoryData,
+): Map<string, PipelineData[]> {
   const m = new Map<string, PipelineData[]>();
   if (particle) m.set("particle", [particle]);
   if (cell) m.set("cell", [cell]);
+  if (trajectory) m.set("trajectory", [trajectory]);
   return m;
 }
 
@@ -146,5 +176,78 @@ describe("executeReplicate", () => {
     const cell = out.get("cell") as CellData;
     expect(cell.type).toBe("cell");
     expect(Array.from(cell.box)).toEqual([20, 0, 0, 0, 10, 0, 0, 0, 10]);
+  });
+
+  it("emits no trajectory output when none is wired in", () => {
+    const particle = makeParticle(CUBIC());
+    const out = executeReplicate(params(2, 1, 1), inputs(particle, makeCell(CUBIC())));
+    expect(out.has("trajectory")).toBe(false);
+  });
+
+  it("replicates trajectory frames with the same per-image offsets as the snapshot", () => {
+    const particle = makeParticle(CUBIC());
+    const out = executeReplicate(
+      params(2, 1, 1),
+      inputs(particle, makeCell(CUBIC()), makeTrajectory()),
+    );
+    const traj = out.get("trajectory") as TrajectoryData;
+    expect(traj.type).toBe("trajectory");
+
+    // Frame 0: original two atoms, then the +a (10 in x) image.
+    const f0 = traj.provider.getFrame(0)!;
+    expect(f0.nAtoms).toBe(4);
+    expect(Array.from(f0.positions.slice(0, 6))).toEqual([1, 1, 1, 2, 2, 2]);
+    expect(Array.from(f0.positions.slice(6, 12))).toEqual([11, 1, 1, 12, 2, 2]);
+
+    // Frame 1 (atoms shifted +5 in x): the image is still shifted by +a on top.
+    const f1 = traj.provider.getFrame(1)!;
+    expect(Array.from(f1.positions.slice(0, 6))).toEqual([6, 1, 1, 7, 2, 2]);
+    expect(Array.from(f1.positions.slice(6, 12))).toEqual([16, 1, 1, 17, 2, 2]);
+  });
+
+  it("scales trajectory meta nAtoms by the image count, preserving nFrames", () => {
+    const particle = makeParticle(CUBIC());
+    const out = executeReplicate(
+      params(2, 2, 2),
+      inputs(particle, makeCell(CUBIC()), makeTrajectory()),
+    );
+    const traj = out.get("trajectory") as TrajectoryData;
+    expect(traj.meta.nAtoms).toBe(2 * 8);
+    expect(traj.meta.nFrames).toBe(2);
+    expect(traj.source).toBe("file");
+  });
+
+  it("preserves the provider's streaming kind", () => {
+    const particle = makeParticle(CUBIC());
+    const out = executeReplicate(
+      params(2, 1, 1),
+      inputs(particle, makeCell(CUBIC()), makeTrajectory()),
+    );
+    const traj = out.get("trajectory") as TrajectoryData;
+    expect(traj.provider.kind).toBe("memory");
+  });
+
+  it("returns null from the replicated provider when the source has no frame", () => {
+    const particle = makeParticle(CUBIC());
+    const out = executeReplicate(
+      params(2, 1, 1),
+      inputs(particle, makeCell(CUBIC()), makeTrajectory()),
+    );
+    const traj = out.get("trajectory") as TrajectoryData;
+    expect(traj.provider.getFrame(99)).toBeNull();
+  });
+
+  it("passes the trajectory through unchanged for 1×1×1 (identity)", () => {
+    const particle = makeParticle(CUBIC());
+    const trajectory = makeTrajectory();
+    const out = executeReplicate(params(1, 1, 1), inputs(particle, makeCell(CUBIC()), trajectory));
+    expect(out.get("trajectory")).toBe(trajectory);
+  });
+
+  it("passes the trajectory through unchanged when there is no unit cell", () => {
+    const particle = makeParticle(null);
+    const trajectory = makeTrajectory();
+    const out = executeReplicate(params(2, 1, 1), inputs(particle, undefined, trajectory));
+    expect(out.get("trajectory")).toBe(trajectory);
   });
 });

--- a/tests/ts/pipeline/openFile.test.ts
+++ b/tests/ts/pipeline/openFile.test.ts
@@ -17,12 +17,7 @@ vi.mock("@/parsers/xtc", () => ({
 
 import { parseStructureFile, parseTopBonds, parsePsfBonds } from "@/parsers/structure";
 import { applyTopologyFile } from "@/pipeline/openFile";
-import {
-  parseXTCFile,
-  parseLammpstrjFile,
-  parseDCDFile,
-  parseNetCDFFile,
-} from "@/parsers/xtc";
+import { parseXTCFile, parseLammpstrjFile, parseDCDFile, parseNetCDFFile } from "@/parsers/xtc";
 import { usePipelineStore } from "@/pipeline/store";
 import type { Snapshot, Frame, TrajectoryMeta } from "@/types";
 
@@ -117,10 +112,21 @@ describe("usePipelineStore.openFile — single structure file", () => {
     // node itself, so the seed LoadTrajectory node should be removed and
     // its downstream consumers rewired to LoadStructure.trajectory.
     expect(state.nodes.find((n) => n.type === "load_trajectory")).toBeUndefined();
+    // The trajectory routes through the replicate node so replicated copies
+    // animate: LoadStructure.trajectory → Replicate.trajectory → Viewport.
+    const replicate = state.nodes.find((n) => n.type === "replicate")!;
     const viewport = state.nodes.find((n) => n.type === "viewport")!;
-    const trajEdge = state.edges.find(
+    const rewiredEdge = state.edges.find(
       (e) =>
         e.source === loader.id &&
+        e.sourceHandle === "trajectory" &&
+        e.target === replicate.id &&
+        e.targetHandle === "trajectory",
+    );
+    expect(rewiredEdge).toBeDefined();
+    const trajEdge = state.edges.find(
+      (e) =>
+        e.source === replicate.id &&
         e.sourceHandle === "trajectory" &&
         e.target === viewport.id &&
         e.targetHandle === "trajectory",
@@ -637,7 +643,9 @@ describe("usePipelineStore — cross-document state isolation", () => {
     await usePipelineStore
       .getState()
       .openFile(new File([JSON.stringify(pipeline)], "loaderless.megane.json"));
-    expect(usePipelineStore.getState().nodes.find((n) => n.type === "load_structure")).toBeUndefined();
+    expect(
+      usePipelineStore.getState().nodes.find((n) => n.type === "load_structure"),
+    ).toBeUndefined();
 
     mockParseStructureFile.mockResolvedValueOnce({
       snapshot: makeSnapshot(5),


### PR DESCRIPTION
The Replicate node only transformed the static base snapshot, so when a
trajectory played, only the original cell moved while every replicated
image stayed frozen at its base position. Trajectory data bypassed the
node entirely (it had no trajectory port) and the viewport received
single-cell frame positions for the enlarged supercell geometry.

Give Replicate a trajectory in/out port and wrap the upstream
FrameProvider in a ReplicatedFrameProvider that tiles each frame's
positions with the same per-image lattice offsets used for the static
snapshot, scaling the trajectory meta nAtoms accordingly. Identity
(1x1x1) and no-cell replications pass the trajectory through unchanged,
and streaming providers keep their kind. Route the trajectory through
Replicate in the default, minimal, and empty pipelines so the fix
applies out of the box on every host.

Add unit tests covering frame tiling, meta scaling, pass-through, and
streaming-null handling; update the openFile rewire test for the new
trajectory path.