### PR TITLE
Add LLM pipeline-generation benchmark harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ coverage/
 .coverage
 lcov.info
 coverage.xml
+
+# megane LLM benchmark generated results
+bench/llm/results/

--- a/bench/llm/README.md
+++ b/bench/llm/README.md
@@ -1,0 +1,69 @@
+# megane LLM benchmark
+
+Evaluates the quality of megane's **LLM pipeline generator** — the feature that
+turns a natural-language request (e.g. _"show a molecule with bonds"_) into a
+`SerializedPipeline` JSON that the pipeline editor can apply.
+
+It is a prompt-suite + programmatic scorer: each case pairs a realistic request
+with a rubric, and the scorer grades the model's response on four dimensions.
+
+## What it measures
+
+| Dimension | Weight | What it checks |
+|---|---|---|
+| **schema** | 0.35 | Structural validity — parses as a v3 pipeline, exactly one viewport, unique ids, known node types, **type-compatible edges** (reuses `canConnect`/`NODE_PORTS` from `src/pipeline/types.ts`), acyclic, every node reaches a viewport, required inputs connected. |
+| **task** | 0.35 | Task coverage — does the pipeline include the node types, connections, and size the request implies? |
+| **params** | 0.15 | Parameter accuracy — are individual node params right (filter queries, `bondSource`, `excludedCenters`, label `source`, scale/opacity, …)? |
+| **format** | 0.15 | Robustness / output-format compliance — fenced JSON-first output with a single trailing one-sentence explanation, no unclosed fences. |
+
+A dimension with no applicable checks for a case is reported as `—` (n/a) and
+excluded from that case's weighted total (the total is renormalised over the
+dimensions that apply). The total per case is in `[0,1]`; the report also gives
+a **pass rate** (cases ≥ 80%) and per-tag breakdowns.
+
+## Running it (live)
+
+The runner makes **real, paid LLM API calls**, so it is gated behind
+`MEGANE_LLM_BENCH=1`. It reuses vitest as a zero-extra-dependency TS runner.
+
+```bash
+# Anthropic
+MEGANE_LLM_BENCH=1 ANTHROPIC_API_KEY=sk-ant-... \
+  MEGANE_LLM_PROVIDER=anthropic MEGANE_LLM_MODEL=claude-sonnet-4-20250514 \
+  npx vitest run tests/ts/bench/llm.bench.test.ts
+
+# OpenAI
+MEGANE_LLM_BENCH=1 OPENAI_API_KEY=sk-... \
+  MEGANE_LLM_PROVIDER=openai MEGANE_LLM_MODEL=gpt-4o \
+  npx vitest run tests/ts/bench/llm.bench.test.ts
+
+# Demo proxy (no key; picks the model server-side)
+MEGANE_LLM_BENCH=1 MEGANE_LLM_PROVIDER=demo \
+  MEGANE_LLM_PROXY_URL=https://proxy.example.com/chat \
+  npx vitest run tests/ts/bench/llm.bench.test.ts
+```
+
+`npm run bench:llm` is a shortcut for the vitest command (still requires the env
+vars above). Reports are written to `bench/llm/results/<provider>-<model>-<ts>.{json,md}`
+and printed to stdout. The results directory is git-ignored.
+
+## How it stays faithful to production
+
+- The **system prompt** is the production `buildSystemPrompt()` from
+  `src/ai/prompt.ts` (imported, not copied).
+- The **skills** are the same markdown files under `src/ai/skills/` (read from
+  disk; only the loader differs because production uses Vite's
+  `import.meta.glob`).
+- The **JSON extraction** mirrors `src/ai/client.ts` (prefers the last valid
+  fenced pipeline), pinned by unit tests.
+
+The providers use non-streaming requests (the benchmark only needs the final
+text) but otherwise replicate the production tool round-trip behaviour.
+
+## Extending it
+
+Add a case to `bench/llm/dataset.ts` — the scorer and runner are generic. Keep
+rubrics referencing only node types/params the system prompt documents, so a
+perfect model can reach 1.0. Deterministic logic (scorer, extract, skills,
+dataset shape) is covered by `tests/ts/bench/bench-unit.test.ts`, which runs in
+the normal `npm test` suite.

