### PR TITLE
fix(ai-chat): raise free-demo daily cap to 30 and generalize rate-limit message

### DIFF
--- a/src/ai/client.ts
+++ b/src/ai/client.ts
@@ -18,13 +18,15 @@ import {
 
 /**
  * Thrown when the backend rejects the request with HTTP 429 — i.e. the
- * shared free-demo proxy's per-IP rate limit (5 requests/day, 3/minute) was
- * exceeded. Carries a user-facing message so the chat surfaces the real
- * reason instead of a generic "something went wrong".
+ * shared free-demo proxy's per-IP rate limit was exceeded. The proxy enforces
+ * both a per-minute and a per-day cap and returns the same 429 for either, so
+ * the message stays generic rather than claiming a specific window. Carries a
+ * user-facing message so the chat surfaces the real reason instead of a
+ * generic "something went wrong".
  */
 export class RateLimitError extends Error {
   constructor(
-    message = "Daily free-demo limit reached (5 requests/day). Try again tomorrow, or add your own API key in settings.",
+    message = "Free demo rate limit reached. Please wait a bit and try again, or add your own API key in settings.",
   ) {
     super(message);
     this.name = "RateLimitError";

--- a/tests/ts/components/PipelineChatBox.test.tsx
+++ b/tests/ts/components/PipelineChatBox.test.tsx
@@ -35,7 +35,7 @@ vi.mock("@/ai/client", () => ({
     return text.slice(lastFenceEnd + 3).trim();
   },
   RateLimitError: class RateLimitError extends Error {
-    constructor(message = "Daily free-demo limit reached (5 requests/day).") {
+    constructor(message = "Free demo rate limit reached. Please wait a bit and try again.") {
       super(message);
       this.name = "RateLimitError";
     }
@@ -412,14 +412,16 @@ describe("PipelineChatBox — applying a generated pipeline", () => {
     expect(screen.queryByText(/429/)).toBeNull();
   });
 
-  it("surfaces the daily-limit message verbatim when the free demo is rate limited", async () => {
+  it("surfaces the rate-limit message verbatim when the free demo is rate limited", async () => {
     (generatePipeline as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
-      new RateLimitError("Daily free-demo limit reached (5 requests/day)."),
+      new RateLimitError("Free demo rate limit reached. Please wait a bit and try again."),
     );
     render(<PipelineChatBox />);
     submit("build me a pipeline");
 
-    expect(await screen.findByText("Daily free-demo limit reached (5 requests/day).")).toBeTruthy();
+    expect(
+      await screen.findByText("Free demo rate limit reached. Please wait a bit and try again."),
+    ).toBeTruthy();
     expect(screen.queryByText("Something went wrong. Please try again.")).toBeNull();
   });
 });

--- a/workers/llm-proxy/src/proxy.ts
+++ b/workers/llm-proxy/src/proxy.ts
@@ -96,7 +96,7 @@ export const MAX_TOOL_NAME_LENGTH = 64;
 export const MAX_TOOL_DESCRIPTION_LENGTH = 1024;
 export const MAX_TOOL_CALL_ID_LENGTH = 256;
 export const PER_MINUTE_LIMIT = 3;
-export const PER_DAY_LIMIT = 5;
+export const PER_DAY_LIMIT = 30;
 
 const MINUTE_TTL_SECONDS = 90;
 const DAY_TTL_SECONDS = 2 * 24 * 60 * 60;

--- a/workers/llm-proxy/test/index.test.ts
+++ b/workers/llm-proxy/test/index.test.ts
@@ -326,8 +326,8 @@ describe("isRateLimited", () => {
     expect(await isRateLimited("5.6.7.8", env)).toBe(false);
   });
 
-  it("caps the free demo at 5 requests per day", () => {
-    expect(PER_DAY_LIMIT).toBe(5);
+  it("caps the free demo at 30 requests per day", () => {
+    expect(PER_DAY_LIMIT).toBe(30);
   });
 
   it("allows a request while still under the per-day limit", async () => {


### PR DESCRIPTION
## Why

After #503 merged, running the demo chat showed **"Something went wrong"**.

I verified against the live worker that the worker + Claude Haiku path is healthy (HTTP 200, valid pipeline generated end-to-end through the real client path). The actual cause is the **per-IP rate limit (429)**:

- The `5/day` cap introduced in #503 is exhausted very quickly during normal/iterative use.
- The proxy returns the same `429` for both the per-minute (3) and per-day caps.
- On hosts still serving an older bundle (the docs site, which only redeploys on version tags), the 429 surfaces as the generic "Something went wrong" instead of a clear message.

## What

- **`workers/llm-proxy/src/proxy.ts`**: raise `PER_DAY_LIMIT` from `5` → `30` (per-minute stays 3).
- **`src/ai/client.ts`**: reword `RateLimitError` so it no longer claims a specific window ("Free demo rate limit reached. Please wait a bit and try again, or add your own API key in settings.") — accurate for both the per-minute and per-day caps.
- Tests updated accordingly (worker cap assertion, component message assertion).

## Verification

- `workers/llm-proxy` tests: 58 passed (includes the 30/day cap assertion).
- `tests/ts/ai/client.test.ts` + `tests/ts/components/PipelineChatBox.test.tsx`: 63 passed.
- ESLint clean, Prettier clean.
- Live worker probe confirmed: valid requests → 200 + valid pipeline; rapid requests → `429 Rate limit exceeded`.

## Deploy note

The worker auto-redeploys on merge (`deploy-llm-proxy.yml`, paths include `workers/llm-proxy/**`), and the S3 demo redeploys via `deploy.yml`. The **docs site** (`hodakamori.github.io`) only redeploys on version tags, so it needs a manual `Deploy Docs` `workflow_dispatch` (with `dry_run: false`) after merge to pick up the new frontend wording.

https://claude.ai/code/session_01N8AcJ2wC8jUmu7CKQJVPtk

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8AcJ2wC8jUmu7CKQJVPtk)_