### PR TITLE
Add scripted zoom demo video tool (Playwright)

### DIFF
--- a/.claude/skills/preview/SKILL.md
+++ b/.claude/skills/preview/SKILL.md
@@ -65,9 +65,10 @@ npm run demo:video -- --url https://<demo-site>/megane/app/
 - **Director (engine):** `scripts/demo-video.mjs` — starts Vite, records a webm
   via Playwright `recordVideo`, and zooms by tweening a CSS `transform` on
   `#root`. Verbs: `askChat` (type + submit), `waitGenerate` (dwell on the chat
-  messages while the reply streams), `rotate`, `showAndScrollPipeline`
-  (Editor-tab fitView shows the whole pipeline, then a linear top→bottom scroll —
-  tune via `config.pipelineScrollScale` / `pipelineScrollMs`).
+  messages while the reply streams), `rotate`, `clickPipelineTabAndScroll`
+  (zoom the Editor tab, click it on camera to switch Chat→pipeline, then a linear
+  top→bottom scroll at ~70% width — tune via `config.pipelineWidthFraction` /
+  `pipelineScrollMs`).
 - **Zoom control:** scene `zoom` is `"full"`, `"keep"`, or
   `{ sel, scale?, pad?, anchorX?, anchorY? }`. Use `scale` for full-height targets
   like the side panel (fit-to-bbox there is ~1×); `anchorY` (0..1) biases the

--- a/.claude/skills/preview/SKILL.md
+++ b/.claude/skills/preview/SKILL.md
@@ -61,9 +61,13 @@ npm run demo:video -- --no-generate                  # force skip the AI call
   touch the engine.
 - **Director (engine):** `scripts/demo-video.mjs` — starts Vite, records a webm
   via Playwright `recordVideo`, and zooms by tweening a CSS `transform` on
-  `#root`. Verbs: `openChatAndType`, `generate`, `rotate`, `showPipeline`.
+  `#root`. Verbs: `openChatAndType`, `generate`, `rotate`, `showAndScrollPipeline`
+  (Editor-tab fitView shows the whole pipeline, then a linear top→bottom scroll —
+  tune via `config.pipelineScrollScale` / `pipelineScrollMs`).
 - **Zoom control:** scene `zoom` is `"full"`, `"keep"`, or `{ sel, scale?, pad? }`.
   Use `scale` for full-height targets like the side panel (fit-to-bbox there is ~1×).
+  Per-scene `transitionMs` overrides the tween speed (used to make the move to the
+  Chat panel slow and legible).
 - **Output:** `demo/out/megane-demo-<timestamp>.webm` (gitignored).
 - **Options:** `--out <path>`, `--prompt "<text>"`, `--width/--height`, `--dpr`,
   `--no-generate`, `--clean`.

--- a/.claude/skills/preview/SKILL.md
+++ b/.claude/skills/preview/SKILL.md
@@ -45,10 +45,14 @@ This script does NOT require WASM (uses pre-parsed JSON data).
 
 ## Scripted Zoom Demo Video (storyboard-as-code)
 