--- a/bench/llm/dataset.ts
+++ b/bench/llm/dataset.ts
@@ -1,0 +1,295 @@
+/**
+ * Benchmark dataset for the megane LLM (pipeline generator).
+ *
+ * Each case is a realistic natural-language request paired with a programmatic
+ * rubric. The rubric only references node types and parameters that the system
+ * prompt (`buildSystemPrompt`) actually documents, so a perfect model can score
+ * 1.0. Cases are tagged by category so the report can break results down by the
+ * kind of request (molecule, crystal, filtering, …).
+ *
+ * To extend the benchmark, add a case here — the scorer and runner are generic.
+ */
+
+import type { BenchCase } from "./types";
+
+/** Read a string parameter off a serialized node without widening to `any`. */
+function str(node: unknown, key: string): string {
+  const v = (node as Record<string, unknown>)[key];
+  return typeof v === "string" ? v : "";
+}
+
+function num(node: unknown, key: string): number {
+  const v = (node as Record<string, unknown>)[key];
+  return typeof v === "number" ? v : NaN;
+}
+
+function arr(node: unknown, key: string): unknown[] {
+  const v = (node as Record<string, unknown>)[key];
+  return Array.isArray(v) ? v : [];
+}
+
+export const DATASET: BenchCase[] = [
+  // ── Basic molecule ───────────────────────────────────────────────────
+  {
+    id: "molecule-basic",
+    prompt: "Show a molecule with its chemical bonds.",
+    tags: ["molecule", "basic"],
+    rubric: {
+      requiredNodeTypes: ["load_structure", "add_bond", "viewport"],
+      requiredConnections: [
+        { sourceType: "load_structure", targetType: "viewport", sourceHandle: "particle" },
+        { sourceType: "add_bond", targetType: "viewport", sourceHandle: "bond", targetHandle: "bond" },
+      ],
+      minNodes: 3,
+    },
+  },
+  {
+    id: "molecule-no-bonds",
+    prompt: "Just display the atoms of my structure, no bonds at all.",
+    tags: ["molecule", "basic"],
+    rubric: {
+      requiredNodeTypes: ["load_structure", "viewport"],
+      forbiddenNodeTypes: ["add_bond"],
+      requiredConnections: [
+        { sourceType: "load_structure", targetType: "viewport", sourceHandle: "particle" },
+      ],
+      maxNodes: 3,
+    },
+  },
+  {
+    id: "molecule-trajectory",
+    prompt: "Load a protein and play its MD trajectory with bonds.",
+    tags: ["molecule", "trajectory"],
+    rubric: {
+      requiredNodeTypes: ["load_structure", "add_bond", "viewport"],
+      requiredConnections: [
+        { sourceType: "add_bond", targetType: "viewport", sourceHandle: "bond", targetHandle: "bond" },
+        { sourceType: "load_trajectory", targetType: "viewport", targetHandle: "trajectory" },
+      ],
+    },
+  },
+
+  // ── Crystalline solids / polyhedra ───────────────────────────────────
+  {
+    id: "crystal-polyhedra",
+    prompt: "Visualize a perovskite crystal with coordination polyhedra around the metal atoms.",
+    tags: ["solid", "polyhedra"],
+    rubric: {
+      requiredNodeTypes: ["load_structure", "polyhedron_generator", "viewport"],
+      requiredConnections: [
+        {
+          sourceType: "polyhedron_generator",
+          targetType: "viewport",
+          sourceHandle: "mesh",
+          targetHandle: "mesh",
+        },
+        { sourceType: "load_structure", targetType: "viewport", sourceHandle: "cell", targetHandle: "cell" },
+      ],
+    },
+  },
+  {
+    id: "crystal-distance-bonds",
+    prompt:
+      "I have a crystal XYZ file without bond records. Show it with distance-based bonds and the unit cell.",
+    tags: ["solid", "bonds"],
+    rubric: {
+      requiredNodeTypes: ["load_structure", "add_bond", "viewport"],
+      requiredConnections: [
+        { sourceType: "load_structure", targetType: "viewport", sourceHandle: "cell", targetHandle: "cell" },
+      ],
+      paramChecks: [
+        {
+          label: 'add_bond.bondSource === "distance"',
+          nodeType: "add_bond",
+          test: (n) => str(n, "bondSource") === "distance",
+        },
+      ],
+    },
+  },
+  {
+    id: "crystal-polyhedra-exclude",
+    prompt:
+      "Show coordination polyhedra for an oxide but skip titanium (Z=22) as a center, keep only the others.",
+    tags: ["solid", "polyhedra", "params"],
+    rubric: {
+      requiredNodeTypes: ["load_structure", "polyhedron_generator", "viewport"],
+      paramChecks: [
+        {
+          label: "polyhedron excludedCenters contains 22 (Ti)",
+          nodeType: "polyhedron_generator",
+          test: (n) => arr(n, "excludedCenters").includes(22),
+        },
+      ],
+    },
+  },
+
+  // ── Filtering ────────────────────────────────────────────────────────
+  {
+    id: "filter-carbon",
+    prompt: "Display only the carbon atoms of my structure.",
+    tags: ["filter", "params"],
+    rubric: {
+      requiredNodeTypes: ["load_structure", "filter", "viewport"],
+      paramChecks: [
+        {
+          label: 'filter.query selects carbon (element == "C")',
+          nodeType: "filter",
+          test: (n) => /element\s*==\s*["']?C["']?/i.test(str(n, "query")),
+        },
+      ],
+    },
+  },
+  {
+    id: "filter-residue",
+    prompt: "Show only the alanine residues (resname ALA).",
+    tags: ["filter", "params"],
+    rubric: {
+      requiredNodeTypes: ["load_structure", "filter", "viewport"],
+      paramChecks: [
+        {
+          label: "filter.query selects resname ALA",
+          nodeType: "filter",
+          test: (n) => /resname\s*==\s*["']?ALA["']?/i.test(str(n, "query")),
+        },
+      ],
+    },
+  },
+  {
+    id: "filter-oxygen-nitrogen",
+    prompt: "Highlight just the oxygen and nitrogen atoms.",
+    tags: ["filter", "params"],
+    rubric: {
+      requiredNodeTypes: ["load_structure", "filter", "viewport"],
+      paramChecks: [
+        {
+          label: "filter.query references both O and N",
+          nodeType: "filter",
+          test: (n) => {
+            const q = str(n, "query");
+            return /["']?O["']?/.test(q) && /["']?N["']?/.test(q) && /\bor\b/i.test(q);
+          },
+        },
+      ],
+    },
+  },
+
+  // ── Modify / appearance ──────────────────────────────────────────────
+  {
+    id: "modify-scale",
+    prompt: "Show the molecule with the atoms drawn at half their normal size.",
+    tags: ["modify", "params"],
+    rubric: {
+      requiredNodeTypes: ["load_structure", "modify", "viewport"],
+      paramChecks: [
+        {
+          label: "modify.scale is around 0.5",
+          nodeType: "modify",
+          test: (n) => Math.abs(num(n, "scale") - 0.5) < 0.2,
+        },
+      ],
+    },
+  },
+  {
+    id: "modify-transparent",
+    prompt: "Make the structure semi-transparent so I can see through it.",
+    tags: ["modify", "params"],
+    rubric: {
+      requiredNodeTypes: ["load_structure", "modify", "viewport"],
+      paramChecks: [
+        {
+          label: "modify.opacity is below 1 (transparent)",
+          nodeType: "modify",
+          test: (n) => num(n, "opacity") < 1 && num(n, "opacity") > 0,
+        },
+      ],
+    },
+  },
+
+  // ── Overlays: labels / vectors ───────────────────────────────────────
+  {
+    id: "labels-element",
+    prompt: "Display the structure and label every atom with its element symbol.",
+    tags: ["overlay", "labels"],
+    rubric: {
+      requiredNodeTypes: ["load_structure", "label_generator", "viewport"],
+      requiredConnections: [
+        {
+          sourceType: "label_generator",
+          targetType: "viewport",
+          sourceHandle: "label",
+          targetHandle: "label",
+        },
+      ],
+      paramChecks: [
+        {
+          label: 'label_generator.source === "element"',
+          nodeType: "label_generator",
+          test: (n) => str(n, "source") === "element",
+        },
+      ],
+    },
+  },
+  {
+    id: "vectors-forces",
+    prompt: "Load forces from a file and draw them as arrows on each atom.",
+    tags: ["overlay", "vectors"],
+    rubric: {
+      requiredNodeTypes: ["load_structure", "load_vector", "vector_overlay", "viewport"],
+      requiredConnections: [
+        {
+          sourceType: "vector_overlay",
+          targetType: "viewport",
+          sourceHandle: "vector",
+          targetHandle: "vector",
+        },
+      ],
+    },
+  },
+
+  // ── Multi-step compositions ──────────────────────────────────────────
+  {
+    id: "multistep-filter-bonds",
+    prompt:
+      "Show my structure with bonds, but only the carbon atoms, and label them with their element.",
+    tags: ["multistep", "filter", "labels"],
+    rubric: {
+      requiredNodeTypes: ["load_structure", "add_bond", "filter", "label_generator", "viewport"],
+      paramChecks: [
+        {
+          label: "filter.query selects carbon",
+          nodeType: "filter",
+          test: (n) => /["']?C["']?/.test(str(n, "query")),
+        },
+      ],
+      minNodes: 5,
+    },
+  },
+
+  // ── Multilingual robustness (Japanese) ───────────────────────────────
+  {
+    id: "molecule-basic-ja",
+    prompt: "分子を結合付きで表示してください。",
+    tags: ["molecule", "multilingual"],
+    rubric: {
+      requiredNodeTypes: ["load_structure", "add_bond", "viewport"],
+      requiredConnections: [
+        { sourceType: "add_bond", targetType: "viewport", sourceHandle: "bond", targetHandle: "bond" },
+      ],
+    },
+  },
+  {
+    id: "filter-carbon-ja",
+    prompt: "炭素原子だけを表示して。",
+    tags: ["filter", "multilingual", "params"],
+    rubric: {
+      requiredNodeTypes: ["load_structure", "filter", "viewport"],
+      paramChecks: [
+        {
+          label: "filter.query selects carbon",
+          nodeType: "filter",
+          test: (n) => /element\s*==\s*["']?C["']?/i.test(str(n, "query")),
+        },
+      ],
+    },
+  },
+];

--- a/bench/llm/extract.ts
+++ b/bench/llm/extract.ts
@@ -1,0 +1,103 @@
+/**
+ * Pipeline JSON extraction for the LLM benchmark.
+ *
+ * This is a faithful port of the pure extraction helpers in
+ * `src/ai/client.ts` (`findLastValidPipeline`, `extractPipelineJSON`,
+ * `tryExtractPipeline`, `stripPipelineJSON`, `extractTrailingExplanation`).
+ * The production helpers live in a module that pulls in Vite-only APIs
+ * (`import.meta.glob` via the skill loader) and browser streaming, so they
+ * cannot be imported under a plain Node/vitest runner. We re-implement only
+ * the IO-free parts here and pin the behaviour with unit tests so the
+ * benchmark scores the *real* extraction contract, not a looser one.
+ */
+
+import type { SerializedPipeline } from "@/pipeline/types";
+
+/** Narrow a parsed value to a SerializedPipeline (version 3, nodes/edges arrays). */
+export function isSerializedPipeline(value: unknown): value is SerializedPipeline {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return v.version === 3 && Array.isArray(v.nodes) && Array.isArray(v.edges);
+}
+
+/**
+ * Scan every closed fence pair and return the parsed pipeline from the *last*
+ * one that validates as a SerializedPipeline, or `null` if none do. Mirrors the
+ * production `findLastValidPipeline`, which prefers the model's final answer
+ * over any earlier template/preamble echo.
+ */
+export function findLastValidPipeline(text: string): SerializedPipeline | null {
+  const fenceRe = /```(?:json)?\s*\n?([\s\S]*?)```/g;
+  let result: SerializedPipeline | null = null;
+  let match: RegExpExecArray | null;
+  while ((match = fenceRe.exec(text)) !== null) {
+    try {
+      const parsed = JSON.parse(match[1].trim());
+      if (isSerializedPipeline(parsed)) {
+        result = parsed;
+      }
+    } catch {
+      // Not JSON (or not a pipeline) — skip this fence.
+    }
+  }
+  return result;
+}
+
+/** Result of a tolerant extraction attempt against a full model response. */
+export interface ExtractionResult {
+  /** The parsed pipeline, or null when nothing valid was found. */
+  pipeline: SerializedPipeline | null;
+  /** How the pipeline (if any) was recovered. Drives the format dimension. */
+  source: "fenced" | "bare" | "none";
+  /** Number of closed fenced blocks (any language) in the response. */
+  fenceCount: number;
+  /** Whether a fenced block was left unclosed (odd number of ``` markers). */
+  hasUnclosedFence: boolean;
+}
+
+/**
+ * Tolerant extraction used by the benchmark. Unlike the production
+ * `extractPipelineJSON` (which throws for precise UI error reporting), this
+ * never throws — a malformed response simply scores zero on schema/format.
+ * It records *how* the pipeline was recovered so the format dimension can
+ * reward fenced output over a bare `{...}` fallback.
+ */
+export function extractPipeline(response: string): ExtractionResult {
+  const markerCount = (response.match(/```/g) ?? []).length;
+  const hasUnclosedFence = markerCount % 2 !== 0;
+  const fenceCount = Math.floor(markerCount / 2);
+
+  const fromFence = findLastValidPipeline(response);
+  if (fromFence) {
+    return { pipeline: fromFence, source: "fenced", fenceCount, hasUnclosedFence };
+  }
+
+  // Fallback: first `{` to last `}` (matches the production fallback path).
+  const start = response.indexOf("{");
+  const end = response.lastIndexOf("}");
+  if (start !== -1 && end > start) {
+    try {
+      const parsed = JSON.parse(response.slice(start, end + 1));
+      if (isSerializedPipeline(parsed)) {
+        return { pipeline: parsed, source: "bare", fenceCount, hasUnclosedFence };
+      }
+    } catch {
+      // fall through
+    }
+  }
+
+  return { pipeline: null, source: "none", fenceCount, hasUnclosedFence };
+}
+
+/**
+ * Return only the natural-language explanation that follows the *last* closed
+ * fence, or an empty string when no fence has closed yet. Mirrors the
+ * production `extractTrailingExplanation`.
+ */
+export function extractTrailingExplanation(text: string): string {
+  const lastFenceEnd = text.lastIndexOf("```");
+  if (lastFenceEnd === -1) return "";
+  const fenceCount = (text.match(/```/g) ?? []).length;
+  if (fenceCount % 2 !== 0) return "";
+  return text.slice(lastFenceEnd + 3).trim();
+}

--- a/bench/llm/providers.ts
+++ b/bench/llm/providers.ts
@@ -1,0 +1,226 @@
+/**
+ * Live LLM providers for the benchmark.
+ *
+ * These mirror the production request shapes in `src/ai/client.ts` (same system
+ * prompt via `buildSystemPrompt`, same on-demand skill tool round trips) but
+ * use non-streaming requests for simplicity — the benchmark only needs the
+ * final text. Supports Anthropic, OpenAI, and the demo proxy.
+ *
+ * API credentials come from the environment:
+ *   - ANTHROPIC_API_KEY  (provider "anthropic")
+ *   - OPENAI_API_KEY     (provider "openai")
+ *   - MEGANE_LLM_PROXY_URL (provider "demo")
+ */
+
+import { buildSystemPrompt } from "@/ai/prompt";
+import {
+  buildOpenAITools,
+  buildToolDefinitions,
+  executeSkill,
+  loadSkills,
+  type BenchSkill,
+} from "./skills";
+
+export type ProviderName = "anthropic" | "openai" | "demo";
+
+export interface ProviderConfig {
+  provider: ProviderName;
+  /** Model id; ignored for the demo proxy (it picks server-side). */
+  model: string;
+  /** API key (anthropic/openai). */
+  apiKey?: string;
+  /** Demo proxy URL. */
+  proxyUrl?: string;
+}
+
+/** Pluggable fetch (defaults to global fetch) — lets tests inject a stub. */
+export type FetchLike = typeof fetch;
+
+const MAX_TOOL_ROUNDS = 4;
+
+/** Resolve a provider config from environment variables. */
+export function configFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): ProviderConfig {
+  const provider = (env.MEGANE_LLM_PROVIDER as ProviderName) || "anthropic";
+  if (provider === "anthropic") {
+    return {
+      provider,
+      model: env.MEGANE_LLM_MODEL || "claude-sonnet-4-20250514",
+      apiKey: env.ANTHROPIC_API_KEY,
+    };
+  }
+  if (provider === "openai") {
+    return {
+      provider,
+      model: env.MEGANE_LLM_MODEL || "gpt-4o",
+      apiKey: env.OPENAI_API_KEY,
+    };
+  }
+  return { provider: "demo", model: "demo", proxyUrl: env.MEGANE_LLM_PROXY_URL };
+}
+
+/** Throw a clear error if the config is missing required credentials. */
+export function assertConfig(config: ProviderConfig): void {
+  if (config.provider === "anthropic" && !config.apiKey) {
+    throw new Error("ANTHROPIC_API_KEY is not set");
+  }
+  if (config.provider === "openai" && !config.apiKey) {
+    throw new Error("OPENAI_API_KEY is not set");
+  }
+  if (config.provider === "demo" && !config.proxyUrl) {
+    throw new Error("MEGANE_LLM_PROXY_URL is not set");
+  }
+}
+
+/**
+ * Generate a pipeline response for one prompt. Returns the full model text
+ * (JSON code block + trailing explanation), ready to hand to the scorer.
+ */
+export async function generatePipelineLive(
+  config: ProviderConfig,
+  userMessage: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<string> {
+  const system = buildSystemPrompt();
+  const skills = loadSkills();
+  if (config.provider === "anthropic") {
+    return runAnthropic(config, system, userMessage, skills, fetchImpl);
+  }
+  return runOpenAICompat(config, system, userMessage, skills, fetchImpl);
+}
+
+// ─── Anthropic ────────────────────────────────────────────────────────
+
+interface AnthropicContentBlock {
+  type: string;
+  text?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+}
+
+async function runAnthropic(
+  config: ProviderConfig,
+  system: string,
+  userMessage: string,
+  skills: BenchSkill[],
+  fetchImpl: FetchLike,
+): Promise<string> {
+  const tools = buildToolDefinitions(skills);
+  const messages: Array<{ role: string; content: unknown }> = [
+    { role: "user", content: userMessage },
+  ];
+
+  for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+    const body: Record<string, unknown> = {
+      model: config.model,
+      max_tokens: 4096,
+      system,
+      messages,
+    };
+    if (tools.length > 0) body.tools = tools;
+
+    const res = await fetchImpl("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "x-api-key": config.apiKey ?? "",
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      throw new Error(`Anthropic request failed (${res.status}): ${await res.text()}`);
+    }
+
+    const data = (await res.json()) as {
+      content: AnthropicContentBlock[];
+      stop_reason: string;
+    };
+    const text = data.content
+      .filter((b) => b.type === "text")
+      .map((b) => b.text ?? "")
+      .join("");
+
+    if (data.stop_reason !== "tool_use") return text;
+
+    // Echo assistant content, answer each tool_use with the skill body.
+    messages.push({ role: "assistant", content: data.content });
+    const toolResults = data.content
+      .filter((b) => b.type === "tool_use")
+      .map((b) => ({
+        type: "tool_result",
+        tool_use_id: b.id,
+        content: executeSkill(skills, b.name ?? "") ?? `Unknown skill: ${b.name}`,
+      }));
+    messages.push({ role: "user", content: toolResults });
+  }
+
+  throw new Error("Too many tool-use rounds");
+}
+
+// ─── OpenAI-compatible (OpenAI + demo proxy) ──────────────────────────
+
+interface OpenAIToolCall {
+  id: string;
+  function: { name: string; arguments: string };
+}
+
+interface OpenAIMessage {
+  role: string;
+  content: string | null;
+  tool_calls?: OpenAIToolCall[];
+  tool_call_id?: string;
+}
+
+async function runOpenAICompat(
+  config: ProviderConfig,
+  system: string,
+  userMessage: string,
+  skills: BenchSkill[],
+  fetchImpl: FetchLike,
+): Promise<string> {
+  const tools = buildOpenAITools(skills);
+  const messages: OpenAIMessage[] = [
+    { role: "system", content: system },
+    { role: "user", content: userMessage },
+  ];
+  const isDemo = config.provider === "demo";
+  const url = isDemo ? config.proxyUrl! : "https://api.openai.com/v1/chat/completions";
+
+  for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+    const body: Record<string, unknown> = { messages };
+    if (!isDemo) body.model = config.model;
+    if (tools.length > 0) body.tools = tools;
+
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (!isDemo) headers.Authorization = `Bearer ${config.apiKey ?? ""}`;
+
+    const res = await fetchImpl(url, { method: "POST", headers, body: JSON.stringify(body) });
+    if (!res.ok) {
+      throw new Error(`${config.provider} request failed (${res.status}): ${await res.text()}`);
+    }
+
+    const data = (await res.json()) as {
+      choices: Array<{ message: OpenAIMessage; finish_reason: string }>;
+    };
+    const choice = data.choices[0];
+    const msg = choice.message;
+
+    if (choice.finish_reason !== "tool_calls" || !msg.tool_calls?.length) {
+      return msg.content ?? "";
+    }
+
+    messages.push({ role: "assistant", content: msg.content ?? null, tool_calls: msg.tool_calls });
+    for (const tc of msg.tool_calls) {
+      messages.push({
+        role: "tool",
+        tool_call_id: tc.id,
+        content: executeSkill(skills, tc.function.name) ?? `Unknown skill: ${tc.function.name}`,
+      });
+    }
+  }
+
+  throw new Error("Too many tool-use rounds");
+}

--- a/bench/llm/report.ts
+++ b/bench/llm/report.ts
@@ -1,0 +1,156 @@
+/**
+ * Aggregation and report rendering for the LLM benchmark.
+ *
+ * Produces both a machine-readable JSON record and a human-readable Markdown
+ * summary (overall scores, per-dimension means, per-tag breakdown, and a
+ * per-case table) so runs can be diffed across models over time.
+ */
+
+import type { BenchCase } from "./types";
+import type { CaseScore, DimensionName } from "./scorer";
+
+const DIMENSIONS: DimensionName[] = ["schema", "task", "params", "format"];
+
+/** One case's full outcome. */
+export interface CaseRecord {
+  case: BenchCase;
+  /** Raw model response (may be omitted from compact reports). */
+  response: string;
+  score: CaseScore;
+  /** Wall-clock latency of the generation call in ms. */
+  latencyMs?: number;
+  /** Set when the generation call threw instead of returning text. */
+  error?: string;
+}
+
+function mean(xs: number[]): number {
+  return xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0;
+}
+
+/** Mean over the records where a dimension applied (score !== null). */
+function meanDimension(records: CaseRecord[], dim: DimensionName): number {
+  const vals = records.map((r) => r.score[dim].score).filter((s): s is number => s !== null);
+  return mean(vals);
+}
+
+export interface Aggregate {
+  count: number;
+  meanTotal: number;
+  /** Fraction of cases scoring >= `passThreshold`. */
+  passRate: number;
+  passThreshold: number;
+  byDimension: Record<DimensionName, number>;
+  byTag: Record<string, { count: number; meanTotal: number }>;
+}
+
+export function aggregate(records: CaseRecord[], passThreshold = 0.8): Aggregate {
+  const byTag: Record<string, { count: number; meanTotal: number }> = {};
+  const tagTotals: Record<string, number[]> = {};
+  for (const r of records) {
+    for (const tag of r.case.tags) {
+      (tagTotals[tag] ??= []).push(r.score.total);
+    }
+  }
+  for (const [tag, totals] of Object.entries(tagTotals)) {
+    byTag[tag] = { count: totals.length, meanTotal: mean(totals) };
+  }
+
+  const byDimension = Object.fromEntries(
+    DIMENSIONS.map((d) => [d, meanDimension(records, d)]),
+  ) as Record<DimensionName, number>;
+
+  return {
+    count: records.length,
+    meanTotal: mean(records.map((r) => r.score.total)),
+    passRate: records.length
+      ? records.filter((r) => r.score.total >= passThreshold).length / records.length
+      : 0,
+    passThreshold,
+    byDimension,
+    byTag,
+  };
+}
+
+export interface ReportMeta {
+  provider: string;
+  model: string;
+  timestamp: string;
+}
+
+/** Full JSON report payload. */
+export function toJSON(meta: ReportMeta, records: CaseRecord[], agg: Aggregate) {
+  return {
+    meta,
+    aggregate: agg,
+    cases: records.map((r) => ({
+      id: r.case.id,
+      tags: r.case.tags,
+      prompt: r.case.prompt,
+      total: r.score.total,
+      dimensions: {
+        schema: r.score.schema.score,
+        task: r.score.task.score,
+        params: r.score.params.score,
+        format: r.score.format.score,
+      },
+      failedChecks: DIMENSIONS.flatMap((d) =>
+        r.score[d].checks.filter((c) => !c.passed).map((c) => `${d}: ${c.label}`),
+      ),
+      latencyMs: r.latencyMs,
+      error: r.error,
+    })),
+  };
+}
+
+function pct(x: number | null): string {
+  return x === null ? "—" : `${Math.round(x * 100)}%`;
+}
+
+/** Render a Markdown summary. */
+export function toMarkdown(meta: ReportMeta, records: CaseRecord[], agg: Aggregate): string {
+  const lines: string[] = [];
+  lines.push(`# megane LLM benchmark`);
+  lines.push("");
+  lines.push(`- **provider**: ${meta.provider}`);
+  lines.push(`- **model**: ${meta.model}`);
+  lines.push(`- **timestamp**: ${meta.timestamp}`);
+  lines.push(`- **cases**: ${agg.count}`);
+  lines.push(`- **mean total**: ${pct(agg.meanTotal)}`);
+  lines.push(`- **pass rate (>= ${pct(agg.passThreshold)})**: ${pct(agg.passRate)}`);
+  lines.push("");
+  lines.push(`## By dimension`);
+  lines.push("");
+  lines.push(`| schema | task | params | format |`);
+  lines.push(`|---|---|---|---|`);
+  lines.push(
+    `| ${pct(agg.byDimension.schema)} | ${pct(agg.byDimension.task)} | ` +
+      `${pct(agg.byDimension.params)} | ${pct(agg.byDimension.format)} |`,
+  );
+  lines.push("");
+  lines.push(`## By tag`);
+  lines.push("");
+  lines.push(`| tag | cases | mean |`);
+  lines.push(`|---|---|---|`);
+  for (const [tag, { count, meanTotal }] of Object.entries(agg.byTag).sort()) {
+    lines.push(`| ${tag} | ${count} | ${pct(meanTotal)} |`);
+  }
+  lines.push("");
+  lines.push(`## Per case`);
+  lines.push("");
+  lines.push(`| case | total | schema | task | params | format | failures |`);
+  lines.push(`|---|---|---|---|---|---|---|`);
+  for (const r of records) {
+    const s = r.score;
+    const failures = r.error
+      ? `error: ${r.error}`
+      : DIMENSIONS.flatMap((d) =>
+          s[d].checks.filter((c) => !c.passed).map((c) => `${d}/${c.label}`),
+        ).join("; ") || "—";
+    lines.push(
+      `| ${r.case.id} | ${pct(s.total)} | ${pct(s.schema.score)} | ${pct(s.task.score)} | ` +
+        `${pct(s.params.score)} | ${pct(s.format.score)} | ${failures} |`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}

--- a/bench/llm/runner.ts
+++ b/bench/llm/runner.ts
@@ -1,0 +1,52 @@
+/**
+ * Benchmark orchestration: run every case through a generate function and
+ * score the responses. The generate function is injected so this module is
+ * fully testable without the network — the live runner passes
+ * `generatePipelineLive`, tests pass a stub.
+ */
+
+import { scoreResponse } from "./scorer";
+import type { CaseRecord } from "./report";
+import type { BenchCase } from "./types";
+
+/** Produce a model response for one prompt. */
+export type GenerateFn = (prompt: string) => Promise<string>;
+
+export interface RunOptions {
+  /** Called after each case completes (for progress logging). */
+  onResult?: (record: CaseRecord, index: number, total: number) => void;
+}
+
+/**
+ * Run every case through `generate`, scoring each response. A generation error
+ * is captured per case (scored as an empty response → total 0) so one failure
+ * never aborts the whole run.
+ */
+export async function runDataset(
+  cases: BenchCase[],
+  generate: GenerateFn,
+  options: RunOptions = {},
+): Promise<CaseRecord[]> {
+  const records: CaseRecord[] = [];
+  for (let i = 0; i < cases.length; i++) {
+    const c = cases[i];
+    const start = Date.now();
+    let response = "";
+    let error: string | undefined;
+    try {
+      response = await generate(c.prompt);
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    }
+    const record: CaseRecord = {
+      case: c,
+      response,
+      score: scoreResponse(response, c.rubric),
+      latencyMs: Date.now() - start,
+      error,
+    };
+    records.push(record);
+    options.onResult?.(record, i, cases.length);
+  }
+  return records;
+}

--- a/bench/llm/scorer.ts
+++ b/bench/llm/scorer.ts
@@ -1,0 +1,341 @@
+/**
+ * Scorer for the megane LLM (pipeline-generation) benchmark.
+ *
+ * Given a model's raw response and a per-case rubric, this computes four
+ * sub-scores in [0,1] and a weighted total:
+ *
+ *   1. schema   — structural / schema validity (reuses the production port and
+ *                 connection-typing rules from `@/pipeline/types`).
+ *   2. task     — task coverage: did the pipeline include the node types,
+ *                 connections, and size the request implies?
+ *   3. params   — parameter accuracy: are individual node parameters correct
+ *                 (filter queries, bond sources, excluded centers, …)?
+ *   4. format   — robustness / output-format compliance: fenced JSON-first
+ *                 output with a single trailing one-sentence explanation.
+ *
+ * A dimension with no applicable checks for a case is reported as `null`
+ * ("n/a") and excluded from the weighted total, which is renormalised over the
+ * dimensions that do apply.
+ */
+
+import {
+  NODE_PORTS,
+  canConnect,
+  type PipelineNodeType,
+  type SerializedPipeline,
+} from "@/pipeline/types";
+import { extractPipeline, extractTrailingExplanation, type ExtractionResult } from "./extract";
+
+/** A single serialized node (with id/position/params flattened). */
+export type SerializedNode = SerializedPipeline["nodes"][number];
+
+/** One pass/fail check with a human-readable label. */
+export interface CheckResult {
+  label: string;
+  passed: boolean;
+}
+
+/** A dimension's outcome: `score` is null when the dimension does not apply. */
+export interface DimensionResult {
+  score: number | null;
+  checks: CheckResult[];
+}
+
+// ─── Rubric ───────────────────────────────────────────────────────────
+
+/** A required edge expressed in terms of the node *types* it connects. */
+export interface ConnectionReq {
+  label?: string;
+  sourceType: PipelineNodeType;
+  targetType: PipelineNodeType;
+  /** Optional output-port name on the source (e.g. "bond"). */
+  sourceHandle?: string;
+  /** Optional input-port name on the target (e.g. "bond"). */
+  targetHandle?: string;
+}
+
+/** A predicate over a node selected by type (and optional occurrence index). */
+export interface ParamCheck {
+  label: string;
+  nodeType: PipelineNodeType;
+  /** 0-based index among nodes of `nodeType`. Defaults to 0 (the first). */
+  index?: number;
+  test: (node: SerializedNode) => boolean;
+}
+
+/** Per-case grading rubric. Any field may be omitted. */
+export interface Rubric {
+  requiredNodeTypes?: PipelineNodeType[];
+  forbiddenNodeTypes?: PipelineNodeType[];
+  requiredConnections?: ConnectionReq[];
+  minNodes?: number;
+  maxNodes?: number;
+  paramChecks?: ParamCheck[];
+}
+
+/** Relative weights for the weighted total (renormalised over applicable dims). */
+export const DIMENSION_WEIGHTS = {
+  schema: 0.35,
+  task: 0.35,
+  params: 0.15,
+  format: 0.15,
+} as const;
+
+export type DimensionName = keyof typeof DIMENSION_WEIGHTS;
+
+export interface CaseScore {
+  schema: DimensionResult;
+  task: DimensionResult;
+  params: DimensionResult;
+  format: DimensionResult;
+  /** Weighted total in [0,1] over the dimensions that apply. */
+  total: number;
+  /** The pipeline recovered from the response (null when none was valid). */
+  pipeline: SerializedPipeline | null;
+  /** How the pipeline was recovered + fence accounting. */
+  extraction: ExtractionResult;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+function fraction(checks: CheckResult[]): number {
+  if (checks.length === 0) return 1;
+  return checks.filter((c) => c.passed).length / checks.length;
+}
+
+/** Map node id -> node type for a serialized pipeline. */
+function typeById(pipeline: SerializedPipeline): Map<string, PipelineNodeType> {
+  const m = new Map<string, PipelineNodeType>();
+  for (const n of pipeline.nodes) m.set(n.id, n.type as PipelineNodeType);
+  return m;
+}
+
+/** Detect a cycle via Kahn's algorithm; true when the graph is acyclic. */
+function isAcyclic(pipeline: SerializedPipeline): boolean {
+  const indeg = new Map<string, number>();
+  const adj = new Map<string, string[]>();
+  for (const n of pipeline.nodes) {
+    indeg.set(n.id, 0);
+    adj.set(n.id, []);
+  }
+  for (const e of pipeline.edges) {
+    if (!indeg.has(e.target) || !adj.has(e.source)) continue;
+    indeg.set(e.target, (indeg.get(e.target) ?? 0) + 1);
+    adj.get(e.source)!.push(e.target);
+  }
+  const queue = [...indeg.entries()].filter(([, d]) => d === 0).map(([id]) => id);
+  let visited = 0;
+  while (queue.length) {
+    const id = queue.shift()!;
+    visited++;
+    for (const next of adj.get(id) ?? []) {
+      indeg.set(next, (indeg.get(next) ?? 0) - 1);
+      if (indeg.get(next) === 0) queue.push(next);
+    }
+  }
+  return visited === pipeline.nodes.length;
+}
+
+/** Every non-viewport node must be an ancestor of a viewport node. */
+function allReachToViewport(pipeline: SerializedPipeline): boolean {
+  const viewportIds = pipeline.nodes.filter((n) => n.type === "viewport").map((n) => n.id);
+  if (viewportIds.length === 0) return false;
+  const preds = new Map<string, string[]>();
+  for (const n of pipeline.nodes) preds.set(n.id, []);
+  for (const e of pipeline.edges) preds.get(e.target)?.push(e.source);
+  const visited = new Set(viewportIds);
+  const queue = [...viewportIds];
+  while (queue.length) {
+    const id = queue.shift()!;
+    for (const p of preds.get(id) ?? []) {
+      if (!visited.has(p)) {
+        visited.add(p);
+        queue.push(p);
+      }
+    }
+  }
+  return pipeline.nodes.every((n) => n.type === "viewport" || visited.has(n.id));
+}
+
+// ─── Dimension 1: schema / structural validity ────────────────────────
+
+export function scoreSchema(pipeline: SerializedPipeline | null): DimensionResult {
+  if (!pipeline) {
+    return { score: 0, checks: [{ label: "parses as a v3 pipeline", passed: false }] };
+  }
+
+  const types = typeById(pipeline);
+  const ids = pipeline.nodes.map((n) => n.id);
+  const viewportCount = pipeline.nodes.filter((n) => n.type === "viewport").length;
+
+  const knownTypes = pipeline.nodes.every((n) => (n.type as string) in NODE_PORTS);
+
+  const edgesReferenceExisting = pipeline.edges.every(
+    (e) => types.has(e.source) && types.has(e.target),
+  );
+
+  // Type-correct edges (only meaningful when endpoints + types are known).
+  const edgesTypeValid =
+    edgesReferenceExisting &&
+    knownTypes &&
+    pipeline.edges.every((e) =>
+      canConnect(
+        types.get(e.source)!,
+        e.sourceHandle,
+        types.get(e.target)!,
+        e.targetHandle,
+      ),
+    );
+
+  // Nodes that declare inputs must have at least one incoming edge.
+  const incoming = new Set(pipeline.edges.map((e) => e.target));
+  const requiredInputsConnected =
+    knownTypes &&
+    pipeline.nodes.every((n) => {
+      const ports = NODE_PORTS[n.type as PipelineNodeType];
+      return !ports || ports.inputs.length === 0 || incoming.has(n.id);
+    });
+
+  const checks: CheckResult[] = [
+    { label: "parses as a v3 pipeline", passed: true },
+    { label: "exactly one viewport node", passed: viewportCount === 1 },
+    { label: "all node ids unique", passed: new Set(ids).size === ids.length },
+    { label: "all node types are known", passed: knownTypes },
+    { label: "edges reference existing nodes", passed: edgesReferenceExisting },
+    { label: "edges connect type-compatible ports", passed: edgesTypeValid },
+    { label: "nodes with inputs are connected", passed: requiredInputsConnected },
+    { label: "graph is acyclic", passed: isAcyclic(pipeline) },
+    { label: "all nodes reach a viewport", passed: allReachToViewport(pipeline) },
+  ];
+
+  return { score: fraction(checks), checks };
+}
+
+// ─── Dimension 2: task coverage ───────────────────────────────────────
+
+export function scoreTask(pipeline: SerializedPipeline | null, rubric: Rubric): DimensionResult {
+  const checks: CheckResult[] = [];
+  const present = new Set((pipeline?.nodes ?? []).map((n) => n.type));
+  const types = pipeline ? typeById(pipeline) : new Map<string, PipelineNodeType>();
+
+  for (const t of rubric.requiredNodeTypes ?? []) {
+    checks.push({ label: `includes a ${t} node`, passed: present.has(t) });
+  }
+  for (const t of rubric.forbiddenNodeTypes ?? []) {
+    checks.push({ label: `omits ${t} node`, passed: !present.has(t) });
+  }
+  for (const c of rubric.requiredConnections ?? []) {
+    const label =
+      c.label ??
+      `connects ${c.sourceType}${c.sourceHandle ? `(${c.sourceHandle})` : ""} -> ` +
+        `${c.targetType}${c.targetHandle ? `(${c.targetHandle})` : ""}`;
+    const passed = (pipeline?.edges ?? []).some(
+      (e) =>
+        types.get(e.source) === c.sourceType &&
+        types.get(e.target) === c.targetType &&
+        (c.sourceHandle === undefined || e.sourceHandle === c.sourceHandle) &&
+        (c.targetHandle === undefined || e.targetHandle === c.targetHandle),
+    );
+    checks.push({ label, passed });
+  }
+  if (rubric.minNodes !== undefined) {
+    checks.push({
+      label: `>= ${rubric.minNodes} nodes`,
+      passed: (pipeline?.nodes.length ?? 0) >= rubric.minNodes,
+    });
+  }
+  if (rubric.maxNodes !== undefined) {
+    checks.push({
+      label: `<= ${rubric.maxNodes} nodes`,
+      passed: (pipeline?.nodes.length ?? 0) <= rubric.maxNodes,
+    });
+  }
+
+  if (checks.length === 0) return { score: null, checks };
+  return { score: fraction(checks), checks };
+}
+
+// ─── Dimension 3: parameter accuracy ──────────────────────────────────
+
+export function scoreParams(pipeline: SerializedPipeline | null, rubric: Rubric): DimensionResult {
+  const paramChecks = rubric.paramChecks ?? [];
+  if (paramChecks.length === 0) return { score: null, checks: [] };
+
+  const checks: CheckResult[] = paramChecks.map((pc) => {
+    const matches = (pipeline?.nodes ?? []).filter((n) => n.type === pc.nodeType);
+    const node = matches[pc.index ?? 0];
+    let passed = false;
+    if (node) {
+      try {
+        passed = pc.test(node);
+      } catch {
+        passed = false;
+      }
+    }
+    return { label: pc.label, passed };
+  });
+
+  return { score: fraction(checks), checks };
+}
+
+// ─── Dimension 4: format / robustness ─────────────────────────────────
+
+export function scoreFormat(response: string, extraction: ExtractionResult): DimensionResult {
+  // No recoverable pipeline at all → the response failed its core contract;
+  // partial credit for incidental formatting would be misleading.
+  if (!extraction.pipeline) {
+    return {
+      score: 0,
+      checks: [{ label: "emits a valid pipeline in a fenced block", passed: false }],
+    };
+  }
+
+  const explanation = extractTrailingExplanation(response);
+  const looksLikeOneSentence =
+    explanation.length > 0 &&
+    explanation.length <= 240 &&
+    !/\n\s*[-*]\s/.test(explanation) && // no bullet list
+    (explanation.match(/[.!?。!?]/g) ?? []).length <= 2;
+
+  const checks: CheckResult[] = [
+    { label: "pipeline recovered from a fenced block", passed: extraction.source === "fenced" },
+    { label: "no unclosed code fence", passed: !extraction.hasUnclosedFence },
+    { label: "at most two fenced blocks", passed: extraction.fenceCount <= 2 },
+    { label: "has a trailing explanation", passed: explanation.length > 0 },
+    { label: "explanation is a short single sentence", passed: looksLikeOneSentence },
+  ];
+
+  return { score: fraction(checks), checks };
+}
+
+// ─── Aggregate ────────────────────────────────────────────────────────
+
+/** Score one model response against a rubric. */
+export function scoreResponse(response: string, rubric: Rubric): CaseScore {
+  const extraction = extractPipeline(response);
+  const pipeline = extraction.pipeline;
+
+  const schema = scoreSchema(pipeline);
+  const task = scoreTask(pipeline, rubric);
+  const params = scoreParams(pipeline, rubric);
+  const format = scoreFormat(response, extraction);
+
+  const dims: Array<[DimensionName, DimensionResult]> = [
+    ["schema", schema],
+    ["task", task],
+    ["params", params],
+    ["format", format],
+  ];
+
+  let weighted = 0;
+  let weightSum = 0;
+  for (const [name, dim] of dims) {
+    if (dim.score === null) continue;
+    const w = DIMENSION_WEIGHTS[name];
+    weighted += w * dim.score;
+    weightSum += w;
+  }
+  const total = weightSum > 0 ? weighted / weightSum : 0;
+
+  return { schema, task, params, format, total, pipeline, extraction };
+}

--- a/bench/llm/skills.ts
+++ b/bench/llm/skills.ts
@@ -1,0 +1,111 @@
+/**
+ * Skill loading for the LLM benchmark.
+ *
+ * Production loads `src/ai/skills/*.md` at build time via Vite's
+ * `import.meta.glob`, which is unavailable under a plain Node/vitest runner.
+ * Here we read the *same* markdown files from disk so the benchmark exercises
+ * the identical skill content (single source of truth — only the loading
+ * mechanism differs). The frontmatter parsing and tool-definition shapes mirror
+ * `src/ai/skillLoader.ts`.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** A parsed pipeline skill (mirrors `PipelineSkill` in skillLoader.ts). */
+export interface BenchSkill {
+  name: string;
+  description: string;
+  content: string;
+}
+
+/** Claude API tool definition shape. */
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  input_schema: { type: "object"; properties: Record<string, never> };
+}
+
+/** OpenAI-compatible function tool definition shape. */
+export interface OpenAITool {
+  type: "function";
+  function: {
+    name: string;
+    description: string;
+    parameters: { type: "object"; properties: Record<string, never> };
+  };
+}
+
+/** Absolute path to the production skills directory. */
+function skillsDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // bench/llm -> repo root -> src/ai/skills
+  return join(here, "..", "..", "src", "ai", "skills");
+}
+
+/** Parse YAML-ish frontmatter (mirrors skillLoader.parseFrontmatter). */
+export function parseFrontmatter(raw: string): {
+  attrs: Record<string, string>;
+  content: string;
+} {
+  const match = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+  if (!match) {
+    return { attrs: {}, content: raw };
+  }
+  const attrs: Record<string, string> = {};
+  for (const line of match[1].split("\n")) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx > 0) {
+      attrs[line.slice(0, colonIdx).trim()] = line.slice(colonIdx + 1).trim();
+    }
+  }
+  return { attrs, content: match[2].trim() };
+}
+
+/** kebab-case -> snake_case for tool names. */
+export function toSnakeCase(s: string): string {
+  return s.replace(/-/g, "_");
+}
+
+let _cached: BenchSkill[] | null = null;
+
+/** Load and parse all pipeline skills from `src/ai/skills/`. Cached. */
+export function loadSkills(): BenchSkill[] {
+  if (_cached) return _cached;
+  const dir = skillsDir();
+  const skills: BenchSkill[] = [];
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith(".md")) continue;
+    const { attrs, content } = parseFrontmatter(readFileSync(join(dir, file), "utf8"));
+    if (!attrs.name || !attrs.description) continue;
+    skills.push({ name: attrs.name, description: attrs.description, content });
+  }
+  return (_cached = skills);
+}
+
+/** Build Anthropic tool definitions from skills. */
+export function buildToolDefinitions(skills: BenchSkill[]): ToolDefinition[] {
+  return skills.map((s) => ({
+    name: toSnakeCase(s.name),
+    description: s.description,
+    input_schema: { type: "object" as const, properties: {} },
+  }));
+}
+
+/** Build OpenAI-compatible function tools from skills. */
+export function buildOpenAITools(skills: BenchSkill[]): OpenAITool[] {
+  return skills.map((s) => ({
+    type: "function",
+    function: {
+      name: toSnakeCase(s.name),
+      description: s.description,
+      parameters: { type: "object" as const, properties: {} },
+    },
+  }));
+}
+
+/** Execute a skill by tool name; returns its markdown content or null. */
+export function executeSkill(skills: BenchSkill[], toolName: string): string | null {
+  return skills.find((s) => toSnakeCase(s.name) === toolName)?.content ?? null;
+}

--- a/bench/llm/types.ts
+++ b/bench/llm/types.ts
@@ -1,0 +1,15 @@
+/** Shared benchmark case type. */
+
+import type { Rubric } from "./scorer";
+
+/** One benchmark case: a natural-language prompt + a grading rubric. */
+export interface BenchCase {
+  /** Stable identifier (used in reports and result files). */
+  id: string;
+  /** The natural-language request handed to the model verbatim. */
+  prompt: string;
+  /** Category tags for per-group reporting (e.g. "molecule", "filter"). */
+  tags: string[];
+  /** Programmatic grading rubric. */
+  rubric: Rubric;
+}

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "test:e2e:trajectory-bonds:widget-vscode": "playwright test --project=trajectory-bonds__widget-vscode",
     "test:e2e:phase2": "playwright test --grep-invert='@phase0' --project=modify-node__webapp --project=camera__webapp --project=measurement__webapp --project=subsystem-rendering__webapp --project=trajectory-bonds__webapp",
     "test:all": "vitest run && playwright test",
+    "bench:llm": "vitest run tests/ts/bench/llm.bench.test.ts",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "format": "prettier --write src/",

--- a/tests/ts/bench/bench-unit.test.ts
+++ b/tests/ts/bench/bench-unit.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  extractPipeline,
+  extractTrailingExplanation,
+  findLastValidPipeline,
+} from "../../../bench/llm/extract";
+import {
+  scoreSchema,
+  scoreTask,
+  scoreParams,
+  scoreFormat,
+  scoreResponse,
+  type Rubric,
+} from "../../../bench/llm/scorer";
+import {
+  loadSkills,
+  buildToolDefinitions,
+  buildOpenAITools,
+  executeSkill,
+  parseFrontmatter,
+  toSnakeCase,
+} from "../../../bench/llm/skills";
+import { runDataset } from "../../../bench/llm/runner";
+import { aggregate, toMarkdown, toJSON } from "../../../bench/llm/report";
+import { DATASET } from "../../../bench/llm/dataset";
+import { NODE_PORTS, type SerializedPipeline } from "@/pipeline/types";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────
+
+const PERFECT_MOLECULE: SerializedPipeline = {
+  version: 3,
+  nodes: [
+    { id: "loader-1", type: "load_structure", position: { x: 0, y: 0 }, fileName: null, hasTrajectory: false, hasCell: true },
+    { id: "addbond-1", type: "add_bond", position: { x: 0, y: 300 }, bondSource: "structure" },
+    { id: "viewport-1", type: "viewport", position: { x: 0, y: 600 }, perspective: false, cellAxesVisible: true, pivotMarkerVisible: true },
+  ],
+  edges: [
+    { source: "loader-1", target: "addbond-1", sourceHandle: "particle", targetHandle: "particle" },
+    { source: "loader-1", target: "viewport-1", sourceHandle: "particle", targetHandle: "particle" },
+    { source: "addbond-1", target: "viewport-1", sourceHandle: "bond", targetHandle: "bond" },
+  ],
+};
+
+function fenced(p: SerializedPipeline, explanation = "Loads the structure and shows bonds."): string {
+  return "```json\n" + JSON.stringify(p) + "\n```\n\n" + explanation;
+}
+
+// ─── extract ──────────────────────────────────────────────────────────
+
+describe("extract", () => {
+  it("recovers a pipeline from a fenced block", () => {
+    const r = extractPipeline(fenced(PERFECT_MOLECULE));
+    expect(r.source).toBe("fenced");
+    expect(r.pipeline?.nodes).toHaveLength(3);
+    expect(r.fenceCount).toBe(1);
+    expect(r.hasUnclosedFence).toBe(false);
+  });
+
+  it("prefers the last valid fence over an earlier one", () => {
+    const small: SerializedPipeline = { version: 3, nodes: [{ id: "v", type: "viewport", position: { x: 0, y: 0 }, perspective: false, cellAxesVisible: true, pivotMarkerVisible: true }], edges: [] };
+    const text = fenced(small, "first") + "\n" + fenced(PERFECT_MOLECULE, "second");
+    expect(findLastValidPipeline(text)?.nodes).toHaveLength(3);
+  });
+
+  it("falls back to bare JSON when no fence is present", () => {
+    const r = extractPipeline("here: " + JSON.stringify(PERFECT_MOLECULE) + " done");
+    expect(r.source).toBe("bare");
+    expect(r.pipeline?.nodes).toHaveLength(3);
+  });
+
+  it("reports an unclosed fence and recovers nothing", () => {
+    const r = extractPipeline("```json\n{ \"version\": 3, \"nodes\": [");
+    expect(r.hasUnclosedFence).toBe(true);
+    expect(r.pipeline).toBeNull();
+    expect(r.source).toBe("none");
+  });
+
+  it("extractTrailingExplanation returns prose after the closed fence", () => {
+    expect(extractTrailingExplanation(fenced(PERFECT_MOLECULE, "Shows bonds."))).toBe("Shows bonds.");
+    expect(extractTrailingExplanation("```json\n{")).toBe("");
+  });
+});
+
+// ─── schema dimension ─────────────────────────────────────────────────
+
+describe("scoreSchema", () => {
+  it("gives a perfect pipeline a full score", () => {
+    const r = scoreSchema(PERFECT_MOLECULE);
+    expect(r.score).toBe(1);
+    expect(r.checks.every((c) => c.passed)).toBe(true);
+  });
+
+  it("scores a null pipeline as zero", () => {
+    expect(scoreSchema(null).score).toBe(0);
+  });
+
+  it("penalizes a missing viewport", () => {
+    const p: SerializedPipeline = { ...PERFECT_MOLECULE, nodes: PERFECT_MOLECULE.nodes.slice(0, 2), edges: [PERFECT_MOLECULE.edges[0]] };
+    const r = scoreSchema(p);
+    expect(r.score).toBeLessThan(1);
+    expect(r.checks.find((c) => c.label === "exactly one viewport node")?.passed).toBe(false);
+  });
+
+  it("penalizes a type-incompatible edge", () => {
+    const p: SerializedPipeline = {
+      ...PERFECT_MOLECULE,
+      edges: [...PERFECT_MOLECULE.edges, { source: "loader-1", target: "viewport-1", sourceHandle: "particle", targetHandle: "bond" }],
+    };
+    const r = scoreSchema(p);
+    expect(r.checks.find((c) => c.label === "edges connect type-compatible ports")?.passed).toBe(false);
+  });
+
+  it("detects a cycle", () => {
+    const p: SerializedPipeline = {
+      ...PERFECT_MOLECULE,
+      edges: [...PERFECT_MOLECULE.edges, { source: "viewport-1", target: "addbond-1", sourceHandle: "x", targetHandle: "particle" }],
+    };
+    expect(scoreSchema(p).checks.find((c) => c.label === "graph is acyclic")?.passed).toBe(false);
+  });
+
+  it("flags a disconnected node", () => {
+    const p: SerializedPipeline = {
+      ...PERFECT_MOLECULE,
+      nodes: [...PERFECT_MOLECULE.nodes, { id: "orphan", type: "load_structure", position: { x: 500, y: 0 }, fileName: null, hasTrajectory: false, hasCell: false }],
+    };
+    expect(scoreSchema(p).checks.find((c) => c.label === "all nodes reach a viewport")?.passed).toBe(false);
+  });
+});
+
+// ─── task dimension ───────────────────────────────────────────────────
+
+describe("scoreTask", () => {
+  it("returns null when the rubric has no task constraints", () => {
+    expect(scoreTask(PERFECT_MOLECULE, {}).score).toBeNull();
+  });
+
+  it("rewards required node types and connections", () => {
+    const rubric: Rubric = {
+      requiredNodeTypes: ["load_structure", "add_bond", "viewport"],
+      requiredConnections: [{ sourceType: "add_bond", targetType: "viewport", sourceHandle: "bond", targetHandle: "bond" }],
+      minNodes: 3,
+    };
+    expect(scoreTask(PERFECT_MOLECULE, rubric).score).toBe(1);
+  });
+
+  it("penalizes a forbidden node type", () => {
+    const r = scoreTask(PERFECT_MOLECULE, { forbiddenNodeTypes: ["add_bond"] });
+    expect(r.score).toBe(0);
+  });
+
+  it("penalizes a missing connection", () => {
+    const r = scoreTask(PERFECT_MOLECULE, {
+      requiredConnections: [{ sourceType: "label_generator", targetType: "viewport" }],
+    });
+    expect(r.score).toBe(0);
+  });
+});
+
+// ─── params dimension ─────────────────────────────────────────────────
+
+describe("scoreParams", () => {
+  it("returns null when there are no param checks", () => {
+    expect(scoreParams(PERFECT_MOLECULE, {}).score).toBeNull();
+  });
+
+  it("scores a matching parameter as full", () => {
+    const r = scoreParams(PERFECT_MOLECULE, {
+      paramChecks: [{ label: "structure bonds", nodeType: "add_bond", test: (n) => (n as { bondSource?: string }).bondSource === "structure" }],
+    });
+    expect(r.score).toBe(1);
+  });
+
+  it("fails when the target node is absent", () => {
+    const r = scoreParams(PERFECT_MOLECULE, {
+      paramChecks: [{ label: "filter q", nodeType: "filter", test: () => true }],
+    });
+    expect(r.score).toBe(0);
+  });
+
+  it("treats a throwing predicate as a failure", () => {
+    const r = scoreParams(PERFECT_MOLECULE, {
+      paramChecks: [{ label: "boom", nodeType: "add_bond", test: () => { throw new Error("x"); } }],
+    });
+    expect(r.score).toBe(0);
+  });
+});
+
+// ─── format dimension ─────────────────────────────────────────────────
+
+describe("scoreFormat", () => {
+  it("rewards fenced JSON with a trailing one-sentence explanation", () => {
+    const text = fenced(PERFECT_MOLECULE);
+    const r = scoreFormat(text, extractPipeline(text));
+    expect(r.score).toBe(1);
+  });
+
+  it("penalizes bare JSON output", () => {
+    const text = JSON.stringify(PERFECT_MOLECULE);
+    const r = scoreFormat(text, extractPipeline(text));
+    expect(r.score).toBeLessThan(1);
+    expect(r.checks.find((c) => c.label === "pipeline recovered from a fenced block")?.passed).toBe(false);
+  });
+
+  it("penalizes a bullet-list explanation", () => {
+    const text = "```json\n" + JSON.stringify(PERFECT_MOLECULE) + "\n```\n- does a thing\n- does another";
+    const r = scoreFormat(text, extractPipeline(text));
+    expect(r.checks.find((c) => c.label === "explanation is a short single sentence")?.passed).toBe(false);
+  });
+});
+
+// ─── aggregate scoreResponse ──────────────────────────────────────────
+
+describe("scoreResponse", () => {
+  it("gives a perfect fenced molecule near 1.0", () => {
+    const rubric: Rubric = {
+      requiredNodeTypes: ["load_structure", "add_bond", "viewport"],
+      paramChecks: [{ label: "structure", nodeType: "add_bond", test: (n) => (n as { bondSource?: string }).bondSource === "structure" }],
+    };
+    const s = scoreResponse(fenced(PERFECT_MOLECULE), rubric);
+    expect(s.total).toBe(1);
+  });
+
+  it("renormalizes the total over applicable dimensions only", () => {
+    // No task/params constraints -> total is the weighted mean of schema+format only.
+    const s = scoreResponse(fenced(PERFECT_MOLECULE), {});
+    expect(s.task.score).toBeNull();
+    expect(s.params.score).toBeNull();
+    expect(s.total).toBe(1);
+  });
+
+  it("scores an unparseable response as zero", () => {
+    const s = scoreResponse("Sorry, I cannot help with that.", { requiredNodeTypes: ["viewport"] });
+    expect(s.total).toBe(0);
+    expect(s.pipeline).toBeNull();
+  });
+});
+
+// ─── skills ───────────────────────────────────────────────────────────
+
+describe("skills", () => {
+  it("loads the production skill markdown from disk", () => {
+    const skills = loadSkills();
+    const names = skills.map((s) => s.name).sort();
+    expect(names).toContain("get-molecule-template");
+    expect(names).toContain("get-solid-template");
+    expect(skills.every((s) => s.content.length > 0)).toBe(true);
+  });
+
+  it("builds tool definitions with snake_case names", () => {
+    const skills = loadSkills();
+    const anthropic = buildToolDefinitions(skills);
+    const openai = buildOpenAITools(skills);
+    expect(anthropic.some((t) => t.name === "get_molecule_template")).toBe(true);
+    expect(openai.some((t) => t.function.name === "get_solid_template")).toBe(true);
+  });
+
+  it("executes a skill by tool name", () => {
+    const skills = loadSkills();
+    expect(executeSkill(skills, "get_molecule_template")).toContain("Molecule Pipeline Template");
+    expect(executeSkill(skills, "unknown")).toBeNull();
+  });
+
+  it("parseFrontmatter and toSnakeCase behave as expected", () => {
+    const { attrs, content } = parseFrontmatter("---\nname: a-b\ndescription: d\n---\nbody");
+    expect(attrs.name).toBe("a-b");
+    expect(content).toBe("body");
+    expect(toSnakeCase("a-b-c")).toBe("a_b_c");
+  });
+});
+
+// ─── dataset integrity ────────────────────────────────────────────────
+
+describe("dataset", () => {
+  it("has unique ids and non-empty prompts/tags", () => {
+    const ids = DATASET.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(DATASET.every((c) => c.prompt.length > 0 && c.tags.length > 0)).toBe(true);
+  });
+
+  it("references only known node types in every rubric", () => {
+    const known = new Set(Object.keys(NODE_PORTS));
+    for (const c of DATASET) {
+      const r = c.rubric;
+      for (const t of [...(r.requiredNodeTypes ?? []), ...(r.forbiddenNodeTypes ?? [])]) {
+        expect(known.has(t)).toBe(true);
+      }
+      for (const conn of r.requiredConnections ?? []) {
+        expect(known.has(conn.sourceType)).toBe(true);
+        expect(known.has(conn.targetType)).toBe(true);
+      }
+      for (const pc of r.paramChecks ?? []) {
+        expect(known.has(pc.nodeType)).toBe(true);
+      }
+    }
+  });
+});
+
+// ─── runner + report ──────────────────────────────────────────────────
+
+describe("runner + report", () => {
+  it("runs the dataset through a stub generate and aggregates", async () => {
+    const cases = DATASET.slice(0, 3);
+    const records = await runDataset(cases, async (prompt) => {
+      // Echo a perfect molecule for every prompt regardless of content.
+      void prompt;
+      return fenced(PERFECT_MOLECULE);
+    });
+    expect(records).toHaveLength(3);
+    const agg = aggregate(records);
+    expect(agg.count).toBe(3);
+    expect(agg.meanTotal).toBeGreaterThan(0);
+    expect(agg.byDimension.schema).toBe(1);
+    const md = toMarkdown({ provider: "stub", model: "stub", timestamp: "t" }, records, agg);
+    expect(md).toContain("megane LLM benchmark");
+    const json = toJSON({ provider: "stub", model: "stub", timestamp: "t" }, records, agg);
+    expect(json.cases).toHaveLength(3);
+  });
+
+  it("captures a generation error without aborting the run", async () => {
+    const records = await runDataset(DATASET.slice(0, 2), async () => {
+      throw new Error("network down");
+    });
+    expect(records).toHaveLength(2);
+    expect(records[0].error).toBe("network down");
+    expect(records[0].score.total).toBe(0);
+  });
+});

--- a/tests/ts/bench/llm.bench.test.ts
+++ b/tests/ts/bench/llm.bench.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Live megane LLM benchmark runner.
+ *
+ * This is a *benchmark*, not a unit test: it makes real, paid LLM API calls,
+ * so it is skipped unless `MEGANE_LLM_BENCH=1` is set. It reuses vitest purely
+ * as a zero-extra-dependency TypeScript runner (the repo already installs it).
+ *
+ * Usage:
+ *   MEGANE_LLM_BENCH=1 ANTHROPIC_API_KEY=sk-... \
+ *     MEGANE_LLM_PROVIDER=anthropic MEGANE_LLM_MODEL=claude-sonnet-4-20250514 \
+ *     npx vitest run tests/ts/bench/llm.bench.test.ts
+ *
+ * Providers: anthropic (ANTHROPIC_API_KEY), openai (OPENAI_API_KEY),
+ * demo (MEGANE_LLM_PROXY_URL). Results are written to bench/llm/results/.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { DATASET } from "../../../bench/llm/dataset";
+import { runDataset } from "../../../bench/llm/runner";
+import { aggregate, toJSON, toMarkdown } from "../../../bench/llm/report";
+import {
+  assertConfig,
+  configFromEnv,
+  generatePipelineLive,
+} from "../../../bench/llm/providers";
+
+const ENABLED = process.env.MEGANE_LLM_BENCH === "1";
+
+describe.skipIf(!ENABLED)("megane LLM benchmark (live)", () => {
+  it(
+    "scores the dataset and writes a report",
+    async () => {
+      const config = configFromEnv();
+      assertConfig(config);
+
+      const records = await runDataset(
+        DATASET,
+        (prompt) => generatePipelineLive(config, prompt),
+        {
+          onResult: (r, i, total) => {
+            const pct = Math.round(r.score.total * 100);
+            // eslint-disable-next-line no-console
+            console.log(`[${i + 1}/${total}] ${r.case.id}: ${pct}%${r.error ? ` (error: ${r.error})` : ""}`);
+          },
+        },
+      );
+
+      const agg = aggregate(records);
+      const meta = {
+        provider: config.provider,
+        model: config.model,
+        timestamp: new Date().toISOString(),
+      };
+
+      const dir = join(process.cwd(), "bench", "llm", "results");
+      mkdirSync(dir, { recursive: true });
+      const stamp = meta.timestamp.replace(/[:.]/g, "-");
+      const base = `${config.provider}-${config.model.replace(/[^\w.-]/g, "_")}-${stamp}`;
+      writeFileSync(join(dir, `${base}.json`), JSON.stringify(toJSON(meta, records, agg), null, 2));
+      const md = toMarkdown(meta, records, agg);
+      writeFileSync(join(dir, `${base}.md`), md);
+
+      // eslint-disable-next-line no-console
+      console.log("\n" + md);
+
+      expect(records).toHaveLength(DATASET.length);
+    },
+    600_000,
+  );
+});


### PR DESCRIPTION
Introduce a prompt-suite + programmatic scorer to evaluate the quality of
megane's LLM pipeline generator (natural language -> SerializedPipeline JSON).

bench/llm/:
- dataset.ts: 16 tagged cases (molecule, solid/polyhedra, filter, modify,
  overlays, multi-step, multilingual) each with a grading rubric.
- scorer.ts: four weighted dimensions in [0,1] — schema/structural validity
  (reuses canConnect/NODE_PORTS from src/pipeline/types), task coverage,
  parameter accuracy, and output-format compliance. N/A dimensions are
  renormalised out of the per-case total.
- extract.ts: faithful port of the production JSON extraction (prefers the
  last valid fenced pipeline), pinned by tests.
- skills.ts/providers.ts: live Anthropic/OpenAI/demo runners reusing the
  production system prompt and the same src/ai/skills markdown.
- runner.ts/report.ts: orchestration + JSON/Markdown report (overall, by
  dimension, by tag, per case).

The live runner is gated behind MEGANE_LLM_BENCH=1 and reuses vitest as a
zero-extra-dependency TS runner (npm run bench:llm). Deterministic logic is
covered by tests/ts/bench/bench-unit.test.ts in the normal npm test suite.
Generated reports under bench/llm/results/ are git-ignored.

No production code changed, so no host/E2E surface is affected.