### PR TITLE
feat(ai-chat): switch demo to Haiku, cap free demo at 5/day, fix streaming flicker

### DIFF
--- a/src/ai/client.ts
+++ b/src/ai/client.ts
@@ -16,6 +16,21 @@ import {
   type OpenAITool,
 } from "./skillLoader";
 
+/**
+ * Thrown when the backend rejects the request with HTTP 429 — i.e. the
+ * shared free-demo proxy's per-IP rate limit (5 requests/day, 3/minute) was
+ * exceeded. Carries a user-facing message so the chat surfaces the real
+ * reason instead of a generic "something went wrong".
+ */
+export class RateLimitError extends Error {
+  constructor(
+    message = "Daily free-demo limit reached (5 requests/day). Try again tomorrow, or add your own API key in settings.",
+  ) {
+    super(message);
+    this.name = "RateLimitError";
+  }
+}
+
 // ─── Types for Anthropic SSE parsing ─────────────────────────────────
 
 interface ToolUseAccumulator {
@@ -118,6 +133,7 @@ async function streamAnthropicWithSkills(
 
     if (!response.ok) {
       await response.text(); // consume body so the connection is released
+      if (response.status === 429) throw new RateLimitError();
       throw new Error("Request failed. Please try again.");
     }
 
@@ -296,6 +312,7 @@ async function streamOpenAICompatWithSkills(
     const response = await send(body, signal);
     if (!response.ok) {
       await response.text(); // consume body so the connection is released
+      if (response.status === 429) throw new RateLimitError();
       throw new Error("Request failed. Please try again.");
     }
 
@@ -502,6 +519,29 @@ export function stripPipelineJSON(text: string): string {
     return "";
   }
   return text.trim();
+}
+
+/**
+ * Return only the natural-language explanation that follows the *last* closed
+ * ```` ```json ```` fence, or an empty string when no fence has closed yet.
+ *
+ * Unlike {@link stripPipelineJSON}, this deliberately ignores any prose that
+ * appears *before* the fence — during a skill tool round trip the model often
+ * streams a short preamble before emitting the JSON, and surfacing it would
+ * make the chat flicker (preamble shown, then reverting to a placeholder once
+ * the JSON starts streaming). The system prompt puts the JSON first and the
+ * one-sentence explanation immediately after it, so the trailing text is the
+ * only thing worth showing. Because that text only ever grows as it streams,
+ * the displayed reply is monotonic — it never jumps back to "Generating…".
+ */
+export function extractTrailingExplanation(text: string): string {
+  const lastFenceEnd = text.lastIndexOf("```");
+  if (lastFenceEnd === -1) return "";
+  // A single ``` means a fence has opened but not closed yet — still streaming
+  // the JSON, so there is no trailing explanation to show.
+  const fenceCount = (text.match(/```/g) ?? []).length;
+  if (fenceCount % 2 !== 0) return "";
+  return text.slice(lastFenceEnd + 3).trim();
 }
 
 // ─── JSON extraction ─────────────────────────────────────────────────

--- a/src/components/PipelineChatBox.tsx
+++ b/src/components/PipelineChatBox.tsx
@@ -12,7 +12,8 @@ import {
   extractPipelineJSON,
   tryExtractPipeline,
   formatActionSummary,
-  stripPipelineJSON,
+  extractTrailingExplanation,
+  RateLimitError,
 } from "../ai/client";
 import { usePipelineStore } from "../pipeline/store";
 import type { NodeSnapshotData } from "../pipeline/execute";
@@ -366,10 +367,10 @@ export function PipelineChatBox({ onPipelineApplied }: { onPipelineApplied?: () 
         applyPipeline(extractPipelineJSON(fullResponse));
       }
 
-      // Show the assistant's own explanation (everything except the JSON
-      // payload); fall back to a generic summary if the model returned only
-      // JSON with no prose.
-      const explanation = stripPipelineJSON(fullResponse);
+      // Show the assistant's own explanation (the sentence that follows the
+      // JSON payload); fall back to a generic summary if the model returned
+      // only JSON with no prose.
+      const explanation = extractTrailingExplanation(fullResponse);
       setMessages((prev) =>
         replaceTrailingAssistant(prev, {
           role: "assistant",
@@ -377,10 +378,14 @@ export function PipelineChatBox({ onPipelineApplied }: { onPipelineApplied?: () 
         }),
       );
     } catch (e: unknown) {
-      const content =
-        (e as Error).name === "AbortError"
-          ? "Generation cancelled."
-          : "Something went wrong. Please try again.";
+      let content: string;
+      if (e instanceof RateLimitError) {
+        content = e.message;
+      } else if ((e as Error).name === "AbortError") {
+        content = "Generation cancelled.";
+      } else {
+        content = "Something went wrong. Please try again.";
+      }
       setMessages((prev) => replaceTrailingAssistant(prev, { role: "error", content }));
     } finally {
       setIsStreaming(false);
@@ -511,10 +516,12 @@ export function PipelineChatBox({ onPipelineApplied }: { onPipelineApplied?: () 
                 </div>
               );
             }
-            // Show the assistant's prose, stripping the JSON payload. While the
-            // explanation is still streaming in (or the model emitted only
-            // JSON), fall back to a neutral status.
-            const prose = stripPipelineJSON(msg.content);
+            // Show the assistant's prose — only the sentence that follows the
+            // JSON payload. While the JSON is still streaming (or the model
+            // emitted only JSON), this is empty and we fall back to a neutral
+            // status. Ignoring any preamble before the JSON keeps the reply
+            // monotonic so it never flickers back to "Generating…".
+            const prose = extractTrailingExplanation(msg.content);
             return (
               <div key={i} style={assistantMsgStyle}>
                 {prose || "Generating…"}

--- a/tests/ts/ai/client.test.ts
+++ b/tests/ts/ai/client.test.ts
@@ -15,6 +15,8 @@ import {
   generatePipeline,
   formatActionSummary,
   stripPipelineJSON,
+  extractTrailingExplanation,
+  RateLimitError,
 } from "@/ai/client";
 import type { AIConfig } from "@/ai/config";
 
@@ -212,9 +214,16 @@ describe("generatePipeline (Anthropic)", () => {
   });
 
   it("throws a generic error when the API returns a non-OK status", async () => {
-    fetchMock.mockResolvedValueOnce(makeJSONResponse("rate limited", 429));
+    fetchMock.mockResolvedValueOnce(makeJSONResponse("server error", 500));
     await expect(generatePipeline(ANTHROPIC_CONFIG, "msg", () => {})).rejects.toThrow(
       /Request failed/,
+    );
+  });
+
+  it("throws a RateLimitError when the API returns 429", async () => {
+    fetchMock.mockResolvedValueOnce(makeJSONResponse("rate limited", 429));
+    await expect(generatePipeline(ANTHROPIC_CONFIG, "msg", () => {})).rejects.toBeInstanceOf(
+      RateLimitError,
     );
   });
 });
@@ -487,9 +496,18 @@ describe("generatePipeline (demo proxy)", () => {
 
   it("throws a generic error when the proxy returns a non-OK status", async () => {
     vi.stubEnv("VITE_LLM_PROXY_URL", "https://proxy.example.com/chat");
-    fetchMock.mockResolvedValueOnce(makeJSONResponse("rate limit exceeded", 429));
+    fetchMock.mockResolvedValueOnce(makeJSONResponse("server error", 500));
 
     await expect(generatePipeline(DEMO_CONFIG, "msg", () => {})).rejects.toThrow(/Request failed/);
+  });
+
+  it("throws a RateLimitError when the proxy returns 429 (daily limit hit)", async () => {
+    vi.stubEnv("VITE_LLM_PROXY_URL", "https://proxy.example.com/chat");
+    fetchMock.mockResolvedValueOnce(makeJSONResponse("rate limit exceeded", 429));
+
+    await expect(generatePipeline(DEMO_CONFIG, "msg", () => {})).rejects.toBeInstanceOf(
+      RateLimitError,
+    );
   });
 });
 
@@ -534,6 +552,36 @@ describe("stripPipelineJSON", () => {
 
   it("returns the whole trimmed text when there is no JSON", () => {
     expect(stripPipelineJSON("  just a sentence.  ")).toBe("just a sentence.");
+  });
+});
+
+describe("extractTrailingExplanation", () => {
+  it("returns the sentence after a closed fenced json block", () => {
+    expect(
+      extractTrailingExplanation(
+        '```json\n{ "version": 3 }\n```\n\nLoads benzene and shows bonds.',
+      ),
+    ).toBe("Loads benzene and shows bonds.");
+  });
+
+  it("ignores a preamble that precedes the json (no flicker from tool round trips)", () => {
+    expect(
+      extractTrailingExplanation(
+        'Let me fetch the molecule template.\n```json\n{ "version": 3 }\n```\nDone — shows the molecule.',
+      ),
+    ).toBe("Done — shows the molecule.");
+  });
+
+  it("returns an empty string while the JSON is still streaming (unclosed fence)", () => {
+    expect(extractTrailingExplanation('```json\n{ "version": 3, "nodes": [')).toBe("");
+  });
+
+  it("returns an empty string when the response is only a closed fenced block", () => {
+    expect(extractTrailingExplanation('```json\n{ "version": 3 }\n```')).toBe("");
+  });
+
+  it("returns an empty string when no fence is present yet", () => {
+    expect(extractTrailingExplanation("Let me think about this request")).toBe("");
   });
 });
 

--- a/tests/ts/components/PipelineChatBox.test.tsx
+++ b/tests/ts/components/PipelineChatBox.test.tsx
@@ -25,11 +25,20 @@ vi.mock("@/ai/client", () => ({
       : null,
   formatActionSummary: (n: number) =>
     `Pipeline applied — ${n} ${n === 1 ? "node" : "nodes"} added to the editor.`,
-  stripPipelineJSON: (text: string) => {
-    const withoutFence = text.replace(/```(?:json)?\s*\n?[\s\S]*?```/g, "").trim();
-    if (withoutFence !== text.trim()) return withoutFence;
-    if (text.includes("```") || text.includes("{")) return "";
-    return text.trim();
+  // Mirrors the real helper: only the text after the *last* closed fence,
+  // ignoring any preamble before the JSON.
+  extractTrailingExplanation: (text: string) => {
+    const lastFenceEnd = text.lastIndexOf("```");
+    if (lastFenceEnd === -1) return "";
+    const fenceCount = (text.match(/```/g) ?? []).length;
+    if (fenceCount % 2 !== 0) return "";
+    return text.slice(lastFenceEnd + 3).trim();
+  },
+  RateLimitError: class RateLimitError extends Error {
+    constructor(message = "Daily free-demo limit reached (5 requests/day).") {
+      super(message);
+      this.name = "RateLimitError";
+    }
   },
 }));
 vi.mock("@/pipeline/store", () => {
@@ -48,7 +57,7 @@ import {
   replaceTrailingAssistant,
 } from "@/components/PipelineChatBox";
 import { useAIConfigStore } from "@/ai/config";
-import { generatePipeline, extractPipelineJSON } from "@/ai/client";
+import { generatePipeline, extractPipelineJSON, RateLimitError } from "@/ai/client";
 
 function openConfigPanel() {
   fireEvent.click(screen.getByTitle("AI Settings"));
@@ -322,12 +331,12 @@ describe("PipelineChatBox — applying a generated pipeline", () => {
     expect(storeState.deserialize).toHaveBeenCalledTimes(1);
   });
 
-  it("shows the assistant's prose explanation, stripping the JSON payload", async () => {
+  it("shows the assistant's trailing prose explanation, stripping the JSON payload", async () => {
     (generatePipeline as ReturnType<typeof vi.fn>).mockImplementation(
       async (_config, _msg, onChunk: (c: string) => void) => {
-        onChunk("Loads benzene and shows it with bonds.\n");
-        onChunk('```json\n{ "version": 3, "nodes": [] }\n```');
-        return 'Loads benzene and shows it with bonds.\n```json\n{ "version": 3, "nodes": [] }\n```';
+        onChunk('```json\n{ "version": 3, "nodes": [] }\n```\n');
+        onChunk("Loads benzene and shows it with bonds.");
+        return '```json\n{ "version": 3, "nodes": [] }\n```\nLoads benzene and shows it with bonds.';
       },
     );
     render(<PipelineChatBox />);
@@ -337,6 +346,28 @@ describe("PipelineChatBox — applying a generated pipeline", () => {
     // Neither the JSON nor the generic summary should appear when prose exists.
     expect(screen.queryByText(/"version": 3/)).toBeNull();
     expect(screen.queryByText(/Pipeline applied/)).toBeNull();
+  });
+
+  it("ignores a preamble before the JSON so the reply never flickers back to a placeholder", async () => {
+    // A skill tool round trip can stream a short preamble before the JSON.
+    // The component must never surface it (showing it then reverting to
+    // "Generating…" once the JSON streams is the flicker we are fixing).
+    (generatePipeline as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_config, _msg, onChunk: (c: string) => void) => {
+        onChunk("Let me fetch the molecule template.");
+        onChunk('\n```json\n{ "version": 3, "nodes": [] }\n```');
+        return 'Let me fetch the molecule template.\n```json\n{ "version": 3, "nodes": [] }\n```';
+      },
+    );
+    render(<PipelineChatBox />);
+    submit("show a molecule");
+
+    // With no trailing prose, it settles on the concise action summary — and
+    // the preamble is never shown at any point.
+    expect(
+      await screen.findByText(/Pipeline applied — 2 nodes added to the editor\./),
+    ).toBeTruthy();
+    expect(screen.queryByText(/fetch the molecule template/)).toBeNull();
   });
 
   it("re-applies the previously loaded structure to the new load_structure node", async () => {
@@ -379,5 +410,16 @@ describe("PipelineChatBox — applying a generated pipeline", () => {
     expect(await screen.findByText("Something went wrong. Please try again.")).toBeTruthy();
     // The underlying error detail must never leak into the transcript.
     expect(screen.queryByText(/429/)).toBeNull();
+  });
+
+  it("surfaces the daily-limit message verbatim when the free demo is rate limited", async () => {
+    (generatePipeline as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new RateLimitError("Daily free-demo limit reached (5 requests/day)."),
+    );
+    render(<PipelineChatBox />);
+    submit("build me a pipeline");
+
+    expect(await screen.findByText("Daily free-demo limit reached (5 requests/day).")).toBeTruthy();
+    expect(screen.queryByText("Something went wrong. Please try again.")).toBeNull();
   });
 });

--- a/workers/llm-proxy/src/proxy.ts
+++ b/workers/llm-proxy/src/proxy.ts
@@ -96,7 +96,7 @@ export const MAX_TOOL_NAME_LENGTH = 64;
 export const MAX_TOOL_DESCRIPTION_LENGTH = 1024;
 export const MAX_TOOL_CALL_ID_LENGTH = 256;
 export const PER_MINUTE_LIMIT = 3;
-export const PER_DAY_LIMIT = 20;
+export const PER_DAY_LIMIT = 5;
 
 const MINUTE_TTL_SECONDS = 90;
 const DAY_TTL_SECONDS = 2 * 24 * 60 * 60;

--- a/workers/llm-proxy/test/index.test.ts
+++ b/workers/llm-proxy/test/index.test.ts
@@ -188,9 +188,7 @@ describe("sanitizeMessages", () => {
 
   it("accepts a tool message with a tool_call_id and large content", () => {
     const out = sanitizeMessages({
-      messages: [
-        { role: "tool", content: "x".repeat(13000), tool_call_id: "call_1" },
-      ],
+      messages: [{ role: "tool", content: "x".repeat(13000), tool_call_id: "call_1" }],
     });
     expect(out).not.toBeNull();
     expect(out?.[0].tool_call_id).toBe("call_1");
@@ -211,9 +209,7 @@ describe("sanitizeMessages", () => {
           {
             role: "user",
             content: "hi",
-            tool_calls: [
-              { id: "c1", type: "function", function: { name: "x", arguments: "{}" } },
-            ],
+            tool_calls: [{ id: "c1", type: "function", function: { name: "x", arguments: "{}" } }],
           },
         ],
       }),
@@ -238,10 +234,18 @@ describe("sanitizeMessages", () => {
         messages: [{ role: "assistant", content: null, tool_calls: toolCalls }],
       });
     expect(wrap([])).toBeNull(); // empty
-    expect(wrap([{ id: "c1", type: "not_function", function: { name: "x", arguments: "{}" } }])).toBeNull();
-    expect(wrap([{ id: "", type: "function", function: { name: "x", arguments: "{}" } }])).toBeNull();
-    expect(wrap([{ id: "c1", type: "function", function: { name: "", arguments: "{}" } }])).toBeNull();
-    expect(wrap([{ id: "c1", type: "function", function: { name: "x", arguments: 5 } }])).toBeNull();
+    expect(
+      wrap([{ id: "c1", type: "not_function", function: { name: "x", arguments: "{}" } }]),
+    ).toBeNull();
+    expect(
+      wrap([{ id: "", type: "function", function: { name: "x", arguments: "{}" } }]),
+    ).toBeNull();
+    expect(
+      wrap([{ id: "c1", type: "function", function: { name: "", arguments: "{}" } }]),
+    ).toBeNull();
+    expect(
+      wrap([{ id: "c1", type: "function", function: { name: "x", arguments: 5 } }]),
+    ).toBeNull();
     expect(wrap([{ id: "c1", type: "function" }])).toBeNull();
   });
 });
@@ -249,7 +253,11 @@ describe("sanitizeMessages", () => {
 describe("sanitizeTools", () => {
   const validTool = {
     type: "function",
-    function: { name: "get_molecule_template", description: "desc", parameters: { type: "object", properties: {} } },
+    function: {
+      name: "get_molecule_template",
+      description: "desc",
+      parameters: { type: "object", properties: {} },
+    },
   };
 
   it("returns undefined when no tools key is present", () => {
@@ -278,7 +286,9 @@ describe("sanitizeTools", () => {
   it("returns null for malformed tool entries", () => {
     expect(sanitizeTools({ tools: "not-an-array" })).toBeNull();
     expect(sanitizeTools({ tools: [null] })).toBeNull();
-    expect(sanitizeTools({ tools: [{ type: "not_function", function: { name: "x" } }] })).toBeNull();
+    expect(
+      sanitizeTools({ tools: [{ type: "not_function", function: { name: "x" } }] }),
+    ).toBeNull();
     expect(sanitizeTools({ tools: [{ type: "function", function: null }] })).toBeNull();
     expect(sanitizeTools({ tools: [{ type: "function", function: { name: "" } }] })).toBeNull();
     expect(
@@ -314,6 +324,18 @@ describe("isRateLimited", () => {
       await isRateLimited("1.2.3.4", env);
     }
     expect(await isRateLimited("5.6.7.8", env)).toBe(false);
+  });
+
+  it("caps the free demo at 5 requests per day", () => {
+    expect(PER_DAY_LIMIT).toBe(5);
+  });
+
+  it("allows a request while still under the per-day limit", async () => {
+    const env = makeEnv();
+    const kv = env.RATE_LIMIT_KV as unknown as FakeKV;
+    const dayKey = `rl:d:9.9.9.9:${Math.floor(Date.now() / 86_400_000)}`;
+    await kv.put(dayKey, String(PER_DAY_LIMIT - 1), {});
+    expect(await isRateLimited("9.9.9.9", env)).toBe(false);
   });
 
   it("blocks once the per-day limit is reached even under the per-minute limit", async () => {
@@ -478,7 +500,10 @@ describe("worker fetch handler", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const res = await worker.fetch(
-      makeRequest({ origin: ALLOWED_ORIGIN, body: { messages: [{ role: "user", content: "hi" }] } }),
+      makeRequest({
+        origin: ALLOWED_ORIGIN,
+        body: { messages: [{ role: "user", content: "hi" }] },
+      }),
       env,
     );
 
@@ -559,7 +584,10 @@ describe("worker fetch handler", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const res = await worker.fetch(
-      makeRequest({ origin: ALLOWED_ORIGIN, body: { messages: [{ role: "user", content: "hi" }] } }),
+      makeRequest({
+        origin: ALLOWED_ORIGIN,
+        body: { messages: [{ role: "user", content: "hi" }] },
+      }),
       env,
     );
 
@@ -581,7 +609,10 @@ describe("worker fetch handler", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const res = await worker.fetch(
-      makeRequest({ origin: ALLOWED_ORIGIN, body: { messages: [{ role: "user", content: "hi" }] } }),
+      makeRequest({
+        origin: ALLOWED_ORIGIN,
+        body: { messages: [{ role: "user", content: "hi" }] },
+      }),
       env,
     );
 
@@ -597,7 +628,10 @@ describe("worker fetch handler", () => {
     );
 
     const res = await worker.fetch(
-      makeRequest({ origin: ALLOWED_ORIGIN, body: { messages: [{ role: "user", content: "hi" }] } }),
+      makeRequest({
+        origin: ALLOWED_ORIGIN,
+        body: { messages: [{ role: "user", content: "hi" }] },
+      }),
       env,
     );
 

--- a/workers/llm-proxy/wrangler.toml
+++ b/workers/llm-proxy/wrangler.toml
@@ -9,19 +9,18 @@ compatibility_date = "2025-01-01"
 [vars]
 ALLOWED_ORIGIN = "https://hodakamori.github.io,https://megane.tech-office-mori.com"
 
-# OpenRouter model slug. Set to Anthropic Claude Sonnet 4.6 (latest) for
-# strong instruction-following and pipeline generation quality.
-# To downgrade to claude-3.5-haiku (~0.5c) or a free model, just change
-# this value — no code change needed. Leave unset to use the default in
+# OpenRouter model slug. Set to Anthropic Claude Haiku 3.5 — cheap and fast
+# while still following the pipeline-generation instructions well. To go
+# back to a stronger Sonnet model or down to a free model, just change this
+# value — no code change needed. Leave unset to use the default in
 # src/proxy.ts.
-OPENROUTER_MODEL = "anthropic/claude-sonnet-4-6"
+OPENROUTER_MODEL = "anthropic/claude-3.5-haiku"
 
 # Comma-separated fallback models, used only if the primary errors. Falls
-# back to Haiku (cheap but reliable) then a free model as a last resort.
-# OpenRouter caps the total routing list at 3, so keep this to 2 entries
-# alongside the primary. Unset = the DEFAULT_FALLBACK_MODELS list in
-# src/proxy.ts.
-OPENROUTER_FALLBACK_MODELS = "anthropic/claude-3.5-haiku,meta-llama/llama-3.3-70b-instruct:free"
+# back to a free model as a last resort. OpenRouter caps the total routing
+# list at 3, so keep this to at most 2 entries alongside the primary.
+# Unset = the DEFAULT_FALLBACK_MODELS list in src/proxy.ts.
+OPENROUTER_FALLBACK_MODELS = "meta-llama/llama-3.3-70b-instruct:free"
 
 # Created via `wrangler kv namespace create RATE_LIMIT_KV`. The id is not a
 # secret, so it is committed here directly.


### PR DESCRIPTION
- wrangler.toml: set the demo proxy model to anthropic/claude-3.5-haiku
  (cheaper and faster than Sonnet) and trim the fallback list to a free model
- proxy.ts: lower PER_DAY_LIMIT from 20 to 5 requests per IP per day
- client.ts: throw a typed RateLimitError on HTTP 429 so the chat surfaces
  the real daily-limit reason instead of a generic failure message
- client.ts: add extractTrailingExplanation() that returns only the prose
  after the last closed JSON fence, and use it for both the live and final
  chat bubbles. This ignores any tool-round-trip preamble and keeps the reply
  monotonic, eliminating the flicker where text appeared then reverted to
  "Generating…"
- tests: cover the new helper, RateLimitError propagation (demo + Anthropic),
  the no-flicker behaviour, the surfaced daily-limit message, and the 5/day cap