### PR TITLE
fix(ai-chat): stop pipeline chat from getting stuck and flickering, revert demo to Sonnet

### DIFF
--- a/src/ai/client.ts
+++ b/src/ai/client.ts
@@ -548,11 +548,52 @@ export function extractTrailingExplanation(text: string): string {
 
 // ─── JSON extraction ─────────────────────────────────────────────────
 
+/** Narrow a parsed value to a SerializedPipeline (version 3, nodes/edges arrays). */
+function isSerializedPipeline(value: unknown): value is SerializedPipeline {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return v.version === 3 && Array.isArray(v.nodes) && Array.isArray(v.edges);
+}
+
+/**
+ * Scan every closed ```` ``` ```` fence pair in `text` and return the parsed
+ * pipeline from the *last* one that validates as a SerializedPipeline, or
+ * `null` if none do.
+ *
+ * The system prompt asks for the pipeline JSON first and a one-sentence
+ * explanation last, but a less precise model can stream an earlier fence
+ * (e.g. echoing a fetched skill template) that also happens to be valid
+ * pipeline JSON. Preferring the *last* valid fence picks the model's final
+ * answer over any earlier preamble/template echo.
+ */
+function findLastValidPipeline(text: string): SerializedPipeline | null {
+  const fenceRe = /```(?:json)?\s*\n?([\s\S]*?)```/g;
+  let result: SerializedPipeline | null = null;
+  let match: RegExpExecArray | null;
+  while ((match = fenceRe.exec(text)) !== null) {
+    try {
+      const parsed = JSON.parse(match[1].trim());
+      if (isSerializedPipeline(parsed)) {
+        result = parsed;
+      }
+    } catch {
+      // Not JSON (or not a pipeline) — skip this fence.
+    }
+  }
+  return result;
+}
+
 /**
  * Extract a SerializedPipeline JSON from the LLM response text.
- * Looks for ```json ... ``` fenced blocks, falls back to raw JSON extraction.
+ * Prefers the last closed fence that validates as a pipeline (see
+ * {@link findLastValidPipeline}); falls back to the first ```` ``` ````
+ * fenced block (or raw `{...}` extraction) for precise error reporting when
+ * no fence holds valid pipeline JSON.
  */
 export function extractPipelineJSON(response: string): SerializedPipeline {
+  const fromFence = findLastValidPipeline(response);
+  if (fromFence) return fromFence;
+
   // Try fenced code block first
   const fenceMatch = response.match(/```(?:json)?\s*\n?([\s\S]*?)```/);
   let jsonStr: string;
@@ -590,17 +631,12 @@ export function extractPipelineJSON(response: string): SerializedPipeline {
 /**
  * Try to extract a complete pipeline from a partial streaming buffer, returning
  * the parsed pipeline as soon as a *closed* ```` ```json ```` fence has arrived
- * and validates, or `null` otherwise. Unlike {@link extractPipelineJSON} this
- * never throws on incomplete or invalid input, so it is safe to call on every
- * streamed chunk to apply the graph the instant the JSON finishes — without
- * waiting for the trailing one-sentence explanation. Requiring a closed fence
- * guards against parsing a half-streamed object.
+ * and validates (see {@link findLastValidPipeline}), or `null` otherwise.
+ * Unlike {@link extractPipelineJSON} this never throws on incomplete or
+ * invalid input, so it is safe to call on every streamed chunk to apply (or
+ * re-apply, once a later fence validates) the graph without waiting for the
+ * trailing one-sentence explanation.
  */
 export function tryExtractPipeline(partial: string): SerializedPipeline | null {
-  if (!/```(?:json)?\s*\n?[\s\S]*?```/.test(partial)) return null;
-  try {
-    return extractPipelineJSON(partial);
-  } catch {
-    return null;
-  }
+  return findLastValidPipeline(partial);
 }

--- a/src/components/PipelineChatBox.tsx
+++ b/src/components/PipelineChatBox.tsx
@@ -305,9 +305,12 @@ export function PipelineChatBox({ onPipelineApplied }: { onPipelineApplied?: () 
     // load_structure node has `fileName: null`, and deserialize() clears
     // nodeSnapshots, so we capture the currently loaded structure first and
     // re-attach it to the new loader afterwards — otherwise the loaded
-    // structure would disappear from the viewport. `appliedNodeCount` doubles
-    // as a "have we applied yet?" guard (-1 = not applied).
+    // structure would disappear from the viewport. `appliedJSON` doubles as
+    // a "have we applied yet?" guard (null = not applied) and lets us detect
+    // when a later fence supersedes an earlier one (e.g. a template echoed
+    // before the model's final, customized pipeline).
     let appliedNodeCount = -1;
+    let appliedJSON: string | null = null;
     const applyPipeline = (pipeline: SerializedPipeline) => {
       const preState = usePipelineStore.getState();
       const preserved = captureLoadedStructure(preState.nodes, preState.nodeSnapshots);
@@ -329,6 +332,7 @@ export function PipelineChatBox({ onPipelineApplied }: { onPipelineApplied?: () 
       }
 
       appliedNodeCount = pipeline.nodes.length;
+      appliedJSON = JSON.stringify(pipeline);
       // Surface the result on the editor tab and trigger fitView via the
       // panel's mode-change effect.
       usePipelineUIStore.getState().markPipelineApplied();
@@ -350,12 +354,18 @@ export function PipelineChatBox({ onPipelineApplied }: { onPipelineApplied?: () 
             }
             return updated;
           });
-          // Apply the graph the instant a complete JSON block has streamed in.
-          // The model emits the JSON first, so the viewport updates without
-          // waiting for the trailing one-sentence explanation to finish.
-          if (appliedNodeCount < 0) {
-            const early = tryExtractPipeline(streamBuffer);
-            if (early) applyPipeline(early);
+          // Apply (or re-apply) the graph as soon as a complete JSON block has
+          // streamed in. The model emits the JSON first, so the viewport
+          // updates without waiting for the trailing one-sentence explanation
+          // to finish. A later fence (e.g. the model's final, customized
+          // pipeline after echoing a template) can supersede an earlier one —
+          // re-apply whenever the latest valid fence differs from what's applied.
+          const candidate = tryExtractPipeline(streamBuffer);
+          if (candidate) {
+            const candidateJSON = JSON.stringify(candidate);
+            if (candidateJSON !== appliedJSON) {
+              applyPipeline(candidate);
+            }
           }
         },
         abort.signal,
@@ -363,7 +373,7 @@ export function PipelineChatBox({ onPipelineApplied }: { onPipelineApplied?: () 
 
       // Fallback: the JSON may only have closed in the final, non-streamed text
       // (or arrived after a tool round trip), so apply it now if we haven't yet.
-      if (appliedNodeCount < 0) {
+      if (appliedJSON === null) {
         applyPipeline(extractPipelineJSON(fullResponse));
       }
 
@@ -508,7 +518,21 @@ export function PipelineChatBox({ onPipelineApplied }: { onPipelineApplied?: () 
                 </div>
               );
             }
-            // assistant — action summary lines start with "Pipeline applied"
+            // The live placeholder (last message while streaming) holds raw
+            // model output that may include fenced JSON — show only the
+            // trailing prose that follows the last closed fence, falling
+            // back to a neutral status while the JSON is still streaming.
+            if (isStreaming && i === messages.length - 1) {
+              const prose = extractTrailingExplanation(msg.content);
+              return (
+                <div key={i} style={assistantMsgStyle}>
+                  {prose || "Generating…"}
+                </div>
+              );
+            }
+            // Completed messages already hold their final text (an action
+            // summary or the assistant's explanation) — render it as-is.
+            // Action summary lines start with "Pipeline applied".
             if (msg.content.startsWith("Pipeline applied")) {
               return (
                 <div key={i} style={successMsgStyle}>
@@ -516,15 +540,9 @@ export function PipelineChatBox({ onPipelineApplied }: { onPipelineApplied?: () 
                 </div>
               );
             }
-            // Show the assistant's prose — only the sentence that follows the
-            // JSON payload. While the JSON is still streaming (or the model
-            // emitted only JSON), this is empty and we fall back to a neutral
-            // status. Ignoring any preamble before the JSON keeps the reply
-            // monotonic so it never flickers back to "Generating…".
-            const prose = extractTrailingExplanation(msg.content);
             return (
               <div key={i} style={assistantMsgStyle}>
-                {prose || "Generating…"}
+                {msg.content}
               </div>
             );
           })

--- a/tests/ts/ai/client.test.ts
+++ b/tests/ts/ai/client.test.ts
@@ -118,6 +118,49 @@ describe("extractPipelineJSON", () => {
   });
 });
 
+describe("extractPipelineJSON / tryExtractPipeline — multiple fences", () => {
+  const TEMPLATE_PIPELINE_JSON = JSON.stringify({
+    version: 3,
+    nodes: [{ id: "template-viewport", type: "viewport", position: { x: 0, y: 0 } }],
+    edges: [],
+  });
+  const CUSTOM_PIPELINE_JSON = JSON.stringify({
+    version: 3,
+    nodes: [
+      { id: "loader-1", type: "load_structure", position: { x: 0, y: 0 } },
+      { id: "viewport-1", type: "viewport", position: { x: 0, y: 310 } },
+    ],
+    edges: [],
+  });
+
+  it("extractPipelineJSON picks the last valid pipeline fence over an earlier template echo", () => {
+    const response =
+      `Here's the template:\n\`\`\`json\n${TEMPLATE_PIPELINE_JSON}\n\`\`\`\n` +
+      `Customized for you:\n\`\`\`json\n${CUSTOM_PIPELINE_JSON}\n\`\`\`\nLoads your structure.`;
+    const result = extractPipelineJSON(response);
+    expect(result.nodes).toHaveLength(2);
+    expect(result.nodes[0].id).toBe("loader-1");
+  });
+
+  it("tryExtractPipeline supersedes an earlier closed fence once a later one closes", () => {
+    const partial = `Here's the template:\n\`\`\`json\n${TEMPLATE_PIPELINE_JSON}\n\`\`\`\n`;
+    const early = tryExtractPipeline(partial);
+    expect(early?.nodes).toHaveLength(1);
+
+    const full = `${partial}Customized for you:\n\`\`\`json\n${CUSTOM_PIPELINE_JSON}\n\`\`\``;
+    const later = tryExtractPipeline(full);
+    expect(later?.nodes).toHaveLength(2);
+  });
+
+  it("skips a fenced block that is not valid pipeline JSON and uses a later valid one", () => {
+    const response =
+      `Format example:\n\`\`\`json\n{ "version": 3, "nodes": [...] }\n\`\`\`\n` +
+      `Actual pipeline:\n\`\`\`json\n${CUSTOM_PIPELINE_JSON}\n\`\`\``;
+    const result = extractPipelineJSON(response);
+    expect(result.nodes).toHaveLength(2);
+  });
+});
+
 describe("generatePipeline (Anthropic)", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 

--- a/tests/ts/components/PipelineChatBox.test.tsx
+++ b/tests/ts/components/PipelineChatBox.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
 
 type LoaderNode = { id: string; type?: string; data: { params: Record<string, unknown> } };
 
@@ -18,11 +18,13 @@ vi.mock("@/ai/client", () => ({
   generatePipeline: vi.fn(),
   extractPipelineJSON: vi.fn(),
   // Only resolves once a *closed* fence has streamed in, mirroring the real
-  // helper that drives the early-apply path.
-  tryExtractPipeline: (text: string) =>
+  // helper that drives the early-apply path. Individual tests override this
+  // with `mockImplementation` to simulate multiple, distinguishable fences.
+  tryExtractPipeline: vi.fn((text: string) =>
     /```[\s\S]*?```/.test(text)
       ? { version: 3, nodes: [{ id: "a" }, { id: "b" }], edges: [] }
       : null,
+  ),
   formatActionSummary: (n: number) =>
     `Pipeline applied — ${n} ${n === 1 ? "node" : "nodes"} added to the editor.`,
   // Mirrors the real helper: only the text after the *last* closed fence,
@@ -57,7 +59,7 @@ import {
   replaceTrailingAssistant,
 } from "@/components/PipelineChatBox";
 import { useAIConfigStore } from "@/ai/config";
-import { generatePipeline, extractPipelineJSON, RateLimitError } from "@/ai/client";
+import { generatePipeline, extractPipelineJSON, tryExtractPipeline, RateLimitError } from "@/ai/client";
 
 function openConfigPanel() {
   fireEvent.click(screen.getByTitle("AI Settings"));
@@ -290,6 +292,13 @@ describe("PipelineChatBox — applying a generated pipeline", () => {
       nodes: [{ id: "a" }, { id: "b" }],
       edges: [],
     });
+    // Restore the default single-pipeline behavior; individual tests may
+    // override this with their own mockImplementation.
+    (tryExtractPipeline as ReturnType<typeof vi.fn>).mockImplementation((text: string) =>
+      /```[\s\S]*?```/.test(text)
+        ? { version: 3, nodes: [{ id: "a" }, { id: "b" }], edges: [] }
+        : null,
+    );
   });
 
   function submit(text: string) {
@@ -423,5 +432,70 @@ describe("PipelineChatBox — applying a generated pipeline", () => {
       await screen.findByText("Free demo rate limit reached. Please wait a bit and try again."),
     ).toBeTruthy();
     expect(screen.queryByText("Something went wrong. Please try again.")).toBeNull();
+  });
+
+  it("keeps showing the finished reply once streaming settles instead of reverting to 'Generating…'", async () => {
+    (generatePipeline as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_config, _msg, onChunk: (c: string) => void) => {
+        onChunk('```json\n{ "version": 3, "nodes": [] }\n```\n');
+        onChunk("Loads benzene and shows it with bonds.");
+        return '```json\n{ "version": 3, "nodes": [] }\n```\nLoads benzene and shows it with bonds.';
+      },
+    );
+    render(<PipelineChatBox />);
+    submit("show benzene");
+
+    expect(await screen.findByText("Loads benzene and shows it with bonds.")).toBeTruthy();
+
+    // Wait for the request to settle (the Cancel button reverts to Generate).
+    await waitFor(() => expect(screen.getByText("Generate")).toBeTruthy());
+
+    // The completed message must keep its final text, not revert to the
+    // streaming placeholder.
+    expect(screen.getByText("Loads benzene and shows it with bonds.")).toBeTruthy();
+    expect(screen.queryByText("Generating…")).toBeNull();
+  });
+
+  it("re-applies the pipeline when a later fence supersedes an earlier template echo", async () => {
+    const TEMPLATE_FENCE = '```json\n{ "version": 3, "nodes": [{ "id": "t" }], "edges": [] }\n```';
+    const CUSTOM_FENCE =
+      '```json\n{ "version": 3, "nodes": [{ "id": "x" }, { "id": "y" }, { "id": "z" }], "edges": [] }\n```';
+    const templatePipeline = { version: 3, nodes: [{ id: "t" }], edges: [] };
+    const customPipeline = {
+      version: 3,
+      nodes: [{ id: "x" }, { id: "y" }, { id: "z" }],
+      edges: [],
+    };
+
+    (tryExtractPipeline as ReturnType<typeof vi.fn>).mockImplementation((text: string) => {
+      if (text.includes(CUSTOM_FENCE)) return customPipeline;
+      if (text.includes(TEMPLATE_FENCE)) return templatePipeline;
+      return null;
+    });
+
+    (generatePipeline as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_config, _msg, onChunk: (c: string) => void) => {
+        onChunk(`Here's the template:\n${TEMPLATE_FENCE}\n`);
+        onChunk(`Customized for you:\n${CUSTOM_FENCE}`);
+        return `Here's the template:\n${TEMPLATE_FENCE}\nCustomized for you:\n${CUSTOM_FENCE}`;
+      },
+    );
+
+    render(<PipelineChatBox />);
+    submit("show a molecule");
+
+    expect(
+      await screen.findByText(/Pipeline applied — 3 nodes added to the editor\./),
+    ).toBeTruthy();
+
+    // Applied twice: once for the template echo, once more for the
+    // customized pipeline that supersedes it.
+    expect(storeState.deserialize).toHaveBeenCalledTimes(2);
+    expect(storeState.deserialize).toHaveBeenNthCalledWith(1, templatePipeline);
+    expect(storeState.deserialize).toHaveBeenNthCalledWith(2, customPipeline);
+
+    // The final UI reflects the second (customized) pipeline's node count,
+    // not the first template's.
+    expect(screen.queryByText(/Pipeline applied — 1 node added to the editor\./)).toBeNull();
   });
 });

--- a/workers/llm-proxy/wrangler.toml
+++ b/workers/llm-proxy/wrangler.toml
@@ -9,18 +9,19 @@ compatibility_date = "2025-01-01"
 [vars]
 ALLOWED_ORIGIN = "https://hodakamori.github.io,https://megane.tech-office-mori.com"
 
-# OpenRouter model slug. Set to Anthropic Claude Haiku 3.5 — cheap and fast
-# while still following the pipeline-generation instructions well. To go
-# back to a stronger Sonnet model or down to a free model, just change this
-# value — no code change needed. Leave unset to use the default in
+# OpenRouter model slug. Set to Anthropic Claude Sonnet 4.6 (latest) for
+# strong instruction-following and pipeline generation quality.
+# To downgrade to claude-3.5-haiku (~0.5c) or a free model, just change
+# this value — no code change needed. Leave unset to use the default in
 # src/proxy.ts.
-OPENROUTER_MODEL = "anthropic/claude-3.5-haiku"
+OPENROUTER_MODEL = "anthropic/claude-sonnet-4-6"
 
 # Comma-separated fallback models, used only if the primary errors. Falls
-# back to a free model as a last resort. OpenRouter caps the total routing
-# list at 3, so keep this to at most 2 entries alongside the primary.
-# Unset = the DEFAULT_FALLBACK_MODELS list in src/proxy.ts.
-OPENROUTER_FALLBACK_MODELS = "meta-llama/llama-3.3-70b-instruct:free"
+# back to Haiku (cheap but reliable) then a free model as a last resort.
+# OpenRouter caps the total routing list at 3, so keep this to 2 entries
+# alongside the primary. Unset = the DEFAULT_FALLBACK_MODELS list in
+# src/proxy.ts.
+OPENROUTER_FALLBACK_MODELS = "anthropic/claude-3.5-haiku,meta-llama/llama-3.3-70b-instruct:free"
 
 # Created via `wrangler kv namespace create RATE_LIMIT_KV`. The id is not a
 # secret, so it is committed here directly.


### PR DESCRIPTION
Two render/extraction bugs caused the AI pipeline chat to misbehave
(easier to trigger on Haiku, but model-agnostic):

- extractPipelineJSON/tryExtractPipeline picked the *first* valid
  ```json fence in the response. If the model echoed a template fence
  before its final, customized pipeline, the editor applied the
  template and never updated to the real result. Both helpers now scan
  all closed fences and use the last one that validates as a
  SerializedPipeline, falling back to the original first-fence logic
  (and its error messages) when no fence validates.

- PipelineChatBox re-ran extractTrailingExplanation on every assistant
  message, including ones already finalized with plain-text content by
  replaceTrailingAssistant. Plain text has no fence, so
  extractTrailingExplanation returned "", and the finished reply
  flickered back to "Generating…". Only the live streaming placeholder
  now extracts trailing prose; completed messages render their final
  text directly.

PipelineChatBox also tracks the JSON of the currently-applied pipeline
and re-applies whenever a later closed fence yields a different
pipeline, instead of applying only once.

Also reverts workers/llm-proxy/wrangler.toml's demo model back to
Sonnet 4.6 (primary) with Haiku + a free model as fallbacks.