-Produces a single continuous webm that walks the live app through a scripted
-flow while zooming into UI regions:
-**full screen → zoom Chat panel + type a prompt → (live AI generate) → rotate
-the molecule → zoom the pipeline graph.**
+Produces a single continuous **full-frame** webm that walks the live app through
+a scripted flow: **show the app → type a prompt → (live AI generate) → rotate the
+molecule → switch to the Editor tab to reveal the generated pipeline.** It is
+recorded un-zoomed on purpose (zoom/pan/crop in post): a #root CSS zoom while the
+pipeline mounts makes ReactFlow mis-measure node handles and the pipeline edges
+detach from the nodes, so the recorder stays at the full view to keep them
+attached. (The director still supports zoom verbs/`alignTop`/scroll for other
+storyboards, but the default storyboard does not use them.)
 
 ```
 npm run demo:video                                   # no key → prompt typed, generate skipped
@@ -64,17 +68,13 @@ npm run demo:video -- --url https://<demo-site>/megane/app/
   touch the engine.
 - **Director (engine):** `scripts/demo-video.mjs` — starts Vite, records a webm
   via Playwright `recordVideo`, and zooms by tweening a CSS `transform` on
-  `#root`. Verbs: `typePrompt` (type only), `submitPrompt` (submit via Enter
-  after the camera settles; the scene's hold then dwells ~30s while the reply
-  streams), `rotate`, `clickPipelineTabAndScroll`
-  (zoom the Editor tab, click it on camera to switch Chat→pipeline, then a linear
-  top→bottom scroll at ~70% width — tune via `config.pipelineWidthFraction` /
-  `pipelineScrollMs`).
+  `#root`. Verbs: `typePrompt` (type only), `submitPrompt` (submit via Enter,
+  then the scene's hold dwells ~30s while the reply streams), `rotate`,
+  `showPipeline` (click the Editor tab to reveal the graph).
 - **Zoom control:** scene `zoom` is `"full"`, `"keep"`, or
-  `{ sel, scale?, pad?, anchorX?, anchorY? }`. Use `scale` for full-height targets
-  like the side panel (fit-to-bbox there is ~1×); `anchorY` (0..1) biases the
-  framing (e.g. 0.72 toward the lower, streaming part of the chat). Per-scene
-  `transitionMs` overrides the tween speed.
+  `{ sel, scale?, pad?, anchorX?, anchorY?, alignTop?, topMargin? }`. The default
+  storyboard uses `"full"` everywhere (full-frame recording); the zoom options
+  remain available for custom storyboards.
 - **Output:** `demo/out/megane-demo-<timestamp>.webm` (gitignored).
 - **Options:** `--out <path>`, `--prompt "<text>"`, `--width/--height`, `--dpr`,
   `--no-generate`, `--generate-timeout <ms>`, `--clean`.

--- a/.claude/skills/preview/SKILL.md
+++ b/.claude/skills/preview/SKILL.md
@@ -77,7 +77,16 @@ npm run demo:video -- --url https://<demo-site>/megane/app/
   `transitionMs` overrides the tween speed.
 - **Output:** `demo/out/megane-demo-<timestamp>.webm` (gitignored).
 - **Options:** `--out <path>`, `--prompt "<text>"`, `--width/--height`, `--dpr`,
-  `--no-generate`, `--clean`.
+  `--no-generate`, `--generate-timeout <ms>`, `--clean`.
+- **Run locally:** the script resolves Playwright via the shared
+  `tests/e2e/utils/playwright.mjs` helper (prefers the project's own
+  `node_modules`), so on a local checkout you only need `npm ci` plus
+  `npx playwright install chromium` for the browser. The easiest path is to
+  record the live demo site (no WASM build, no API key):
+  `npm run demo:video -- --url https://megane.tech-office-mori.com/`.
+  To record a local build instead, omit `--url` (it builds WASM and starts Vite);
+  live generation there needs `ANTHROPIC_API_KEY` since the local build has no
+  LLM proxy.
 - **Notes:** `deviceScaleFactor: 2` keeps CSS-zoomed pixels reasonably crisp.
   The pipeline panel defaults to the **Chat** tab, so `.react-flow` mounts
   hidden until the Editor tab is selected (the `pipeline` scene handles this via

--- a/.claude/skills/preview/SKILL.md
+++ b/.claude/skills/preview/SKILL.md
@@ -52,8 +52,11 @@ the molecule → zoom the pipeline graph.**
 
 ```
 npm run demo:video                                   # no key → prompt typed, generate skipped
-ANTHROPIC_API_KEY=sk-ant-... npm run demo:video      # live AI generation
+ANTHROPIC_API_KEY=sk-ant-... npm run demo:video      # live AI generation (local BYOK)
 npm run demo:video -- --no-generate                  # force skip the AI call
+
+# Record the deployed demo site (its built-in LLM proxy runs generation, no key):
+npm run demo:video -- --url https://<demo-site>/megane/app/
 ```
 
 - **Storyboard ("台本"):** `scripts/demo-script.mjs` — a declarative `scenes`
@@ -61,13 +64,15 @@ npm run demo:video -- --no-generate                  # force skip the AI call
   touch the engine.
 - **Director (engine):** `scripts/demo-video.mjs` — starts Vite, records a webm
   via Playwright `recordVideo`, and zooms by tweening a CSS `transform` on
-  `#root`. Verbs: `openChatAndType`, `generate`, `rotate`, `showAndScrollPipeline`
+  `#root`. Verbs: `askChat` (type + submit), `waitGenerate` (dwell on the chat
+  messages while the reply streams), `rotate`, `showAndScrollPipeline`
   (Editor-tab fitView shows the whole pipeline, then a linear top→bottom scroll —
   tune via `config.pipelineScrollScale` / `pipelineScrollMs`).
-- **Zoom control:** scene `zoom` is `"full"`, `"keep"`, or `{ sel, scale?, pad? }`.
-  Use `scale` for full-height targets like the side panel (fit-to-bbox there is ~1×).
-  Per-scene `transitionMs` overrides the tween speed (used to make the move to the
-  Chat panel slow and legible).
+- **Zoom control:** scene `zoom` is `"full"`, `"keep"`, or
+  `{ sel, scale?, pad?, anchorX?, anchorY? }`. Use `scale` for full-height targets
+  like the side panel (fit-to-bbox there is ~1×); `anchorY` (0..1) biases the
+  framing (e.g. 0.72 toward the lower, streaming part of the chat). Per-scene
+  `transitionMs` overrides the tween speed.
 - **Output:** `demo/out/megane-demo-<timestamp>.webm` (gitignored).
 - **Options:** `--out <path>`, `--prompt "<text>"`, `--width/--height`, `--dpr`,
   `--no-generate`, `--clean`.

--- a/.claude/skills/preview/SKILL.md
+++ b/.claude/skills/preview/SKILL.md
@@ -64,9 +64,9 @@ npm run demo:video -- --url https://<demo-site>/megane/app/
   touch the engine.
 - **Director (engine):** `scripts/demo-video.mjs` — starts Vite, records a webm
   via Playwright `recordVideo`, and zooms by tweening a CSS `transform` on
-  `#root`. Verbs: `typePrompt` (type only), `submitAndWait` (submit via Enter
-  after the camera settles, then dwell fixed while the reply streams), `rotate`,
-  `clickPipelineTabAndScroll`
+  `#root`. Verbs: `typePrompt` (type only), `submitPrompt` (submit via Enter
+  after the camera settles; the scene's hold then dwells ~30s while the reply
+  streams), `rotate`, `clickPipelineTabAndScroll`
   (zoom the Editor tab, click it on camera to switch Chat→pipeline, then a linear
   top→bottom scroll at ~70% width — tune via `config.pipelineWidthFraction` /
   `pipelineScrollMs`).

--- a/.claude/skills/preview/SKILL.md
+++ b/.claude/skills/preview/SKILL.md
@@ -64,8 +64,9 @@ npm run demo:video -- --url https://<demo-site>/megane/app/
   touch the engine.
 - **Director (engine):** `scripts/demo-video.mjs` — starts Vite, records a webm
   via Playwright `recordVideo`, and zooms by tweening a CSS `transform` on
-  `#root`. Verbs: `askChat` (type + submit), `waitGenerate` (dwell on the chat
-  messages while the reply streams), `rotate`, `clickPipelineTabAndScroll`
+  `#root`. Verbs: `typePrompt` (type only), `submitAndWait` (submit via Enter
+  after the camera settles, then dwell fixed while the reply streams), `rotate`,
+  `clickPipelineTabAndScroll`
   (zoom the Editor tab, click it on camera to switch Chat→pipeline, then a linear
   top→bottom scroll at ~70% width — tune via `config.pipelineWidthFraction` /
   `pipelineScrollMs`).

--- a/.claude/skills/preview/SKILL.md
+++ b/.claude/skills/preview/SKILL.md
@@ -43,6 +43,36 @@ Captures a high-quality 1280x720 DPR=2 screenshot of caffeine_water molecule.
 Output: `docs/public/screenshots/hero.png`.
 This script does NOT require WASM (uses pre-parsed JSON data).
 
+## Scripted Zoom Demo Video (storyboard-as-code)
+
+Produces a single continuous webm that walks the live app through a scripted
+flow while zooming into UI regions:
+**full screen → zoom Chat panel + type a prompt → (live AI generate) → rotate
+the molecule → zoom the pipeline graph.**
+
+```
+npm run demo:video                                   # no key → prompt typed, generate skipped
+ANTHROPIC_API_KEY=sk-ant-... npm run demo:video      # live AI generation
+npm run demo:video -- --no-generate                  # force skip the AI call
+```
+
+- **Storyboard ("台本"):** `scripts/demo-script.mjs` — a declarative `scenes`
+  array (id / zoom / action / hold). Edit it to change the demo; no need to
+  touch the engine.
+- **Director (engine):** `scripts/demo-video.mjs` — starts Vite, records a webm
+  via Playwright `recordVideo`, and zooms by tweening a CSS `transform` on
+  `#root`. Verbs: `openChatAndType`, `generate`, `rotate`, `showPipeline`.
+- **Zoom control:** scene `zoom` is `"full"`, `"keep"`, or `{ sel, scale?, pad? }`.
+  Use `scale` for full-height targets like the side panel (fit-to-bbox there is ~1×).
+- **Output:** `demo/out/megane-demo-<timestamp>.webm` (gitignored).
+- **Options:** `--out <path>`, `--prompt "<text>"`, `--width/--height`, `--dpr`,
+  `--no-generate`, `--clean`.
+- **Notes:** `deviceScaleFactor: 2` keeps CSS-zoomed pixels reasonably crisp.
+  The pipeline panel defaults to the **Chat** tab, so `.react-flow` mounts
+  hidden until the Editor tab is selected (the `pipeline` scene handles this via
+  `actionFirst`). Live generation needs `ANTHROPIC_API_KEY` + network; without
+  them the run still completes (prompt typed, generation skipped).
+
 ## Prerequisites
 
 - WASM must be built for dev-preview.mjs (it auto-builds if missing)

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ docs/docs/api/typescript/
 docs/notebooks/
 docs/public/notebooks/
 dev-preview/
+demo/
 coverage/
 .coverage
 lcov.info

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "build:lib": "npm run build:wasm && vite build --config vite.widget.config.ts --outDir dist && vite build --config vite.lib.config.ts",
     "build:lab": "cd jupyterlab-megane && npm install && npm run build",
     "preview": "vite preview",
+    "demo:video": "node scripts/demo-video.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",

--- a/scripts/demo-script.mjs
+++ b/scripts/demo-script.mjs
@@ -28,41 +28,56 @@ export const config = {
   width: 1920,
   height: 1080,
   dpr: 2, // render headroom so CSS-zoomed pixels stay crisp
-  transitionMs: 900, // zoom tween duration (CSS transition on #root)
+  transitionMs: 900, // default zoom tween duration (CSS transition on #root)
   // The prompt typed into the Chat tab. Keep it short so it reads on screen.
   prompt: "Show the protein as cartoon colored by chain",
+  // Pipeline scroll-through (TB layout): zoom level + linear scroll duration.
+  pipelineScrollScale: 1.6,
+  pipelineScrollMs: 4800,
 };
 
 export const scenes = [
   // 1. Whole app — let the viewer take in the full UI.
   { id: "overview", zoom: "full", hold: 2500 },
 
-  // 2. Zoom into the Chat input (centered on the prompt box) and type a prompt.
-  //    The panel is full-height, so use an explicit scale rather than fit.
+  // 2. Deliberately move the camera to the right-hand pipeline panel first, so
+  //    the next push-in reads as "we're going into the chat" rather than a jump.
+  {
+    id: "chat-approach",
+    zoom: { sel: '[data-testid="panel-pipeline"]', scale: 1.25 },
+    transitionMs: 1500,
+    hold: 700,
+  },
+
+  // 3. Push in on the Chat input (centered on the prompt box) and type a prompt.
   {
     id: "chat",
     zoom: { sel: 'textarea[placeholder="Describe the pipeline you want..."]', scale: 2.2 },
+    transitionMs: 1100,
     action: "openChatAndType",
     hold: 1200,
   },
 
-  // 3. Run the generation (live AI; output may vary). Stays zoomed on chat.
+  // 4. Run the generation (live AI; output may vary). Stays zoomed on chat.
   { id: "generate", zoom: "keep", action: "generate", hold: 4000 },
 
-  // 4. Zoom into the 3D viewport and slowly rotate the molecule.
+  // 5. Pull out and zoom into the 3D viewport, then slowly rotate the molecule.
   {
     id: "molecule",
     zoom: { sel: '[data-testid="viewer-root"]', scale: 1.5 },
+    transitionMs: 1300,
     action: "rotate",
     hold: 1500,
   },
 
-  // 5. Switch to the Editor tab first (unhides .react-flow), then zoom the graph.
+  // 6. Show the whole pipeline (Editor tab fitView), then scroll it top→bottom
+  //    so every node passes through in order. The verb drives its own zoom, so
+  //    the scene zoom is "keep".
   {
     id: "pipeline",
-    zoom: { sel: ".react-flow", scale: 1.7 },
-    action: "showPipeline",
+    zoom: "keep",
+    action: "showAndScrollPipeline",
     actionFirst: true,
-    hold: 3000,
+    hold: 1500,
   },
 ];

--- a/scripts/demo-script.mjs
+++ b/scripts/demo-script.mjs
@@ -1,0 +1,68 @@
+/**
+ * Demo video script ("台本") for the megane app.
+ *
+ * This file is the editable storyboard. Tweak `config` and the `scenes`
+ * array to change the demo — the director (`scripts/demo-video.mjs`)
+ * interprets it and drives the live app while recording a webm.
+ *
+ * Flow captured by the default scenes:
+ *   full screen → zoom the Chat panel + type a prompt → (live AI generate)
+ *   → show the 3D molecule (slow rotate) → show the pipeline graph.
+ *
+ * Scene fields:
+ *   id         unique label (also used for logging)
+ *   zoom       "full" (reset to whole screen) | "keep" (keep current zoom)
+ *              | { sel, pad?, scale? } — frame an element. With `scale` it zooms
+ *              by that fixed factor centered on the element (use for full-height
+ *              targets like the side panel, where fit-to-bbox would be ~1×);
+ *              without `scale` it fits the padded bbox to the viewport.
+ *   action     name of a director "verb" to run after the zoom settles
+ *              (one of: openChatAndType | generate | rotate | showPipeline),
+ *              or omit for a static hold
+ *   actionFirst  run the action before zooming (use when the action reveals
+ *                the zoom target, e.g. switching tabs to unhide .react-flow)
+ *   hold       ms to dwell after the action, showcasing the state
+ */
+
+export const config = {
+  width: 1920,
+  height: 1080,
+  dpr: 2, // render headroom so CSS-zoomed pixels stay crisp
+  transitionMs: 900, // zoom tween duration (CSS transition on #root)
+  // The prompt typed into the Chat tab. Keep it short so it reads on screen.
+  prompt: "Show the protein as cartoon colored by chain",
+};
+
+export const scenes = [
+  // 1. Whole app — let the viewer take in the full UI.
+  { id: "overview", zoom: "full", hold: 2500 },
+
+  // 2. Zoom into the Chat input (centered on the prompt box) and type a prompt.
+  //    The panel is full-height, so use an explicit scale rather than fit.
+  {
+    id: "chat",
+    zoom: { sel: 'textarea[placeholder="Describe the pipeline you want..."]', scale: 2.2 },
+    action: "openChatAndType",
+    hold: 1200,
+  },
+
+  // 3. Run the generation (live AI; output may vary). Stays zoomed on chat.
+  { id: "generate", zoom: "keep", action: "generate", hold: 4000 },
+
+  // 4. Zoom into the 3D viewport and slowly rotate the molecule.
+  {
+    id: "molecule",
+    zoom: { sel: '[data-testid="viewer-root"]', scale: 1.5 },
+    action: "rotate",
+    hold: 1500,
+  },
+
+  // 5. Switch to the Editor tab first (unhides .react-flow), then zoom the graph.
+  {
+    id: "pipeline",
+    zoom: { sel: ".react-flow", scale: 1.7 },
+    action: "showPipeline",
+    actionFirst: true,
+    hold: 3000,
+  },
+];

--- a/scripts/demo-script.mjs
+++ b/scripts/demo-script.mjs
@@ -57,13 +57,16 @@ export const scenes = [
     hold: 600,
   },
 
-  // 3. Settle on a FIXED frame with the Pipeline/Chat tab bar pinned to the top
-  //    of the screen, THEN submit, then dwell in place ~30s while the reply
-  //    streams in just below the tabs. The screen does not move and (with
-  //    scrollIntoView neutralised) the response stays put. Output may vary.
+  // 3. Pull back to the full view (identity) and submit, then dwell ~30s while
+  //    the reply streams in. This scene MUST stay unzoomed: the generated
+  //    pipeline mounts here, and ReactFlow measures node handle positions via
+  //    getBoundingClientRect — if a #root CSS zoom is active during that
+  //    measurement, the handle coords are scaled wrong and the pipeline edges
+  //    render detached from the nodes (and never re-measure). With identity the
+  //    handles are correct, so the later full-screen pipeline zoom stays clean.
   {
     id: "chat-generate",
-    zoom: { sel: '[data-testid="panel-pipeline"]', scale: 1.9, alignTop: true, topMargin: 24 },
+    zoom: "full",
     transitionMs: 1000,
     action: "submitPrompt",
     hold: config.chatResponseHoldMs, // ~30s fixed dwell

--- a/scripts/demo-script.mjs
+++ b/scripts/demo-script.mjs
@@ -32,9 +32,12 @@ export const config = {
   transitionMs: 900, // default zoom tween duration (CSS transition on #root)
   // The prompt typed into the Chat tab. Keep it short so it reads on screen.
   prompt: "Show the protein as cartoon colored by chain",
-  // Pipeline scroll-through (TB layout): zoom level + linear scroll duration.
+  // Pipeline scroll-through (TB layout). `pipelineWidthFraction` sizes the graph
+  // to a fraction of the screen width (0.7 ≈ 70%); it overrides the fixed
+  // `pipelineScrollScale` fallback. `pipelineScrollMs` is the linear scroll time.
+  pipelineWidthFraction: 0.7,
   pipelineScrollScale: 1.6,
-  pipelineScrollMs: 4800,
+  pipelineScrollMs: 5200,
 };
 
 export const scenes = [
@@ -50,13 +53,13 @@ export const scenes = [
     hold: 600,
   },
 
-  // 3. Move up to the chat messages area to watch the response generate
-  //    (anchored low so the streaming reply, which auto-scrolls down, stays in
-  //    frame). With a live LLM this records the real generation; without one it
-  //    just dwells on the typed prompt. Output may vary.
+  // 3. Move further up to the top of the chat messages, where a short
+  //    conversation (prompt + streaming reply) sits, so the generation is
+  //    actually visible. With a live LLM this records the real generation;
+  //    without one it just dwells on the typed prompt. Output may vary.
   {
     id: "chat-generate",
-    zoom: { sel: '[data-testid="pipeline-chat-messages"]', scale: 1.7, anchorY: 0.72 },
+    zoom: { sel: '[data-testid="pipeline-chat-messages"]', scale: 1.7, anchorY: 0.3 },
     transitionMs: 900,
     action: "waitGenerate",
     hold: 1500,

--- a/scripts/demo-script.mjs
+++ b/scripts/demo-script.mjs
@@ -32,6 +32,9 @@ export const config = {
   transitionMs: 900, // default zoom tween duration (CSS transition on #root)
   // The prompt typed into the Chat tab. Keep it short so it reads on screen.
   prompt: "Show the protein as cartoon colored by chain",
+  // After generation finishes, dwell this long on the fixed chat frame so the
+  // LLM response is clearly readable before the camera moves to the molecule.
+  chatResponseHoldMs: 10000,
   // Pipeline scroll-through (TB layout). `pipelineWidthFraction` sizes the graph
   // to a fraction of the screen width (0.7 ≈ 70%); it overrides the fixed
   // `pipelineScrollScale` fallback. `pipelineScrollMs` is the linear scroll time.
@@ -64,7 +67,9 @@ export const scenes = [
     zoom: { sel: '[data-testid="panel-pipeline"]', scale: 1.9, alignTop: true, topMargin: 24 },
     transitionMs: 1000,
     action: "submitAndWait",
-    hold: 2000,
+    // Stay fixed for ~10s after generation so the response is clearly visible
+    // before the camera moves on.
+    hold: config.chatResponseHoldMs,
   },
 
   // 4. Once generation completes, move over to the 3D molecule view and rotate.

--- a/scripts/demo-script.mjs
+++ b/scripts/demo-script.mjs
@@ -53,16 +53,17 @@ export const scenes = [
     hold: 600,
   },
 
-  // 3. Move further up to the top of the chat messages, where a short
-  //    conversation (prompt + streaming reply) sits, so the generation is
-  //    actually visible. With a live LLM this records the real generation;
-  //    without one it just dwells on the typed prompt. Output may vary.
+  // 3. Settle on a fixed frame with the Pipeline/Chat tab bar pinned to the top
+  //    of the screen, so the short conversation (prompt + streaming reply) is
+  //    visible just below it while the response generates. The camera does not
+  //    move during generation. With a live LLM this records the real
+  //    generation; without one it dwells on the typed prompt. Output may vary.
   {
     id: "chat-generate",
-    zoom: { sel: '[data-testid="pipeline-chat-messages"]', scale: 1.7, anchorY: 0.3 },
-    transitionMs: 900,
+    zoom: { sel: '[data-testid="panel-pipeline"]', scale: 1.9, alignTop: true, topMargin: 24 },
+    transitionMs: 1000,
     action: "waitGenerate",
-    hold: 1500,
+    hold: 2000,
   },
 
   // 4. Once generation completes, move over to the 3D molecule view and rotate.

--- a/scripts/demo-script.mjs
+++ b/scripts/demo-script.mjs
@@ -74,14 +74,14 @@ export const scenes = [
     hold: 1500,
   },
 
-  // 5. Show the whole pipeline (Editor tab fitView), then scroll it top→bottom
-  //    so every node passes through in order. The verb drives its own zoom, so
-  //    the scene zoom is "keep".
+  // 5. Zoom into the sidebar's "Pipeline"/Editor tab, click it on camera so the
+  //    panel switches from Chat to the pipeline graph, then scroll the graph
+  //    top→bottom (at ~70% screen width) to reveal its contents. The verb drives
+  //    its own camera, so the scene zoom is "keep".
   {
     id: "pipeline",
     zoom: "keep",
-    action: "showAndScrollPipeline",
-    actionFirst: true,
+    action: "clickPipelineTabAndScroll",
     hold: 1500,
   },
 ];

--- a/scripts/demo-script.mjs
+++ b/scripts/demo-script.mjs
@@ -31,7 +31,7 @@ export const config = {
   dpr: 2, // render headroom so CSS-zoomed pixels stay crisp
   transitionMs: 900, // default zoom tween duration (CSS transition on #root)
   // The prompt typed into the Chat tab. Keep it short so it reads on screen.
-  prompt: "Show the protein as cartoon colored by chain",
+  prompt: "Make the water molecules semi-transparent",
   // After submitting, dwell this long on the fixed chat frame (the screen does
   // not move) while the reply streams in and the response becomes readable.
   chatResponseHoldMs: 30000,

--- a/scripts/demo-script.mjs
+++ b/scripts/demo-script.mjs
@@ -44,25 +44,26 @@ export const scenes = [
   // 1. Whole app — let the viewer take in the full UI.
   { id: "overview", zoom: "full", hold: 2200 },
 
-  // 2. Go straight from the full view into the Chat input, type, and submit.
+  // 2. Go straight from the full view into the Chat input and type the prompt
+  //    (submission happens in the next scene, after the camera has settled).
   {
     id: "chat-input",
     zoom: { sel: 'textarea[placeholder="Describe the pipeline you want..."]', scale: 2.2 },
     transitionMs: 950,
-    action: "askChat",
+    action: "typePrompt",
     hold: 600,
   },
 
-  // 3. Settle on a fixed frame with the Pipeline/Chat tab bar pinned to the top
-  //    of the screen, so the short conversation (prompt + streaming reply) is
-  //    visible just below it while the response generates. The camera does not
-  //    move during generation. With a live LLM this records the real
+  // 3. Settle on a FIXED frame with the Pipeline/Chat tab bar pinned to the top
+  //    of the screen, THEN submit — so the camera is already still by the time
+  //    the response streams in just below the tabs. The screen does not move
+  //    while the reply is visible. With a live LLM this records the real
   //    generation; without one it dwells on the typed prompt. Output may vary.
   {
     id: "chat-generate",
     zoom: { sel: '[data-testid="panel-pipeline"]', scale: 1.9, alignTop: true, topMargin: 24 },
     transitionMs: 1000,
-    action: "waitGenerate",
+    action: "submitAndWait",
     hold: 2000,
   },
 

--- a/scripts/demo-script.mjs
+++ b/scripts/demo-script.mjs
@@ -44,51 +44,20 @@ export const config = {
 };
 
 export const scenes = [
-  // 1. Whole app — let the viewer take in the full UI.
-  { id: "overview", zoom: "full", hold: 2200 },
+  // Recorded entirely at the full (un-zoomed) view so the #root transform never
+  // moves: ReactFlow then always measures node handles at identity and the
+  // pipeline edges stay attached. Zoom/pan into each region in post.
+  { id: "overview", zoom: "full", hold: 2500 },
 
-  // 2. Go straight from the full view into the Chat input and type the prompt
-  //    (submission happens in the next scene, after the camera has settled).
-  {
-    id: "chat-input",
-    zoom: { sel: 'textarea[placeholder="Describe the pipeline you want..."]', scale: 2.2 },
-    transitionMs: 950,
-    action: "typePrompt",
-    hold: 600,
-  },
+  // Type the prompt into the Chat input.
+  { id: "chat-input", zoom: "full", action: "typePrompt", hold: 1200 },
 
-  // 3. Pull back to the full view (identity) and submit, then dwell ~30s while
-  //    the reply streams in. This scene MUST stay unzoomed: the generated
-  //    pipeline mounts here, and ReactFlow measures node handle positions via
-  //    getBoundingClientRect — if a #root CSS zoom is active during that
-  //    measurement, the handle coords are scaled wrong and the pipeline edges
-  //    render detached from the nodes (and never re-measure). With identity the
-  //    handles are correct, so the later full-screen pipeline zoom stays clean.
-  {
-    id: "chat-generate",
-    zoom: "full",
-    transitionMs: 1000,
-    action: "submitPrompt",
-    hold: config.chatResponseHoldMs, // ~30s fixed dwell
-  },
+  // Submit and dwell while the reply streams in (output may vary).
+  { id: "chat-generate", zoom: "full", action: "submitPrompt", hold: config.chatResponseHoldMs },
 
-  // 4. Once generation completes, move over to the 3D molecule view and rotate.
-  {
-    id: "molecule",
-    zoom: { sel: '[data-testid="viewer-root"]', scale: 1.5 },
-    transitionMs: 1200,
-    action: "rotate",
-    hold: 1500,
-  },
+  // Rotate the molecule (its look reflects the applied pipeline).
+  { id: "molecule", zoom: "full", action: "rotate", hold: 2500 },
 
-  // 5. Zoom into the sidebar's "Pipeline"/Editor tab, click it on camera so the
-  //    panel switches from Chat to the pipeline graph, then scroll the graph
-  //    top→bottom (at ~70% screen width) to reveal its contents. The verb drives
-  //    its own camera, so the scene zoom is "keep".
-  {
-    id: "pipeline",
-    zoom: "keep",
-    action: "clickPipelineTabAndScroll",
-    hold: 1500,
-  },
+  // Switch to the Editor tab to reveal the generated pipeline graph.
+  { id: "pipeline", zoom: "full", action: "showPipeline", hold: 6000 },
 ];

--- a/scripts/demo-script.mjs
+++ b/scripts/demo-script.mjs
@@ -12,10 +12,11 @@
  * Scene fields:
  *   id         unique label (also used for logging)
  *   zoom       "full" (reset to whole screen) | "keep" (keep current zoom)
- *              | { sel, pad?, scale? } — frame an element. With `scale` it zooms
- *              by that fixed factor centered on the element (use for full-height
- *              targets like the side panel, where fit-to-bbox would be ~1×);
- *              without `scale` it fits the padded bbox to the viewport.
+ *              | { sel, pad?, scale?, anchorX?, anchorY? } — frame an element.
+ *              With `scale` it zooms by that fixed factor; without it, fits the
+ *              padded bbox to the viewport. `anchorX`/`anchorY` (0..1, default
+ *              0.5) pick which point of the element maps to the viewport center
+ *              — e.g. anchorY: 0.72 biases toward the lower (streaming) area.
  *   action     name of a director "verb" to run after the zoom settles
  *              (one of: openChatAndType | generate | rotate | showPipeline),
  *              or omit for a static hold
@@ -38,39 +39,39 @@ export const config = {
 
 export const scenes = [
   // 1. Whole app — let the viewer take in the full UI.
-  { id: "overview", zoom: "full", hold: 2500 },
+  { id: "overview", zoom: "full", hold: 2200 },
 
-  // 2. Deliberately move the camera to the right-hand pipeline panel first, so
-  //    the next push-in reads as "we're going into the chat" rather than a jump.
+  // 2. Go straight from the full view into the Chat input, type, and submit.
   {
-    id: "chat-approach",
-    zoom: { sel: '[data-testid="panel-pipeline"]', scale: 1.25 },
-    transitionMs: 1500,
-    hold: 700,
-  },
-
-  // 3. Push in on the Chat input (centered on the prompt box) and type a prompt.
-  {
-    id: "chat",
+    id: "chat-input",
     zoom: { sel: 'textarea[placeholder="Describe the pipeline you want..."]', scale: 2.2 },
-    transitionMs: 1100,
-    action: "openChatAndType",
-    hold: 1200,
+    transitionMs: 950,
+    action: "askChat",
+    hold: 600,
   },
 
-  // 4. Run the generation (live AI; output may vary). Stays zoomed on chat.
-  { id: "generate", zoom: "keep", action: "generate", hold: 4000 },
+  // 3. Move up to the chat messages area to watch the response generate
+  //    (anchored low so the streaming reply, which auto-scrolls down, stays in
+  //    frame). With a live LLM this records the real generation; without one it
+  //    just dwells on the typed prompt. Output may vary.
+  {
+    id: "chat-generate",
+    zoom: { sel: '[data-testid="pipeline-chat-messages"]', scale: 1.7, anchorY: 0.72 },
+    transitionMs: 900,
+    action: "waitGenerate",
+    hold: 1500,
+  },
 
-  // 5. Pull out and zoom into the 3D viewport, then slowly rotate the molecule.
+  // 4. Once generation completes, move over to the 3D molecule view and rotate.
   {
     id: "molecule",
     zoom: { sel: '[data-testid="viewer-root"]', scale: 1.5 },
-    transitionMs: 1300,
+    transitionMs: 1200,
     action: "rotate",
     hold: 1500,
   },
 
-  // 6. Show the whole pipeline (Editor tab fitView), then scroll it top→bottom
+  // 5. Show the whole pipeline (Editor tab fitView), then scroll it top→bottom
   //    so every node passes through in order. The verb drives its own zoom, so
   //    the scene zoom is "keep".
   {

--- a/scripts/demo-script.mjs
+++ b/scripts/demo-script.mjs
@@ -32,9 +32,9 @@ export const config = {
   transitionMs: 900, // default zoom tween duration (CSS transition on #root)
   // The prompt typed into the Chat tab. Keep it short so it reads on screen.
   prompt: "Show the protein as cartoon colored by chain",
-  // After generation finishes, dwell this long on the fixed chat frame so the
-  // LLM response is clearly readable before the camera moves to the molecule.
-  chatResponseHoldMs: 10000,
+  // After submitting, dwell this long on the fixed chat frame (the screen does
+  // not move) while the reply streams in and the response becomes readable.
+  chatResponseHoldMs: 30000,
   // Pipeline scroll-through (TB layout). `pipelineWidthFraction` sizes the graph
   // to a fraction of the screen width (0.7 ≈ 70%); it overrides the fixed
   // `pipelineScrollScale` fallback. `pipelineScrollMs` is the linear scroll time.
@@ -58,18 +58,15 @@ export const scenes = [
   },
 
   // 3. Settle on a FIXED frame with the Pipeline/Chat tab bar pinned to the top
-  //    of the screen, THEN submit — so the camera is already still by the time
-  //    the response streams in just below the tabs. The screen does not move
-  //    while the reply is visible. With a live LLM this records the real
-  //    generation; without one it dwells on the typed prompt. Output may vary.
+  //    of the screen, THEN submit, then dwell in place ~30s while the reply
+  //    streams in just below the tabs. The screen does not move and (with
+  //    scrollIntoView neutralised) the response stays put. Output may vary.
   {
     id: "chat-generate",
     zoom: { sel: '[data-testid="panel-pipeline"]', scale: 1.9, alignTop: true, topMargin: 24 },
     transitionMs: 1000,
-    action: "submitAndWait",
-    // Stay fixed for ~10s after generation so the response is clearly visible
-    // before the camera moves on.
-    hold: config.chatResponseHoldMs,
+    action: "submitPrompt",
+    hold: config.chatResponseHoldMs, // ~30s fixed dwell
   },
 
   // 4. Once generation completes, move over to the 3D molecule view and rotate.

--- a/scripts/demo-video.mjs
+++ b/scripts/demo-video.mjs
@@ -66,6 +66,7 @@ const HEIGHT = parseInt(getFlag("--height", String(config.height)), 10);
 const DPR = parseFloat(getFlag("--dpr", String(config.dpr)));
 const TRANSITION_MS = config.transitionMs ?? 900;
 const PIPELINE_SCROLL_SCALE = config.pipelineScrollScale ?? 1.6;
+const PIPELINE_WIDTH_FRACTION = config.pipelineWidthFraction ?? 0;
 const PIPELINE_SCROLL_MS = config.pipelineScrollMs ?? 4800;
 const PROMPT = getFlag("--prompt", config.prompt);
 const NO_GENERATE = hasFlag("--no-generate");
@@ -278,7 +279,11 @@ const actions = {
     await page.waitForTimeout(1100); // let fitView settle: whole pipeline visible
     const box = await page.locator(SEL.reactFlow).first().boundingBox();
     if (!box) return;
-    const S = PIPELINE_SCROLL_SCALE;
+    // Size the graph to a fraction of the screen width (≈70%) when configured,
+    // else fall back to the fixed scale.
+    const S = PIPELINE_WIDTH_FRACTION
+      ? (PIPELINE_WIDTH_FRACTION * WIDTH) / box.width
+      : PIPELINE_SCROLL_SCALE;
     const topM = 56;
     const botM = 56;
     // Measured at identity (actionFirst reset to full), so screen == local.
@@ -368,10 +373,13 @@ try {
     // Chromium doesn't trust; tolerate it so --url can reach remote sites.
     ignoreHTTPSErrors: true,
   });
-  // Suppress the first-run tour overlay.
+  // Suppress the first-run tour overlay, and boot the pipeline panel on the Chat
+  // tab so the opening frame shows Chat by default (the deployed build may
+  // otherwise default to the Editor tab). Set before the app's scripts run.
   await context.addInitScript(() => {
     try {
       localStorage.setItem("megane-tour-prefs", JSON.stringify({ dontShowAgain: true }));
+      sessionStorage.setItem("megane-pipeline-ui", JSON.stringify({ mode: "chat" }));
     } catch {
       /* noop */
     }

--- a/scripts/demo-video.mjs
+++ b/scripts/demo-video.mjs
@@ -392,6 +392,13 @@ try {
 
   await setupApiKey(page);
 
+  // Ensure the panel is on the Chat tab so the prompt box is visible. The
+  // current source defaults to Chat, but the deployed build may default to the
+  // Editor tab (which keeps the chat textarea visibility:hidden). Done at full
+  // view, before any zoom, so the tab is on-screen and clickable.
+  await page.locator(SEL.chatTab).first().click().catch(() => {});
+  await page.waitForTimeout(500);
+
   for (const scene of scenes) {
     console.log(`Scene: ${scene.id}`);
     const runAction = async () => {

--- a/scripts/demo-video.mjs
+++ b/scripts/demo-video.mjs
@@ -271,34 +271,45 @@ const actions = {
     await page.mouse.up();
   },
 
-  // Reveal the whole pipeline (Editor tab fitView frames every node), then
-  // scroll the graph top→bottom so each node passes through in reading order.
-  // The TB dagre layout makes a vertical scroll the natural traversal.
-  async showAndScrollPipeline(page) {
-    await page.locator(SEL.editorTab).first().click();
-    await page.waitForTimeout(1100); // let fitView settle: whole pipeline visible
+  // Zoom into the top of the sidebar (the "Pipeline" panel header + Editor tab),
+  // click the Editor tab on camera so the panel visibly switches from Chat to
+  // the pipeline graph, then frame the graph at ~70% width and scroll it
+  // top→bottom so each node passes through in reading order (TB dagre layout).
+  async clickPipelineTabAndScroll(page) {
+    // Move the camera onto the Editor tab and dwell so the click reads.
+    await zoomTo(page, { sel: SEL.editorTab, scale: 2.6 }, 1100);
+    await page.waitForTimeout(700);
+    await page
+      .locator(SEL.editorTab)
+      .first()
+      .click()
+      .catch((e) => console.log("  editor tab click failed:", e.message));
+    await page.waitForTimeout(1300); // show the switch chat → pipeline graph
+
+    // Frame the whole graph at ~70% width, aligned to the top. Measure in local
+    // coordinates (the camera is mid-zoom on the tab, not at identity).
     const box = await page.locator(SEL.reactFlow).first().boundingBox();
     if (!box) return;
-    // Size the graph to a fraction of the screen width (≈70%) when configured,
-    // else fall back to the fixed scale.
+    const lx = (box.x - current.tx) / current.s;
+    const ly = (box.y - current.ty) / current.s;
+    const lw = box.width / current.s;
+    const lh = box.height / current.s;
     const S = PIPELINE_WIDTH_FRACTION
-      ? (PIPELINE_WIDTH_FRACTION * WIDTH) / box.width
+      ? (PIPELINE_WIDTH_FRACTION * WIDTH) / lw
       : PIPELINE_SCROLL_SCALE;
     const topM = 56;
     const botM = 56;
-    // Measured at identity (actionFirst reset to full), so screen == local.
-    const tx = WIDTH / 2 - (box.x + box.width / 2) * S;
-    const tyTop = topM - box.y * S;
-    const tyBottom = HEIGHT - botM - (box.y + box.height) * S;
+    const tx = WIDTH / 2 - (lx + lw / 2) * S;
+    const tyTop = topM - ly * S;
+    const tyBottom = HEIGHT - botM - (ly + lh) * S;
 
     // Ease into the top of the pipeline.
     await setTransition(page, TRANSITION_MS);
     await applyTransform(page, { tx, ty: tyTop, s: S });
     await page.waitForTimeout(TRANSITION_MS + 600);
 
-    // Only scroll if the scaled graph is taller than the viewport; otherwise it
-    // already fits and we just dwell on it.
-    if (box.height * S > HEIGHT - topM - botM) {
+    // Scroll down to the bottom when the scaled graph is taller than the view.
+    if (lh * S > HEIGHT - topM - botM) {
       await setTransition(page, PIPELINE_SCROLL_MS, "linear");
       await applyTransform(page, { tx, ty: tyBottom, s: S });
       await page.waitForTimeout(PIPELINE_SCROLL_MS);

--- a/scripts/demo-video.mjs
+++ b/scripts/demo-video.mjs
@@ -178,11 +178,14 @@ async function zoomTo(page, spec, ms = TRANSITION_MS) {
   // when the target is full-height (fit-to-bbox would compute ~1× and not zoom).
   // Otherwise fit the padded bbox to the viewport.
   const s = scale ?? Math.min(WIDTH / lw, HEIGHT / lh);
-  // anchorX/anchorY pick which point of the element maps to the viewport center
-  // (default the element centre). Biasing anchorY toward 1 frames lower content.
-  const cx = lx + lw * (spec.anchorX ?? 0.5);
-  const cy = ly + lh * (spec.anchorY ?? 0.5);
-  await applyTransform(page, { tx: WIDTH / 2 - cx * s, ty: HEIGHT / 2 - cy * s, s });
+  // Horizontal: anchorX picks which point maps to the viewport centre.
+  const tx = WIDTH / 2 - (lx + lw * (spec.anchorX ?? 0.5)) * s;
+  // Vertical: `alignTop` pins the element's top near the top of the screen
+  // (e.g. to keep the Pipeline/Chat tab bar up top); otherwise anchorY centres.
+  const ty = spec.alignTop
+    ? (spec.topMargin ?? 28) - ly * s
+    : HEIGHT / 2 - (ly + lh * (spec.anchorY ?? 0.5)) * s;
+  await applyTransform(page, { tx, ty, s });
   await page.waitForTimeout(ms);
 }
 
@@ -196,6 +199,7 @@ const SEL = {
   cancelBtn: 'button:has-text("Cancel")',
   chatMessages: '[data-testid="pipeline-chat-messages"]',
   appliedNotice: '[data-testid="pipeline-editor-applied-notice"]',
+  panelPipeline: '[data-testid="panel-pipeline"]',
   viewer: '[data-testid="viewer-root"]',
   reactFlow: ".react-flow",
 };
@@ -271,14 +275,32 @@ const actions = {
     await page.mouse.up();
   },
 
-  // Zoom into the top of the sidebar (the "Pipeline" panel header + Editor tab),
-  // click the Editor tab on camera so the panel visibly switches from Chat to
-  // the pipeline graph, then frame the graph at ~70% width and scroll it
+  // Frame the pipeline panel at ~70% width with the Pipeline/Chat tab bar pinned
+  // to the top of the screen, click the Editor tab on camera so the panel
+  // visibly switches from Chat to the pipeline graph, then scroll the graph
   // top→bottom so each node passes through in reading order (TB dagre layout).
   async clickPipelineTabAndScroll(page) {
-    // Move the camera onto the Editor tab and dwell so the click reads.
-    await zoomTo(page, { sel: SEL.editorTab, scale: 2.6 }, 1100);
-    await page.waitForTimeout(700);
+    const topM = 24;
+    const botM = 56;
+    // Size from the panel width and pin its top (the "Pipeline" title + tabs) to
+    // the top of the screen. Measure in local coords (camera may be mid-zoom).
+    const pbox = await page.locator(SEL.panelPipeline).first().boundingBox();
+    if (!pbox) return;
+    const plx = (pbox.x - current.tx) / current.s;
+    const ply = (pbox.y - current.ty) / current.s;
+    const plw = pbox.width / current.s;
+    const S = PIPELINE_WIDTH_FRACTION
+      ? (PIPELINE_WIDTH_FRACTION * WIDTH) / plw
+      : PIPELINE_SCROLL_SCALE;
+    const tx = WIDTH / 2 - (plx + plw / 2) * S;
+    const tyTop = topM - ply * S;
+
+    // Move in with the tabs at the top, dwell so the click reads.
+    await setTransition(page, 1100);
+    await applyTransform(page, { tx, ty: tyTop, s: S });
+    await page.waitForTimeout(1100 + 700);
+
+    // Click the Editor tab (near the top, in frame) → switch chat → graph.
     await page
       .locator(SEL.editorTab)
       .first()
@@ -286,30 +308,13 @@ const actions = {
       .catch((e) => console.log("  editor tab click failed:", e.message));
     await page.waitForTimeout(1300); // show the switch chat → pipeline graph
 
-    // Frame the whole graph at ~70% width, aligned to the top. Measure in local
-    // coordinates (the camera is mid-zoom on the tab, not at identity).
-    const box = await page.locator(SEL.reactFlow).first().boundingBox();
-    if (!box) return;
-    const lx = (box.x - current.tx) / current.s;
-    const ly = (box.y - current.ty) / current.s;
-    const lw = box.width / current.s;
-    const lh = box.height / current.s;
-    const S = PIPELINE_WIDTH_FRACTION
-      ? (PIPELINE_WIDTH_FRACTION * WIDTH) / lw
-      : PIPELINE_SCROLL_SCALE;
-    const topM = 56;
-    const botM = 56;
-    const tx = WIDTH / 2 - (lx + lw / 2) * S;
-    const tyTop = topM - ly * S;
-    const tyBottom = HEIGHT - botM - (ly + lh) * S;
-
-    // Ease into the top of the pipeline.
-    await setTransition(page, TRANSITION_MS);
-    await applyTransform(page, { tx, ty: tyTop, s: S });
-    await page.waitForTimeout(TRANSITION_MS + 600);
-
-    // Scroll down to the bottom when the scaled graph is taller than the view.
-    if (lh * S > HEIGHT - topM - botM) {
+    // Scroll down through the now-visible graph, keeping the same scale/centre.
+    const rf = await page.locator(SEL.reactFlow).first().boundingBox();
+    if (!rf) return;
+    const rly = (rf.y - current.ty) / current.s;
+    const rlh = rf.height / current.s;
+    const tyBottom = HEIGHT - botM - (rly + rlh) * S;
+    if (rlh * S > HEIGHT - topM - botM) {
       await setTransition(page, PIPELINE_SCROLL_MS, "linear");
       await applyTransform(page, { tx, ty: tyBottom, s: S });
       await page.waitForTimeout(PIPELINE_SCROLL_MS);

--- a/scripts/demo-video.mjs
+++ b/scripts/demo-video.mjs
@@ -263,48 +263,54 @@ const actions = {
     await page.mouse.up();
   },
 
-  // Switch to the Editor tab, then frame the pipeline panel at ~70% width with
-  // the Pipeline/Chat tab bar pinned to the top of the screen and scroll the
-  // graph top→bottom (TB dagre layout).
+  // Zoom into the pipeline panel (Pipeline/Chat tab bar pinned to the top of the
+  // screen) FIRST, then click the Editor tab on camera so the panel visibly
+  // switches Chat → pipeline graph, then scroll the graph top→bottom (TB dagre
+  // layout).
   //
-  // The tab is clicked at IDENTITY (no #root transform) on purpose: ReactFlow
-  // runs fitView on the chat→editor switch, and if a CSS transform is active
-  // while it measures, the edges render offset from the node handles. We let
-  // fitView settle untransformed, then zoom/scroll with a pure uniform scale —
-  // which triggers no re-measure, so the edges stay connected.
+  // Clicking the tab while zoomed is safe here: the node handle positions were
+  // already measured at identity when the pipeline mounted during chat-generate,
+  // and a tab switch / fitView pans the viewport without re-measuring handles —
+  // so the edges stay attached. (The earlier breakage came from the pipeline
+  // mounting *while* a zoom was active, which is now avoided.)
   async clickPipelineTabAndScroll(page) {
     const topM = 24;
     const botM = 56;
 
-    // Pull back to full view and switch tabs so fitView measures untransformed.
-    await zoomTo(page, "full", 900);
+    // Frame the panel at ~70% width with its top (the "Pipeline" title + tabs)
+    // pinned to the top. Measure in local coords (camera arrives mid-zoom from
+    // the molecule scene).
+    const pbox = await page.locator(SEL.panelPipeline).first().boundingBox();
+    if (!pbox) return;
+    const plx = (pbox.x - current.tx) / current.s;
+    const ply = (pbox.y - current.ty) / current.s;
+    const plw = pbox.width / current.s;
+    const S = PIPELINE_WIDTH_FRACTION
+      ? (PIPELINE_WIDTH_FRACTION * WIDTH) / plw
+      : PIPELINE_SCROLL_SCALE;
+    const tx = WIDTH / 2 - (plx + plw / 2) * S;
+    const tyTop = topM - ply * S;
+
+    // Zoom in (still on the Chat tab), dwell so the move reads.
+    await setTransition(page, 1100);
+    await applyTransform(page, { tx, ty: tyTop, s: S });
+    await page.waitForTimeout(1100 + 700);
+
+    // Now switch Chat → Editor on camera (tabs are at the top, in frame).
     await page
       .locator(SEL.editorTab)
       .first()
       .click()
       .catch((e) => console.log("  editor tab click failed:", e.message));
-    await page.waitForTimeout(1500); // let fitView settle at identity
-
-    // Now at identity, so on-screen boxes equal local coordinates. Size from the
-    // panel width and pin its top (the "Pipeline" title + tabs) to the top.
-    const pbox = await page.locator(SEL.panelPipeline).first().boundingBox();
-    if (!pbox) return;
-    const S = PIPELINE_WIDTH_FRACTION
-      ? (PIPELINE_WIDTH_FRACTION * WIDTH) / pbox.width
-      : PIPELINE_SCROLL_SCALE;
-    const tx = WIDTH / 2 - (pbox.x + pbox.width / 2) * S;
-    const tyTop = topM - pbox.y * S;
-
-    // Ease in with the tabs at the top.
-    await setTransition(page, 1100);
-    await applyTransform(page, { tx, ty: tyTop, s: S });
-    await page.waitForTimeout(1100 + 700);
+    await page.waitForTimeout(1300); // show the switch chat → pipeline graph
 
     // Scroll down through the graph, keeping the same scale/centre.
     const rf = await page.locator(SEL.reactFlow).first().boundingBox();
     if (!rf) return;
-    const tyBottom = HEIGHT - botM - (rf.y + rf.height) * S;
-    if (rf.height * S > HEIGHT - topM - botM) {
+    const rly = (rf.y - current.ty) / current.s;
+    const rlh = rf.height / current.s;
+    const tyBottom = HEIGHT - botM - (rly + rlh) * S;
+    if (rlh * S > HEIGHT - topM - botM) {
       await setTransition(page, PIPELINE_SCROLL_MS, "linear");
       await applyTransform(page, { tx, ty: tyBottom, s: S });
       await page.waitForTimeout(PIPELINE_SCROLL_MS);

--- a/scripts/demo-video.mjs
+++ b/scripts/demo-video.mjs
@@ -60,6 +60,8 @@ const WIDTH = parseInt(getFlag("--width", String(config.width)), 10);
 const HEIGHT = parseInt(getFlag("--height", String(config.height)), 10);
 const DPR = parseFloat(getFlag("--dpr", String(config.dpr)));
 const TRANSITION_MS = config.transitionMs ?? 900;
+const PIPELINE_SCROLL_SCALE = config.pipelineScrollScale ?? 1.6;
+const PIPELINE_SCROLL_MS = config.pipelineScrollMs ?? 4800;
 const PROMPT = getFlag("--prompt", config.prompt);
 const NO_GENERATE = hasFlag("--no-generate");
 const CLEAN = hasFlag("--clean");
@@ -127,11 +129,23 @@ async function applyTransform(page, t) {
   );
 }
 
-async function zoomTo(page, spec) {
+// Swap the #root transition used for the next move (duration + easing).
+async function setTransition(page, ms, easing = "cubic-bezier(0.4, 0, 0.2, 1)") {
+  await page.evaluate(
+    ({ ms, easing }) => {
+      const root = document.getElementById("root");
+      if (root) root.style.transition = `transform ${ms}ms ${easing}`;
+    },
+    { ms, easing },
+  );
+}
+
+async function zoomTo(page, spec, ms = TRANSITION_MS) {
   if (spec === "keep") return;
+  await setTransition(page, ms);
   if (!spec || spec === "full") {
     await applyTransform(page, { tx: 0, ty: 0, s: 1 });
-    await page.waitForTimeout(TRANSITION_MS);
+    await page.waitForTimeout(ms);
     return;
   }
   const { sel, pad = 0, scale } = spec;
@@ -152,7 +166,7 @@ async function zoomTo(page, spec) {
   const cx = lx + lw / 2;
   const cy = ly + lh / 2;
   await applyTransform(page, { tx: WIDTH / 2 - cx * s, ty: HEIGHT / 2 - cy * s, s });
-  await page.waitForTimeout(TRANSITION_MS);
+  await page.waitForTimeout(ms);
 }
 
 // ---- Scene actions ("verbs") ----
@@ -166,6 +180,7 @@ const SEL = {
   chatMessages: '[data-testid="pipeline-chat-messages"]',
   appliedNotice: '[data-testid="pipeline-editor-applied-notice"]',
   viewer: '[data-testid="viewer-root"]',
+  reactFlow: ".react-flow",
 };
 
 const actions = {
@@ -232,9 +247,35 @@ const actions = {
     await page.mouse.up();
   },
 
-  async showPipeline(page) {
+  // Reveal the whole pipeline (Editor tab fitView frames every node), then
+  // scroll the graph top→bottom so each node passes through in reading order.
+  // The TB dagre layout makes a vertical scroll the natural traversal.
+  async showAndScrollPipeline(page) {
     await page.locator(SEL.editorTab).first().click();
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(1100); // let fitView settle: whole pipeline visible
+    const box = await page.locator(SEL.reactFlow).first().boundingBox();
+    if (!box) return;
+    const S = PIPELINE_SCROLL_SCALE;
+    const topM = 56;
+    const botM = 56;
+    // Measured at identity (actionFirst reset to full), so screen == local.
+    const tx = WIDTH / 2 - (box.x + box.width / 2) * S;
+    const tyTop = topM - box.y * S;
+    const tyBottom = HEIGHT - botM - (box.y + box.height) * S;
+
+    // Ease into the top of the pipeline.
+    await setTransition(page, TRANSITION_MS);
+    await applyTransform(page, { tx, ty: tyTop, s: S });
+    await page.waitForTimeout(TRANSITION_MS + 600);
+
+    // Only scroll if the scaled graph is taller than the viewport; otherwise it
+    // already fits and we just dwell on it.
+    if (box.height * S > HEIGHT - topM - botM) {
+      await setTransition(page, PIPELINE_SCROLL_MS, "linear");
+      await applyTransform(page, { tx, ty: tyBottom, s: S });
+      await page.waitForTimeout(PIPELINE_SCROLL_MS);
+      await setTransition(page, TRANSITION_MS); // restore eased default
+    }
   },
 };
 
@@ -321,12 +362,13 @@ try {
     // are on-screen regardless of the prior zoom), run the verb — which may
     // reveal the zoom target, e.g. the Editor tab unhiding `.react-flow` — then
     // frame it.
+    const ms = scene.transitionMs ?? TRANSITION_MS;
     if (scene.actionFirst) {
-      await zoomTo(page, "full");
+      await zoomTo(page, "full", ms);
       await runAction();
-      await zoomTo(page, scene.zoom);
+      await zoomTo(page, scene.zoom, ms);
     } else {
-      await zoomTo(page, scene.zoom);
+      await zoomTo(page, scene.zoom, ms);
       await runAction();
     }
     if (scene.hold) await page.waitForTimeout(scene.hold);

--- a/scripts/demo-video.mjs
+++ b/scripts/demo-video.mjs
@@ -263,46 +263,48 @@ const actions = {
     await page.mouse.up();
   },
 
-  // Frame the pipeline panel at ~70% width with the Pipeline/Chat tab bar pinned
-  // to the top of the screen, click the Editor tab on camera so the panel
-  // visibly switches from Chat to the pipeline graph, then scroll the graph
-  // top→bottom so each node passes through in reading order (TB dagre layout).
+  // Switch to the Editor tab, then frame the pipeline panel at ~70% width with
+  // the Pipeline/Chat tab bar pinned to the top of the screen and scroll the
+  // graph top→bottom (TB dagre layout).
+  //
+  // The tab is clicked at IDENTITY (no #root transform) on purpose: ReactFlow
+  // runs fitView on the chat→editor switch, and if a CSS transform is active
+  // while it measures, the edges render offset from the node handles. We let
+  // fitView settle untransformed, then zoom/scroll with a pure uniform scale —
+  // which triggers no re-measure, so the edges stay connected.
   async clickPipelineTabAndScroll(page) {
     const topM = 24;
     const botM = 56;
-    // Size from the panel width and pin its top (the "Pipeline" title + tabs) to
-    // the top of the screen. Measure in local coords (camera may be mid-zoom).
-    const pbox = await page.locator(SEL.panelPipeline).first().boundingBox();
-    if (!pbox) return;
-    const plx = (pbox.x - current.tx) / current.s;
-    const ply = (pbox.y - current.ty) / current.s;
-    const plw = pbox.width / current.s;
-    const S = PIPELINE_WIDTH_FRACTION
-      ? (PIPELINE_WIDTH_FRACTION * WIDTH) / plw
-      : PIPELINE_SCROLL_SCALE;
-    const tx = WIDTH / 2 - (plx + plw / 2) * S;
-    const tyTop = topM - ply * S;
 
-    // Move in with the tabs at the top, dwell so the click reads.
-    await setTransition(page, 1100);
-    await applyTransform(page, { tx, ty: tyTop, s: S });
-    await page.waitForTimeout(1100 + 700);
-
-    // Click the Editor tab (near the top, in frame) → switch chat → graph.
+    // Pull back to full view and switch tabs so fitView measures untransformed.
+    await zoomTo(page, "full", 900);
     await page
       .locator(SEL.editorTab)
       .first()
       .click()
       .catch((e) => console.log("  editor tab click failed:", e.message));
-    await page.waitForTimeout(1300); // show the switch chat → pipeline graph
+    await page.waitForTimeout(1500); // let fitView settle at identity
 
-    // Scroll down through the now-visible graph, keeping the same scale/centre.
+    // Now at identity, so on-screen boxes equal local coordinates. Size from the
+    // panel width and pin its top (the "Pipeline" title + tabs) to the top.
+    const pbox = await page.locator(SEL.panelPipeline).first().boundingBox();
+    if (!pbox) return;
+    const S = PIPELINE_WIDTH_FRACTION
+      ? (PIPELINE_WIDTH_FRACTION * WIDTH) / pbox.width
+      : PIPELINE_SCROLL_SCALE;
+    const tx = WIDTH / 2 - (pbox.x + pbox.width / 2) * S;
+    const tyTop = topM - pbox.y * S;
+
+    // Ease in with the tabs at the top.
+    await setTransition(page, 1100);
+    await applyTransform(page, { tx, ty: tyTop, s: S });
+    await page.waitForTimeout(1100 + 700);
+
+    // Scroll down through the graph, keeping the same scale/centre.
     const rf = await page.locator(SEL.reactFlow).first().boundingBox();
     if (!rf) return;
-    const rly = (rf.y - current.ty) / current.s;
-    const rlh = rf.height / current.s;
-    const tyBottom = HEIGHT - botM - (rly + rlh) * S;
-    if (rlh * S > HEIGHT - topM - botM) {
+    const tyBottom = HEIGHT - botM - (rf.y + rf.height) * S;
+    if (rf.height * S > HEIGHT - topM - botM) {
       await setTransition(page, PIPELINE_SCROLL_MS, "linear");
       await applyTransform(page, { tx, ty: tyBottom, s: S });
       await page.waitForTimeout(PIPELINE_SCROLL_MS);

--- a/scripts/demo-video.mjs
+++ b/scripts/demo-video.mjs
@@ -205,8 +205,9 @@ const SEL = {
 };
 
 const actions = {
-  // Type the prompt into the Chat input, then submit it (when generation is on).
-  async askChat(page) {
+  // Type the prompt into the Chat input — but do NOT submit yet, so generation
+  // only starts once the next scene has settled on a fixed frame.
+  async typePrompt(page) {
     // The panel defaults to the Chat tab, so the textarea is already present.
     await page.locator(SEL.promptBox).first().waitFor({ state: "visible", timeout: 10000 });
     // Typewriter effect driven entirely in-page: set the value via React's
@@ -229,23 +230,21 @@ const actions = {
       );
       await page.waitForTimeout(45);
     }
-    if (!RUN_GENERATE) {
-      console.log("  askChat: typed prompt; generation off (no key / no site LLM / --no-generate)");
-      return;
-    }
-    // Submit while the input row (and Generate button) is still framed.
-    await page
-      .locator(SEL.generateBtn)
-      .first()
-      .click()
-      .catch((e) => console.log("  askChat: submit click failed:", e.message));
   },
 
-  // Wait for the streamed response to finish. While streaming the submit button
-  // reads "Cancel"; it returns to "Generate" once the response (and pipeline
-  // apply) completes — a host-agnostic signal that also covers the demo proxy.
-  async waitGenerate(page) {
-    if (!RUN_GENERATE) return;
+  // Submit the typed prompt and wait for the streamed reply to finish. Called
+  // only after the camera has settled on the fixed response frame, so the screen
+  // stays still while the response is visible. Submits via Enter (the textarea's
+  // own handler) so the off-screen Generate button isn't required. While
+  // streaming the submit button reads "Cancel"; it returns to "Generate" once
+  // the response (and pipeline apply) completes — host-agnostic, covers the proxy.
+  async submitAndWait(page) {
+    if (!RUN_GENERATE) {
+      console.log("  generation off (no key / no site LLM / --no-generate); prompt left in box");
+      return;
+    }
+    await page.evaluate((sel) => document.querySelector(sel)?.focus(), SEL.promptBox);
+    await page.keyboard.press("Enter");
     await page
       .locator(SEL.cancelBtn)
       .first()
@@ -255,7 +254,7 @@ const actions = {
       .locator(SEL.generateBtn)
       .first()
       .waitFor({ state: "visible", timeout: GENERATE_TIMEOUT_MS })
-      .catch(() => console.log("  waitGenerate: still streaming at timeout (recording current state)"));
+      .catch(() => console.log("  submitAndWait: still streaming at timeout (recording current state)"));
   },
 
   async rotate(page) {

--- a/scripts/demo-video.mjs
+++ b/scripts/demo-video.mjs
@@ -232,29 +232,18 @@ const actions = {
     }
   },
 
-  // Submit the typed prompt and wait for the streamed reply to finish. Called
-  // only after the camera has settled on the fixed response frame, so the screen
-  // stays still while the response is visible. Submits via Enter (the textarea's
-  // own handler) so the off-screen Generate button isn't required. While
-  // streaming the submit button reads "Cancel"; it returns to "Generate" once
-  // the response (and pipeline apply) completes — host-agnostic, covers the proxy.
-  async submitAndWait(page) {
+  // Submit the typed prompt (fire-and-forget). Called after the camera has
+  // settled on the fixed response frame; the scene's `hold` then dwells in place
+  // (~30s) while the reply streams in and the pipeline applies — the screen does
+  // not move. Submits via Enter (the textarea's own handler) so the off-screen
+  // Generate button isn't required.
+  async submitPrompt(page) {
     if (!RUN_GENERATE) {
       console.log("  generation off (no key / no site LLM / --no-generate); prompt left in box");
       return;
     }
     await page.evaluate((sel) => document.querySelector(sel)?.focus(), SEL.promptBox);
     await page.keyboard.press("Enter");
-    await page
-      .locator(SEL.cancelBtn)
-      .first()
-      .waitFor({ state: "visible", timeout: 12000 })
-      .catch(() => {});
-    await page
-      .locator(SEL.generateBtn)
-      .first()
-      .waitFor({ state: "visible", timeout: GENERATE_TIMEOUT_MS })
-      .catch(() => console.log("  submitAndWait: still streaming at timeout (recording current state)"));
   },
 
   async rotate(page) {
@@ -398,6 +387,12 @@ try {
     } catch {
       /* noop */
     }
+    // The chat auto-scrolls to the latest message via scrollIntoView on every
+    // streamed chunk; with a verbose reply this scrolls the response out of our
+    // fixed top-aligned frame mid-generation. Neutralise it for the recording so
+    // the response stays put (the only scrollIntoView caller is the chat; the
+    // pipeline editor pans via ReactFlow's own transform, not scrollIntoView).
+    window.Element.prototype.scrollIntoView = function () {};
   });
 
   const page = await context.newPage();

--- a/scripts/demo-video.mjs
+++ b/scripts/demo-video.mjs
@@ -31,15 +31,16 @@ import { spawn, execSync } from "child_process";
 import { existsSync, mkdirSync, readdirSync, renameSync, rmSync } from "fs";
 import { join, dirname, isAbsolute } from "path";
 import { fileURLToPath, pathToFileURL } from "url";
-import { createRequire } from "module";
+import { getChromium } from "../tests/e2e/utils/playwright.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, "..");
 const OUT_DIR = join(ROOT, "demo", "out");
 
-// Resolve Playwright from the global install (same pattern as dev-preview.mjs).
-const _require = createRequire("/opt/node22/lib/node_modules/");
-const { chromium } = _require("playwright");
+// Resolve Playwright via the shared helper, which prefers the project's own
+// node_modules and falls back to common global install paths — so this works
+// both in the hosted sandbox and on a local checkout.
+const chromium = getChromium();
 
 // ---- CLI parsing ----
 const args = process.argv.slice(2);

--- a/scripts/demo-video.mjs
+++ b/scripts/demo-video.mjs
@@ -1,0 +1,353 @@
+/**
+ * Demo video director for the megane app.
+ *
+ * Interprets the storyboard in `scripts/demo-script.mjs` ("台本"), drives the
+ * live Vite app with Playwright, and records a single continuous webm while
+ * zooming into UI regions via a CSS transform tween on `#root`.
+ *
+ * Usage:
+ *   node scripts/demo-video.mjs [options]
+ *   ANTHROPIC_API_KEY=sk-ant-... node scripts/demo-video.mjs   # live AI generate
+ *
+ * Options:
+ *   --out <path>        Output webm path (default: demo/out/megane-demo-<ts>.webm)
+ *   --prompt <text>     Override the Chat prompt from the storyboard
+ *   --width <px>        Viewport width  (default: storyboard config.width)
+ *   --height <px>       Viewport height (default: storyboard config.height)
+ *   --dpr <n>           deviceScaleFactor (default: storyboard config.dpr)
+ *   --no-generate       Skip the live AI call; type the prompt only
+ *   --clean             Remove demo/out before running
+ *
+ * Requires WASM to be built first (`npm run build:wasm`); this script will
+ * build it automatically if the pkg directory is missing.
+ */
+
+import { spawn, execSync } from "child_process";
+import { existsSync, mkdirSync, readdirSync, renameSync, rmSync } from "fs";
+import { join, dirname, isAbsolute } from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+import { createRequire } from "module";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+const OUT_DIR = join(ROOT, "demo", "out");
+
+// Resolve Playwright from the global install (same pattern as dev-preview.mjs).
+const _require = createRequire("/opt/node22/lib/node_modules/");
+const { chromium } = _require("playwright");
+
+// ---- CLI parsing ----
+const args = process.argv.slice(2);
+const hasFlag = (f) => args.includes(f);
+const getFlag = (f, d) => {
+  const i = args.indexOf(f);
+  return i === -1 || i + 1 >= args.length ? d : args[i + 1];
+};
+
+const TIMESTAMP = new Date()
+  .toISOString()
+  .replace(/[:.]/g, "-")
+  .replace("T", "_")
+  .slice(0, 19);
+const PORT = 15473 + Math.floor(Math.random() * 100);
+
+// ---- Storyboard ----
+const { config, scenes } = await import(
+  pathToFileURL(join(__dirname, "demo-script.mjs")).href
+);
+
+const WIDTH = parseInt(getFlag("--width", String(config.width)), 10);
+const HEIGHT = parseInt(getFlag("--height", String(config.height)), 10);
+const DPR = parseFloat(getFlag("--dpr", String(config.dpr)));
+const TRANSITION_MS = config.transitionMs ?? 900;
+const PROMPT = getFlag("--prompt", config.prompt);
+const NO_GENERATE = hasFlag("--no-generate");
+const CLEAN = hasFlag("--clean");
+const API_KEY = process.env.ANTHROPIC_API_KEY || "";
+
+const outArg = getFlag("--out", join(OUT_DIR, `megane-demo-${TIMESTAMP}.webm`));
+const OUT_PATH = isAbsolute(outArg) ? outArg : join(ROOT, outArg);
+
+// ---- Setup helpers (reused from dev-preview.mjs patterns) ----
+
+function ensureWasm() {
+  if (existsSync(join(ROOT, "crates", "megane-wasm", "pkg"))) return;
+  console.log("WASM package not found. Building...");
+  execSync("npm run build:wasm", { cwd: ROOT, stdio: "inherit", timeout: 180000 });
+}
+
+function startViteServer() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("npx", ["vite", "--port", String(PORT), "--host", "127.0.0.1"], {
+      cwd: ROOT,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, NODE_ENV: "development" },
+    });
+    const timeout = setTimeout(() => reject(new Error("Vite did not start in time")), 30000);
+    const handler = (data) => {
+      const line = data.toString();
+      if (line.includes("Local:") && line.includes(String(PORT))) {
+        clearTimeout(timeout);
+        resolve(proc);
+      }
+    };
+    proc.stdout.on("data", handler);
+    proc.stderr.on("data", handler);
+    proc.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+async function waitForApp(page) {
+  await page.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: "domcontentloaded", timeout: 30000 });
+  await page.waitForSelector("canvas", { timeout: 15000 });
+  // The pipeline panel defaults to the Chat tab, so the Editor tab's
+  // `.react-flow` mounts hidden — wait for it attached, not visible.
+  await page.waitForSelector('[data-testid="panel-pipeline"]', { state: "visible", timeout: 15000 });
+  await page.waitForSelector(".react-flow", { state: "attached", timeout: 15000 });
+  await page.waitForTimeout(3000); // let the first render settle
+}
+
+// ---- Zoom engine ----
+// Current #root transform: screen = translate(tx,ty) ∘ scale(s) over local coords,
+// with transform-origin at the top-left. We track it so a target element's
+// untransformed rect can be recovered from its on-screen boundingBox.
+let current = { tx: 0, ty: 0, s: 1 };
+
+async function applyTransform(page, t) {
+  current = t;
+  await page.evaluate(
+    ({ tx, ty, s }) => {
+      const root = document.getElementById("root");
+      if (root) root.style.transform = `translate(${tx}px, ${ty}px) scale(${s})`;
+    },
+    t,
+  );
+}
+
+async function zoomTo(page, spec) {
+  if (spec === "keep") return;
+  if (!spec || spec === "full") {
+    await applyTransform(page, { tx: 0, ty: 0, s: 1 });
+    await page.waitForTimeout(TRANSITION_MS);
+    return;
+  }
+  const { sel, pad = 0, scale } = spec;
+  const box = await page.locator(sel).first().boundingBox();
+  if (!box) {
+    console.warn(`  zoom target not found: ${sel} (skipping)`);
+    return;
+  }
+  // Recover the untransformed (local) rect from the on-screen box.
+  const lx = (box.x - current.tx) / current.s - pad;
+  const ly = (box.y - current.ty) / current.s - pad;
+  const lw = box.width / current.s + 2 * pad;
+  const lh = box.height / current.s + 2 * pad;
+  // `scale` (explicit) zooms by a fixed factor centered on the target — use it
+  // when the target is full-height (fit-to-bbox would compute ~1× and not zoom).
+  // Otherwise fit the padded bbox to the viewport.
+  const s = scale ?? Math.min(WIDTH / lw, HEIGHT / lh);
+  const cx = lx + lw / 2;
+  const cy = ly + lh / 2;
+  await applyTransform(page, { tx: WIDTH / 2 - cx * s, ty: HEIGHT / 2 - cy * s, s });
+  await page.waitForTimeout(TRANSITION_MS);
+}
+
+// ---- Scene actions ("verbs") ----
+
+const SEL = {
+  chatTab: '[data-testid="pipeline-editor-tab-chat"]',
+  editorTab: '[data-testid="pipeline-editor-tab-editor"]',
+  promptBox: 'textarea[placeholder="Describe the pipeline you want..."]',
+  generateBtn: 'button:has-text("Generate")',
+  cancelBtn: 'button:has-text("Cancel")',
+  chatMessages: '[data-testid="pipeline-chat-messages"]',
+  appliedNotice: '[data-testid="pipeline-editor-applied-notice"]',
+  viewer: '[data-testid="viewer-root"]',
+};
+
+const actions = {
+  async openChatAndType(page) {
+    // The panel defaults to the Chat tab, so the textarea is already present.
+    await page.locator(SEL.promptBox).first().waitFor({ state: "visible", timeout: 10000 });
+    // Typewriter effect driven entirely in-page: set the value via React's
+    // native textarea setter and dispatch an `input` event so React picks it up.
+    // This bypasses Playwright actionability (no per-key click/stability checks),
+    // so it stays fast and reliable even while the #root zoom transform is live.
+    for (let i = 1; i <= PROMPT.length; i++) {
+      await page.evaluate(
+        ({ sel, val }) => {
+          const el = document.querySelector(sel);
+          if (!el) return;
+          const setter = Object.getOwnPropertyDescriptor(
+            window.HTMLTextAreaElement.prototype,
+            "value",
+          ).set;
+          setter.call(el, val);
+          el.dispatchEvent(new Event("input", { bubbles: true }));
+        },
+        { sel: SEL.promptBox, val: PROMPT.slice(0, i) },
+      );
+      await page.waitForTimeout(45);
+    }
+  },
+
+  async generate(page) {
+    if (NO_GENERATE || !API_KEY) {
+      console.log("  generate: skipped (no key / --no-generate); prompt left in box");
+      return;
+    }
+    await page.locator(SEL.generateBtn).first().click();
+    // While streaming, the button swaps to "Cancel"; it returns to "Generate"
+    // once the response (and pipeline apply) completes. Wait on that round trip
+    // rather than the applied-notice, which only renders on the Editor tab.
+    await page
+      .locator(SEL.cancelBtn)
+      .first()
+      .waitFor({ state: "visible", timeout: 8000 })
+      .catch(() => {});
+    await page
+      .locator(SEL.generateBtn)
+      .first()
+      .waitFor({ state: "visible", timeout: 30000 })
+      .catch(() => console.log("  generate: still streaming at timeout (recording current state)"));
+  },
+
+  async rotate(page) {
+    const box = await page.locator(SEL.viewer).first().boundingBox();
+    if (!box) return;
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    const r = Math.min(box.width, box.height) * 0.18;
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    const steps = 40;
+    for (let i = 0; i <= steps; i++) {
+      const a = (i / steps) * Math.PI * 1.2;
+      await page.mouse.move(cx + r * Math.cos(a), cy + r * Math.sin(a) * 0.35);
+      await page.waitForTimeout(40);
+    }
+    await page.mouse.up();
+  },
+
+  async showPipeline(page) {
+    await page.locator(SEL.editorTab).first().click();
+    await page.waitForTimeout(500);
+  },
+};
+
+// ---- API key setup (BYOK via the Chat config panel) ----
+async function setupApiKey(page) {
+  if (NO_GENERATE || !API_KEY) return;
+  try {
+    await page.locator(SEL.chatTab).first().click();
+    await page.waitForTimeout(300);
+    await page.locator('button[title="AI Settings"]').first().click();
+    await page.waitForTimeout(300);
+    const keyInput = page.locator('input[type="password"]').first();
+    await keyInput.fill(API_KEY);
+    // Close the config panel, leaving the panel on the Chat tab (its default)
+    // so the chat scene finds the prompt box without an extra tab switch.
+    await page.locator('button[title="AI Settings"]').first().click();
+    await page.waitForTimeout(300);
+    console.log("  API key injected via Chat config panel");
+  } catch (e) {
+    console.warn("  API key setup failed (will fall back to no-generate):", e.message);
+  }
+}
+
+// ---- Main ----
+let server = null;
+let browser = null;
+let context = null;
+
+try {
+  if (CLEAN && existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true });
+  mkdirSync(OUT_DIR, { recursive: true });
+  ensureWasm();
+
+  console.log(`Output: ${OUT_PATH}`);
+  console.log(`Viewport: ${WIDTH}x${HEIGHT} @${DPR}x  | scenes: ${scenes.map((s) => s.id).join(" → ")}`);
+  console.log(`Generate: ${NO_GENERATE ? "off (--no-generate)" : API_KEY ? "live (ANTHROPIC_API_KEY)" : "off (no key)"}`);
+
+  console.log("\nStarting Vite dev server...");
+  server = await startViteServer();
+  console.log(`Vite running on port ${PORT}`);
+
+  browser = await chromium.launch({ headless: true });
+  const tmpDir = join(OUT_DIR, `tmp-${TIMESTAMP}`);
+  mkdirSync(tmpDir, { recursive: true });
+
+  context = await browser.newContext({
+    viewport: { width: WIDTH, height: HEIGHT },
+    deviceScaleFactor: DPR,
+    recordVideo: { dir: tmpDir, size: { width: WIDTH, height: HEIGHT } },
+  });
+  // Suppress the first-run tour overlay.
+  await context.addInitScript(() => {
+    try {
+      localStorage.setItem("megane-tour-prefs", JSON.stringify({ dontShowAgain: true }));
+    } catch {
+      /* noop */
+    }
+  });
+
+  const page = await context.newPage();
+  await waitForApp(page);
+
+  // Make #root zoomable with a smooth tween, anchored at the top-left.
+  await page.evaluate((ms) => {
+    const root = document.getElementById("root");
+    if (root) {
+      root.style.transformOrigin = "0 0";
+      root.style.transition = `transform ${ms}ms cubic-bezier(0.4, 0, 0.2, 1)`;
+      root.style.willChange = "transform";
+    }
+  }, TRANSITION_MS);
+
+  await setupApiKey(page);
+
+  for (const scene of scenes) {
+    console.log(`Scene: ${scene.id}`);
+    const runAction = async () => {
+      if (!scene.action) return;
+      const fn = actions[scene.action];
+      if (!fn) throw new Error(`Unknown action: ${scene.action}`);
+      await fn(page);
+    };
+    // `actionFirst` scenes pull back to full first (so the verb's click targets
+    // are on-screen regardless of the prior zoom), run the verb — which may
+    // reveal the zoom target, e.g. the Editor tab unhiding `.react-flow` — then
+    // frame it.
+    if (scene.actionFirst) {
+      await zoomTo(page, "full");
+      await runAction();
+      await zoomTo(page, scene.zoom);
+    } else {
+      await zoomTo(page, scene.zoom);
+      await runAction();
+    }
+    if (scene.hold) await page.waitForTimeout(scene.hold);
+  }
+
+  // Finalize the recording.
+  await page.close();
+  await context.close();
+  context = null;
+
+  const file = readdirSync(tmpDir).find((f) => f.endsWith(".webm"));
+  if (!file) throw new Error(`No webm produced in ${tmpDir}`);
+  renameSync(join(tmpDir, file), OUT_PATH);
+  rmSync(tmpDir, { recursive: true });
+
+  console.log(`\nDone. Demo video saved: ${OUT_PATH}`);
+} catch (err) {
+  console.error("Demo video failed:", err.message);
+  process.exitCode = 1;
+} finally {
+  if (context) await context.close();
+  if (browser) await browser.close();
+  if (server) server.kill();
+}

--- a/scripts/demo-video.mjs
+++ b/scripts/demo-video.mjs
@@ -11,11 +11,16 @@
  *
  * Options:
  *   --out <path>        Output webm path (default: demo/out/megane-demo-<ts>.webm)
+ *   --url <url>         Record an already-running instance (e.g. the deployed
+ *                       demo site) instead of starting a local Vite server. The
+ *                       demo site's built-in LLM proxy makes generation run with
+ *                       no API key.
  *   --prompt <text>     Override the Chat prompt from the storyboard
  *   --width <px>        Viewport width  (default: storyboard config.width)
  *   --height <px>       Viewport height (default: storyboard config.height)
  *   --dpr <n>           deviceScaleFactor (default: storyboard config.dpr)
  *   --no-generate       Skip the live AI call; type the prompt only
+ *   --generate-timeout <ms>  Max wait for the streamed response (default 45000)
  *   --clean             Remove demo/out before running
  *
  * Requires WASM to be built first (`npm run build:wasm`); this script will
@@ -66,6 +71,15 @@ const PROMPT = getFlag("--prompt", config.prompt);
 const NO_GENERATE = hasFlag("--no-generate");
 const CLEAN = hasFlag("--clean");
 const API_KEY = process.env.ANTHROPIC_API_KEY || "";
+// Point at an already-running instance (e.g. the deployed demo site) instead of
+// spinning up a local Vite server. The demo site ships the free LLM proxy, so
+// generation runs there without an API key.
+const URL = getFlag("--url", "");
+const URL_MODE = URL.length > 0;
+// Run a real generation when we have a key (local BYOK) or a site that provides
+// its own LLM (the deployed demo proxy via --url). Output is non-deterministic.
+const RUN_GENERATE = !NO_GENERATE && (Boolean(API_KEY) || URL_MODE);
+const GENERATE_TIMEOUT_MS = parseInt(getFlag("--generate-timeout", "45000"), 10);
 
 const outArg = getFlag("--out", join(OUT_DIR, `megane-demo-${TIMESTAMP}.webm`));
 const OUT_PATH = isAbsolute(outArg) ? outArg : join(ROOT, outArg);
@@ -102,9 +116,9 @@ function startViteServer() {
   });
 }
 
-async function waitForApp(page) {
-  await page.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: "domcontentloaded", timeout: 30000 });
-  await page.waitForSelector("canvas", { timeout: 15000 });
+async function waitForApp(page, appUrl) {
+  await page.goto(appUrl, { waitUntil: "domcontentloaded", timeout: 30000 });
+  await page.waitForSelector("canvas", { timeout: 20000 });
   // The pipeline panel defaults to the Chat tab, so the Editor tab's
   // `.react-flow` mounts hidden — wait for it attached, not visible.
   await page.waitForSelector('[data-testid="panel-pipeline"]', { state: "visible", timeout: 15000 });
@@ -163,8 +177,10 @@ async function zoomTo(page, spec, ms = TRANSITION_MS) {
   // when the target is full-height (fit-to-bbox would compute ~1× and not zoom).
   // Otherwise fit the padded bbox to the viewport.
   const s = scale ?? Math.min(WIDTH / lw, HEIGHT / lh);
-  const cx = lx + lw / 2;
-  const cy = ly + lh / 2;
+  // anchorX/anchorY pick which point of the element maps to the viewport center
+  // (default the element centre). Biasing anchorY toward 1 frames lower content.
+  const cx = lx + lw * (spec.anchorX ?? 0.5);
+  const cy = ly + lh * (spec.anchorY ?? 0.5);
   await applyTransform(page, { tx: WIDTH / 2 - cx * s, ty: HEIGHT / 2 - cy * s, s });
   await page.waitForTimeout(ms);
 }
@@ -184,7 +200,8 @@ const SEL = {
 };
 
 const actions = {
-  async openChatAndType(page) {
+  // Type the prompt into the Chat input, then submit it (when generation is on).
+  async askChat(page) {
     // The panel defaults to the Chat tab, so the textarea is already present.
     await page.locator(SEL.promptBox).first().waitFor({ state: "visible", timeout: 10000 });
     // Typewriter effect driven entirely in-page: set the value via React's
@@ -207,27 +224,33 @@ const actions = {
       );
       await page.waitForTimeout(45);
     }
-  },
-
-  async generate(page) {
-    if (NO_GENERATE || !API_KEY) {
-      console.log("  generate: skipped (no key / --no-generate); prompt left in box");
+    if (!RUN_GENERATE) {
+      console.log("  askChat: typed prompt; generation off (no key / no site LLM / --no-generate)");
       return;
     }
-    await page.locator(SEL.generateBtn).first().click();
-    // While streaming, the button swaps to "Cancel"; it returns to "Generate"
-    // once the response (and pipeline apply) completes. Wait on that round trip
-    // rather than the applied-notice, which only renders on the Editor tab.
+    // Submit while the input row (and Generate button) is still framed.
+    await page
+      .locator(SEL.generateBtn)
+      .first()
+      .click()
+      .catch((e) => console.log("  askChat: submit click failed:", e.message));
+  },
+
+  // Wait for the streamed response to finish. While streaming the submit button
+  // reads "Cancel"; it returns to "Generate" once the response (and pipeline
+  // apply) completes — a host-agnostic signal that also covers the demo proxy.
+  async waitGenerate(page) {
+    if (!RUN_GENERATE) return;
     await page
       .locator(SEL.cancelBtn)
       .first()
-      .waitFor({ state: "visible", timeout: 8000 })
+      .waitFor({ state: "visible", timeout: 12000 })
       .catch(() => {});
     await page
       .locator(SEL.generateBtn)
       .first()
-      .waitFor({ state: "visible", timeout: 30000 })
-      .catch(() => console.log("  generate: still streaming at timeout (recording current state)"));
+      .waitFor({ state: "visible", timeout: GENERATE_TIMEOUT_MS })
+      .catch(() => console.log("  waitGenerate: still streaming at timeout (recording current state)"));
   },
 
   async rotate(page) {
@@ -280,8 +303,10 @@ const actions = {
 };
 
 // ---- API key setup (BYOK via the Chat config panel) ----
+// Only needed for local BYOK runs. In --url mode the target (e.g. the demo
+// site) provides its own LLM via the built-in proxy, so no key is entered.
 async function setupApiKey(page) {
-  if (NO_GENERATE || !API_KEY) return;
+  if (NO_GENERATE || !API_KEY || URL_MODE) return;
   try {
     await page.locator(SEL.chatTab).first().click();
     await page.waitForTimeout(300);
@@ -307,15 +332,29 @@ let context = null;
 try {
   if (CLEAN && existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true });
   mkdirSync(OUT_DIR, { recursive: true });
-  ensureWasm();
 
+  const genLabel = NO_GENERATE
+    ? "off (--no-generate)"
+    : API_KEY
+      ? "live (ANTHROPIC_API_KEY)"
+      : URL_MODE
+        ? "live (site LLM via --url)"
+        : "off (no key)";
   console.log(`Output: ${OUT_PATH}`);
   console.log(`Viewport: ${WIDTH}x${HEIGHT} @${DPR}x  | scenes: ${scenes.map((s) => s.id).join(" → ")}`);
-  console.log(`Generate: ${NO_GENERATE ? "off (--no-generate)" : API_KEY ? "live (ANTHROPIC_API_KEY)" : "off (no key)"}`);
+  console.log(`Generate: ${genLabel}`);
 
-  console.log("\nStarting Vite dev server...");
-  server = await startViteServer();
-  console.log(`Vite running on port ${PORT}`);
+  let appUrl;
+  if (URL_MODE) {
+    appUrl = URL;
+    console.log(`\nTarget: ${appUrl} (no local server)`);
+  } else {
+    ensureWasm();
+    console.log("\nStarting Vite dev server...");
+    server = await startViteServer();
+    appUrl = `http://127.0.0.1:${PORT}/`;
+    console.log(`Vite running on port ${PORT}`);
+  }
 
   browser = await chromium.launch({ headless: true });
   const tmpDir = join(OUT_DIR, `tmp-${TIMESTAMP}`);
@@ -336,7 +375,7 @@ try {
   });
 
   const page = await context.newPage();
-  await waitForApp(page);
+  await waitForApp(page, appUrl);
 
   // Make #root zoomable with a smooth tween, anchored at the top-left.
   await page.evaluate((ms) => {

--- a/scripts/demo-video.mjs
+++ b/scripts/demo-video.mjs
@@ -364,6 +364,9 @@ try {
     viewport: { width: WIDTH, height: HEIGHT },
     deviceScaleFactor: DPR,
     recordVideo: { dir: tmpDir, size: { width: WIDTH, height: HEIGHT } },
+    // Some networks (e.g. a TLS-intercepting egress proxy) present a cert
+    // Chromium doesn't trust; tolerate it so --url can reach remote sites.
+    ignoreHTTPSErrors: true,
   });
   // Suppress the first-run tour overlay.
   await context.addInitScript(() => {

--- a/scripts/demo-video.mjs
+++ b/scripts/demo-video.mjs
@@ -264,59 +264,17 @@ const actions = {
     await page.mouse.up();
   },
 
-  // Zoom into the pipeline panel (Pipeline/Chat tab bar pinned to the top of the
-  // screen) FIRST, then click the Editor tab on camera so the panel visibly
-  // switches Chat → pipeline graph, then scroll the graph top→bottom (TB dagre
-  // layout).
-  //
-  // Clicking the tab while zoomed is safe here: the node handle positions were
-  // already measured at identity when the pipeline mounted during chat-generate,
-  // and a tab switch / fitView pans the viewport without re-measuring handles —
-  // so the edges stay attached. (The earlier breakage came from the pipeline
-  // mounting *while* a zoom was active, which is now avoided.)
-  async clickPipelineTabAndScroll(page) {
-    const topM = 24;
-    const botM = 56;
-
-    // Frame the panel at ~70% width with its top (the "Pipeline" title + tabs)
-    // pinned to the top. Measure in local coords (camera arrives mid-zoom from
-    // the molecule scene).
-    const pbox = await page.locator(SEL.panelPipeline).first().boundingBox();
-    if (!pbox) return;
-    const plx = (pbox.x - current.tx) / current.s;
-    const ply = (pbox.y - current.ty) / current.s;
-    const plw = pbox.width / current.s;
-    const S = PIPELINE_WIDTH_FRACTION
-      ? (PIPELINE_WIDTH_FRACTION * WIDTH) / plw
-      : PIPELINE_SCROLL_SCALE;
-    const tx = WIDTH / 2 - (plx + plw / 2) * S;
-    const tyTop = topM - ply * S;
-
-    // Zoom in (still on the Chat tab), dwell so the move reads.
-    await setTransition(page, 1100);
-    await applyTransform(page, { tx, ty: tyTop, s: S });
-    await page.waitForTimeout(1100 + 700);
-
-    // Now switch Chat → Editor on camera (tabs are at the top, in frame).
+  // Switch to the Editor tab to reveal the generated pipeline graph. At the full
+  // view (identity) ReactFlow's fitView measures the handles correctly, so the
+  // edges stay attached. We deliberately do NOT zoom here — the recording stays
+  // full-frame and any zoom/pan is done in post.
+  async showPipeline(page) {
     await page
       .locator(SEL.editorTab)
       .first()
       .click()
       .catch((e) => console.log("  editor tab click failed:", e.message));
-    await page.waitForTimeout(1300); // show the switch chat → pipeline graph
-
-    // Scroll down through the graph, keeping the same scale/centre.
-    const rf = await page.locator(SEL.reactFlow).first().boundingBox();
-    if (!rf) return;
-    const rly = (rf.y - current.ty) / current.s;
-    const rlh = rf.height / current.s;
-    const tyBottom = HEIGHT - botM - (rly + rlh) * S;
-    if (rlh * S > HEIGHT - topM - botM) {
-      await setTransition(page, PIPELINE_SCROLL_MS, "linear");
-      await applyTransform(page, { tx, ty: tyBottom, s: S });
-      await page.waitForTimeout(PIPELINE_SCROLL_MS);
-      await setTransition(page, TRANSITION_MS); // restore eased default
-    }
+    await page.waitForTimeout(1200); // let fitView settle
   },
 };
 


### PR DESCRIPTION
Add a storyboard-as-code demo video generator that drives the live app
and records a webm while zooming into UI regions:
full screen -> zoom Chat panel + type prompt -> (live AI generate) ->
rotate molecule -> zoom pipeline graph.

- scripts/demo-script.mjs: declarative scene storyboard (the editable script)
- scripts/demo-video.mjs: director — Vite + Playwright recordVideo, CSS
  transform zoom on #root, named verbs (openChatAndType/generate/rotate/
  showPipeline)
- npm run demo:video; output to demo/out (gitignored)
- document the workflow in the preview skill

Tooling only (no src/ changes), so it is outside Codecov and the E2E
baseline matrix, consistent with the existing scripts/*.mjs preview tools.

https://claude.ai/code/session_017tgauQjrBPaL2ZNjxmspUt