### PR TITLE
Use CSPRNG for CSP nonce generation instead of Math.random

### DIFF
--- a/tests/ts/vscode/extension.test.ts
+++ b/tests/ts/vscode/extension.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { webcrypto } from "crypto";
 
 interface FakeProvider {
   openCustomDocument: (
@@ -448,6 +449,26 @@ describe("MeganeEditorProvider — structureViewer", () => {
     }
     // Random — collisions across 4 picks of 32-char strings should be effectively impossible.
     expect(seen.size).toBe(4);
+  });
+
+  it("derives the CSP nonce from a CSPRNG, not Math.random", async () => {
+    const getRandomValuesSpy = vi.spyOn(webcrypto, "getRandomValues");
+    const mathRandomSpy = vi.spyOn(Math, "random");
+
+    const provider = getProvider("megane.structureViewer");
+    mockState.readFile.mockResolvedValue(new Uint8Array());
+
+    const doc = { uri: VscodeUri.file("/work/sample.pdb"), dispose: vi.fn() };
+    const { panel } = makeWebviewPanel();
+    await provider.resolveCustomEditor(doc, panel, {});
+
+    const nonce = panel.webview.html.match(/nonce-([A-Za-z0-9]+)/)?.[1];
+    expect(nonce).toHaveLength(32);
+    expect(getRandomValuesSpy).toHaveBeenCalled();
+    expect(mathRandomSpy).not.toHaveBeenCalled();
+
+    getRandomValuesSpy.mockRestore();
+    mathRandomSpy.mockRestore();
   });
 });
 

--- a/vscode-megane/src/extension.ts
+++ b/vscode-megane/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import * as path from "path";
+import { webcrypto } from "crypto";
 
 interface SerializedPipelineNode {
   id: string;
@@ -320,10 +321,14 @@ function getHtmlForWebview(webview: vscode.Webview, mediaDir: vscode.Uri): strin
 }
 
 function getNonce(): string {
-  let text = "";
+  // The nonce backs the webview CSP (`script-src 'nonce-...'`), so it must be
+  // unpredictable. Use a CSPRNG (webcrypto) rather than Math.random().
   const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  for (let i = 0; i < 32; i++) {
-    text += chars.charAt(Math.floor(Math.random() * chars.length));
+  const bytes = new Uint8Array(32);
+  webcrypto.getRandomValues(bytes);
+  let text = "";
+  for (let i = 0; i < bytes.length; i++) {
+    text += chars.charAt(bytes[i] % chars.length);
   }
   return text;
 }


### PR DESCRIPTION
## Summary

Replace `Math.random()` with `webcrypto.getRandomValues()` in the CSP nonce generation function. The nonce backs the webview's `script-src 'nonce-...'` Content Security Policy directive, so it must be cryptographically unpredictable. `Math.random()` is not suitable for security-sensitive use cases.

This change:
- Imports `webcrypto` from Node's `crypto` module in both the extension and test files
- Refactors `getNonce()` to generate 32 random bytes using `webcrypto.getRandomValues()` and map them to the character set
- Adds a test that verifies the nonce is derived from the CSPRNG and not from `Math.random()`

## Test Plan

- [x] Added unit test `derives the CSP nonce from a CSPRNG, not Math.random` that verifies `webcrypto.getRandomValues()` is called and `Math.random()` is not
- [x] `npm test` passes with new test coverage

https://claude.ai/code/session_0161zpBeHzW7PPQyf9EAkgEF