### PR TITLE
Enable the demo LLM proxy on the custom-domain S3 site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,13 @@ jobs:
 
       - run: npm run build:wasm
 
+      # Inject the demo LLM proxy URL so the built app enables the free
+      # "demo" provider (isDemoProviderAvailable() in src/ai/config.ts keys
+      # off this) instead of falling back to BYOK. Same repo variable the
+      # docs demo build uses.
       - run: npm run build:app
+        env:
+          VITE_LLM_PROXY_URL: ${{ vars.LLM_PROXY_URL }}
 
       - name: Verify build artifacts
         run: test -f python/megane/static/app/index.html

--- a/workers/llm-proxy/src/proxy.ts
+++ b/workers/llm-proxy/src/proxy.ts
@@ -12,6 +12,13 @@
 
 export interface Env {
   OPENROUTER_API_KEY: string;
+  /**
+   * Comma-separated list of origins allowed to call this proxy. A single
+   * value (no comma) is the common case, but multiple let one proxy serve
+   * several demo deployments — e.g. the GitHub Pages docs demo and a
+   * custom-domain S3 site. Both the explicit Origin check and the CORS
+   * headers key off this list.
+   */
   ALLOWED_ORIGIN: string;
   RATE_LIMIT_KV: KVNamespace;
   /**
@@ -182,7 +189,9 @@ export async function handleFetch(request: Request, env: Env): Promise<Response>
       headers: {
         Authorization: `Bearer ${env.OPENROUTER_API_KEY}`,
         "Content-Type": "application/json",
-        "HTTP-Referer": env.ALLOWED_ORIGIN,
+        // origin is guaranteed allowed (and non-null) here; fall back to the
+        // first configured origin only to satisfy the type.
+        "HTTP-Referer": origin ?? parseAllowedOrigins(env)[0],
         "X-Title": "megane demo",
       },
       body: JSON.stringify(upstreamBody),
@@ -212,14 +221,27 @@ export async function handleFetch(request: Request, env: Env): Promise<Response>
 
 // ─── CORS ────────────────────────────────────────────────────────────
 
+/**
+ * Parse the comma-separated {@link Env.ALLOWED_ORIGIN} config into a
+ * trimmed, non-empty list of origins.
+ */
+export function parseAllowedOrigins(env: Env): string[] {
+  return env.ALLOWED_ORIGIN.split(",")
+    .map((o) => o.trim())
+    .filter((o) => o.length > 0);
+}
+
 export function isAllowedOrigin(origin: string | null, env: Env): boolean {
-  return origin !== null && origin === env.ALLOWED_ORIGIN;
+  return origin !== null && parseAllowedOrigins(env).includes(origin);
 }
 
 export function corsHeaders(origin: string | null, env: Env): Record<string, string> {
   if (!isAllowedOrigin(origin, env)) return {};
+  // Echo back the matching origin (not the whole list): with multiple
+  // allowed origins the response may name only one, and it must be the
+  // caller's for the browser to accept it.
   return {
-    "Access-Control-Allow-Origin": env.ALLOWED_ORIGIN,
+    "Access-Control-Allow-Origin": origin as string,
     Vary: "Origin",
   };
 }

--- a/workers/llm-proxy/test/index.test.ts
+++ b/workers/llm-proxy/test/index.test.ts
@@ -3,6 +3,7 @@ import worker from "../src/index";
 import {
   isAllowedOrigin,
   corsHeaders,
+  parseAllowedOrigins,
   sanitizeMessages,
   sanitizeTools,
   isRateLimited,
@@ -15,6 +16,7 @@ import {
 } from "../src/proxy";
 
 const ALLOWED_ORIGIN = "https://hodakamori.github.io";
+const SECOND_ORIGIN = "https://megane.tech-office-mori.com";
 
 class FakeKV {
   private store = new Map<string, string>();
@@ -36,11 +38,27 @@ function makeEnv(kv: FakeKV = new FakeKV()): Env {
   };
 }
 
+/** An env whose ALLOWED_ORIGIN lists two comma-separated origins. */
+function makeMultiOriginEnv(kv: FakeKV = new FakeKV()): Env {
+  return { ...makeEnv(kv), ALLOWED_ORIGIN: `${ALLOWED_ORIGIN}, ${SECOND_ORIGIN}` };
+}
+
 beforeEach(() => {
   vi.restoreAllMocks();
 });
 
 // ─── CORS helpers ────────────────────────────────────────────────────
+
+describe("parseAllowedOrigins", () => {
+  it("returns a single-element list for one origin", () => {
+    expect(parseAllowedOrigins(makeEnv())).toEqual([ALLOWED_ORIGIN]);
+  });
+
+  it("splits, trims, and drops blank entries for a comma-separated list", () => {
+    const env = { ...makeEnv(), ALLOWED_ORIGIN: ` ${ALLOWED_ORIGIN} , ,${SECOND_ORIGIN}, ` };
+    expect(parseAllowedOrigins(env)).toEqual([ALLOWED_ORIGIN, SECOND_ORIGIN]);
+  });
+});
 
 describe("isAllowedOrigin", () => {
   it("accepts the configured origin", () => {
@@ -54,6 +72,13 @@ describe("isAllowedOrigin", () => {
   it("rejects a missing origin", () => {
     expect(isAllowedOrigin(null, makeEnv())).toBe(false);
   });
+
+  it("accepts any origin in a comma-separated list", () => {
+    const env = makeMultiOriginEnv();
+    expect(isAllowedOrigin(ALLOWED_ORIGIN, env)).toBe(true);
+    expect(isAllowedOrigin(SECOND_ORIGIN, env)).toBe(true);
+    expect(isAllowedOrigin("https://evil.example", env)).toBe(false);
+  });
 });
 
 describe("corsHeaders", () => {
@@ -65,6 +90,12 @@ describe("corsHeaders", () => {
 
   it("returns no headers for a disallowed origin", () => {
     expect(corsHeaders("https://evil.example", makeEnv())).toEqual({});
+  });
+
+  it("echoes back the matching origin from a multi-origin list", () => {
+    const env = makeMultiOriginEnv();
+    expect(corsHeaders(SECOND_ORIGIN, env)["Access-Control-Allow-Origin"]).toBe(SECOND_ORIGIN);
+    expect(corsHeaders(ALLOWED_ORIGIN, env)["Access-Control-Allow-Origin"]).toBe(ALLOWED_ORIGIN);
   });
 });
 
@@ -455,6 +486,26 @@ describe("worker fetch handler", () => {
     expect(res.headers.get("Content-Type")).toBe("text/event-stream");
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe(ALLOWED_ORIGIN);
     expect(await res.text()).toBe(upstreamBody);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("accepts a request from a second allowed origin and echoes it in CORS", async () => {
+    const env = makeMultiOriginEnv();
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      const headers = init.headers as Record<string, string>;
+      // HTTP-Referer should carry the actual caller's origin.
+      expect(headers["HTTP-Referer"]).toBe(SECOND_ORIGIN);
+      return new Response("data: ok\n\n", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await worker.fetch(
+      makeRequest({ origin: SECOND_ORIGIN, body: { messages: [{ role: "user", content: "hi" }] } }),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(SECOND_ORIGIN);
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 

--- a/workers/llm-proxy/wrangler.toml
+++ b/workers/llm-proxy/wrangler.toml
@@ -2,10 +2,12 @@ name = "megane-llm-proxy"
 main = "src/index.ts"
 compatibility_date = "2025-01-01"
 
-# Origin allowed to call this proxy. CORS and the explicit Origin check
-# in src/index.ts both key off this value.
+# Origins allowed to call this proxy (comma-separated). CORS and the
+# explicit Origin check in src/index.ts both key off this list. The first
+# entry is the GitHub Pages docs demo; the second is the custom-domain S3
+# demo site.
 [vars]
-ALLOWED_ORIGIN = "https://hodakamori.github.io"
+ALLOWED_ORIGIN = "https://hodakamori.github.io,https://megane.tech-office-mori.com"
 
 # OpenRouter model slug. Set to Anthropic Claude Sonnet 4.6 (latest) for
 # strong instruction-following and pipeline generation quality.


### PR DESCRIPTION
## Problem

The custom-domain demo site (`https://megane.tech-office-mori.com`, S3 + CloudFront) loaded the molecular viewer fine, but sending a chat prompt returned **"Please set your API key in the config panel."** — the app fell back to BYOK instead of using the shared demo proxy.

Two independent gaps caused this:

1. **The S3 build was made without `VITE_LLM_PROXY_URL`.** `isDemoProviderAvailable()` (`src/ai/config.ts`) keys off that build-time variable; without it the default flips to BYOK. Only the docs demo build (`docs.yml`) was injecting it.
2. **The LLM proxy Worker only allowed a single origin.** `ALLOWED_ORIGIN` was matched exactly (`origin === env.ALLOWED_ORIGIN`) and only listed `https://hodakamori.github.io`, so requests from the custom domain would be rejected with a 403 even after fix #1.

## Changes

- **`workers/llm-proxy`**: parse `ALLOWED_ORIGIN` as a comma-separated list (`parseAllowedOrigins`), accept any listed origin, and echo the *matching* origin back in the CORS and `HTTP-Referer` headers. `wrangler.toml` now lists both the GitHub Pages docs demo and the custom-domain site. New unit tests cover the multi-origin behavior (56 tests pass, `tsc --noEmit` clean).
- **`.github/workflows/deploy.yml`**: inject `VITE_LLM_PROXY_URL: ${{ vars.LLM_PROXY_URL }}` into the `npm run build:app` step, reusing the same repo variable the docs demo build already uses, so the free demo provider is enabled on the S3 site automatically on every deploy.

## Automation

Merging to `main` triggers both existing workflows automatically:

- `deploy-llm-proxy.yml` (touched `workers/llm-proxy/**`) → redeploys the Worker with the multi-origin `ALLOWED_ORIGIN`.
- `deploy.yml` → rebuilds the app with the proxy URL, syncs to S3, and invalidates CloudFront.

## Prerequisite to verify

The repo variable **`LLM_PROXY_URL`** (Settings → Secrets and variables → Actions → Variables) must point at the Worker URL. The docs demo build already relies on it, so it is likely already set; if empty, the S3 build will again lack the proxy URL.

## Note

The fix is unmeasured by E2E (the chat demo proxy path is local/CI-deploy only). Worker logic is covered by the unit tests in `workers/llm-proxy/test/index.test.ts`.

https://claude.ai/code/session_01DwArTVDBeJq75oMLY7vfwZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwArTVDBeJq75oMLY7vfwZ)_