### PR TITLE
Improve LLM pipeline-generation accuracy (molecular selection)

### DIFF
--- a/src/ai/client.ts
+++ b/src/ai/client.ts
@@ -6,7 +6,7 @@
 import type { AIConfig } from "./config";
 import type { SerializedPipeline } from "../pipeline/types";
 import { buildSystemPrompt } from "./prompt";
-import { collectQueryErrors, buildRepairPrompt } from "./validatePipeline";
+import { collectPipelineErrors, buildRepairPrompt } from "./validatePipeline";
 import {
   getSkills,
   buildToolDefinitions,
@@ -99,12 +99,12 @@ export async function generatePipeline(
 
   const text = await runProvider(userMessage);
 
-  // Validate the selection queries and, if any are invalid, ask the model once
-  // to repair them. Only fires when a pipeline with broken filter queries was
-  // actually produced, so plain text responses are unaffected.
+  // Validate the generated pipeline (structure + selection queries) and, if any
+  // problems are found, ask the model once to repair them. Only fires when a
+  // pipeline was actually produced, so plain text responses are unaffected.
   const pipeline = tryExtractPipeline(text);
   if (pipeline) {
-    const errors = collectQueryErrors(pipeline);
+    const errors = collectPipelineErrors(pipeline);
     if (errors.length > 0) {
       return runProvider(buildRepairPrompt(userMessage, pipeline, errors));
     }

--- a/src/ai/client.ts
+++ b/src/ai/client.ts
@@ -6,6 +6,7 @@
 import type { AIConfig } from "./config";
 import type { SerializedPipeline } from "../pipeline/types";
 import { buildSystemPrompt } from "./prompt";
+import { collectQueryErrors, buildRepairPrompt } from "./validatePipeline";
 import {
   getSkills,
   buildToolDefinitions,
@@ -52,39 +53,63 @@ interface AnthropicStreamResult {
 /**
  * Generate a pipeline by calling the LLM API with streaming.
  * Returns the full response text.
+ *
+ * When `structureSummary` is provided it is appended to the system prompt so
+ * the model can reference the real elements/resnames present when building
+ * filter queries. After generation, the resulting pipeline's selection queries
+ * are validated; if any are invalid, one repair round trip is performed asking
+ * the model to fix them.
  */
 export async function generatePipeline(
   config: AIConfig,
   userMessage: string,
   onChunk: (text: string) => void,
   signal?: AbortSignal,
+  structureSummary?: string | null,
 ): Promise<string> {
-  const systemPrompt = buildSystemPrompt();
+  const systemPrompt = buildSystemPrompt(structureSummary);
   const skills = getSkills();
 
-  if (config.provider === "anthropic") {
-    const tools = buildToolDefinitions(skills);
-    return streamAnthropicWithSkills(
-      config,
-      systemPrompt,
-      userMessage,
-      skills,
-      tools,
-      onChunk,
-      signal,
-    );
-  }
+  // Dispatch one streamed generation for a given user message. Reused for the
+  // optional repair pass with a different (correction) message.
+  const runProvider = (message: string): Promise<string> => {
+    if (config.provider === "anthropic") {
+      const tools = buildToolDefinitions(skills);
+      return streamAnthropicWithSkills(
+        config,
+        systemPrompt,
+        message,
+        skills,
+        tools,
+        onChunk,
+        signal,
+      );
+    }
 
-  // OpenAI-compatible providers (and the OpenRouter-backed demo proxy)
-  // speak the OpenAI tool-calling protocol, so the model fetches skill
-  // templates on demand via function calls — the same on-demand behaviour
-  // as the Anthropic path, no inlining required.
-  const tools = buildOpenAITools(skills);
+    // OpenAI-compatible providers (and the OpenRouter-backed demo proxy)
+    // speak the OpenAI tool-calling protocol, so the model fetches skill
+    // templates on demand via function calls — the same on-demand behaviour
+    // as the Anthropic path, no inlining required.
+    const tools = buildOpenAITools(skills);
+    if (config.provider === "demo") {
+      return streamDemoProxy(systemPrompt, message, skills, tools, onChunk, signal);
+    }
+    return streamOpenAI(config, systemPrompt, message, skills, tools, onChunk, signal);
+  };
 
-  if (config.provider === "demo") {
-    return streamDemoProxy(systemPrompt, userMessage, skills, tools, onChunk, signal);
+  const text = await runProvider(userMessage);
+
+  // Validate the selection queries and, if any are invalid, ask the model once
+  // to repair them. Only fires when a pipeline with broken filter queries was
+  // actually produced, so plain text responses are unaffected.
+  const pipeline = tryExtractPipeline(text);
+  if (pipeline) {
+    const errors = collectQueryErrors(pipeline);
+    if (errors.length > 0) {
+      return runProvider(buildRepairPrompt(userMessage, pipeline, errors));
+    }
   }
-  return streamOpenAI(config, systemPrompt, userMessage, skills, tools, onChunk, signal);
+  return text;
 }
 
 // ─── Anthropic with tool_use ─────────────────────────────────────────

--- a/src/ai/pipelineSchema.ts
+++ b/src/ai/pipelineSchema.ts
@@ -1,0 +1,102 @@
+/**
+ * Structural validation of a generated SerializedPipeline. Complements the
+ * selection-query validation in validatePipeline.ts: where that checks the DSL
+ * inside filter nodes, this checks the *shape* of the graph the LLM produced
+ * (known node types, well-formed positions, exactly one viewport, edges that
+ * reference real nodes). Errors feed the same repair round trip.
+ *
+ * Implemented as a small hand-rolled validator rather than pulling in a JSON
+ * Schema library — it keeps the dependency footprint flat and emits the same
+ * `node "<id>": <reason>` style messages as collectQueryErrors so the repair
+ * prompt reads uniformly.
+ */
+
+import type { SerializedPipeline } from "../pipeline/types";
+import { NODE_TYPE_LABELS } from "../pipeline/types";
+
+/** The set of valid node `type` strings, sourced from the type-label record. */
+const KNOWN_NODE_TYPES = new Set(Object.keys(NODE_TYPE_LABELS));
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+/**
+ * Validate the structure of a pipeline. Returns a list of human-readable error
+ * strings (empty when the graph is well-formed). Assumes the caller already
+ * confirmed `version: 3` with `nodes`/`edges` arrays (see isSerializedPipeline
+ * in client.ts); re-checks defensively so it is safe to call standalone.
+ */
+export function collectSchemaErrors(pipeline: SerializedPipeline): string[] {
+  const errors: string[] = [];
+
+  if (pipeline.version !== 3) {
+    errors.push(`pipeline version must be 3 (got ${JSON.stringify(pipeline.version)})`);
+  }
+  if (!Array.isArray(pipeline.nodes) || !Array.isArray(pipeline.edges)) {
+    errors.push("pipeline must have `nodes` and `edges` arrays");
+    return errors; // can't validate further without the arrays
+  }
+
+  const nodeIds = new Set<string>();
+  let viewportCount = 0;
+
+  pipeline.nodes.forEach((node, i) => {
+    const n = node as {
+      id?: unknown;
+      type?: unknown;
+      position?: unknown;
+    };
+    const where = typeof n.id === "string" && n.id ? `node "${n.id}"` : `node[${i}]`;
+
+    if (typeof n.id !== "string" || n.id === "") {
+      errors.push(`${where}: missing string "id"`);
+    } else if (nodeIds.has(n.id)) {
+      errors.push(`${where}: duplicate node id`);
+    } else {
+      nodeIds.add(n.id);
+    }
+
+    if (typeof n.type !== "string" || !KNOWN_NODE_TYPES.has(n.type)) {
+      errors.push(`${where}: unknown node type ${JSON.stringify(n.type)}`);
+    } else if (n.type === "viewport") {
+      viewportCount++;
+    }
+
+    const pos = n.position as { x?: unknown; y?: unknown } | undefined;
+    if (!pos || !isFiniteNumber(pos.x) || !isFiniteNumber(pos.y)) {
+      errors.push(`${where}: "position" must have numeric x and y`);
+    }
+  });
+
+  if (viewportCount === 0) {
+    errors.push("pipeline must contain exactly one viewport node (found none)");
+  } else if (viewportCount > 1) {
+    errors.push(`pipeline must contain exactly one viewport node (found ${viewportCount})`);
+  }
+
+  pipeline.edges.forEach((edge, i) => {
+    const e = edge as {
+      source?: unknown;
+      target?: unknown;
+      sourceHandle?: unknown;
+      targetHandle?: unknown;
+    };
+    const where = `edge[${i}]`;
+
+    for (const key of ["source", "target", "sourceHandle", "targetHandle"] as const) {
+      if (typeof e[key] !== "string" || e[key] === "") {
+        errors.push(`${where}: missing string "${key}"`);
+      }
+    }
+
+    if (typeof e.source === "string" && e.source && !nodeIds.has(e.source)) {
+      errors.push(`${where}: source "${e.source}" does not reference an existing node`);
+    }
+    if (typeof e.target === "string" && e.target && !nodeIds.has(e.target)) {
+      errors.push(`${where}: target "${e.target}" does not reference an existing node`);
+    }
+  });
+
+  return errors;
+}

--- a/src/ai/prompt.ts
+++ b/src/ai/prompt.ts
@@ -3,8 +3,8 @@
  * Contains the complete pipeline schema so the LLM can generate valid SerializedPipeline JSON.
  */
 
-export function buildSystemPrompt(): string {
-  return `You are a pipeline generator for Megane, a molecular visualization application.
+export function buildSystemPrompt(structureSummary?: string | null): string {
+  const base = `You are a pipeline generator for Megane, a molecular visualization application.
 Your task is to generate a pipeline configuration in JSON format based on the user's request.
 
 ## Output Format
@@ -75,9 +75,12 @@ Detects or infers bonds between atoms.
 - Outputs: \`bond\` (bond data type)
 
 ### filter
-Filters atoms by a selection query.
-- Parameters: \`{ type: "filter", query: string }\`
-  - Query examples: \`element == "C"\`, \`index < 10\`, \`resname == "ALA"\`, \`element == "O" or element == "N"\`
+Filters atoms (and optionally bonds) by a selection query. See the
+"Atom & Bond Selection Query Language" section below for the full, authoritative
+grammar — only the syntax documented there is supported.
+- Parameters: \`{ type: "filter", query: string, bond_query?: string }\`
+  - \`query\`: atom selection (e.g. \`element == "C"\`, \`index < 10\`, \`resname == "ALA"\`, \`element == "O" or element == "N"\`)
+  - \`bond_query\`: optional bond selection (e.g. \`both element != "H"\`)
 - Inputs: \`in\` (accepts particle or bond data type)
 - Outputs: \`out\` (same type as input)
 
@@ -135,6 +138,68 @@ The final rendering sink. Every pipeline MUST have exactly one viewport node. Al
 3. Data types: particle, bond, cell, label, mesh, trajectory, vector.
 4. Filter and Modify nodes accept both \`particle\` and \`bond\` types on their \`in\` port.
 5. Multiple edges can connect to the same viewport input port (data is collected).
+
+## Atom & Bond Selection Query Language
+
+The \`filter\` node's \`query\` (atoms) and \`bond_query\` (bonds) use a small custom
+DSL. This is NOT VMD, PyMOL, MDAnalysis, or ProDy syntax — only the grammar
+below works. Generating any other syntax silently fails (the filter falls back
+to selecting all or no atoms), so follow these rules exactly.
+
+### Atom query grammar
+\`\`\`
+Query      := OrExpr
+OrExpr     := AndExpr ("or" AndExpr)*
+AndExpr    := NotExpr ("and" NotExpr)*
+NotExpr    := "not" NotExpr | Atom
+Atom       := Comparison | "(" OrExpr ")" | "all" | "none"
+Comparison := Field Op Value
+Field      := "element" | "index" | "x" | "y" | "z" | "resname" | "mass"
+Op         := "==" | "!=" | ">" | "<" | ">=" | "<="
+Value      := QuotedString | Number
+\`\`\`
+- Fields are ONLY: \`element\`, \`index\`, \`x\`, \`y\`, \`z\`, \`resname\`, \`mass\`. No other field exists.
+- String values MUST be double-quoted: \`element == "C"\` (NOT \`element == C\`).
+  This applies to \`element\` and \`resname\`.
+- \`element\` compares the element symbol ("C", "Fe", …). \`index\` is the 0-based
+  atom index. \`x\`/\`y\`/\`z\` are Cartesian coordinates (Å). \`mass\` is atomic mass.
+- An empty query or \`all\` selects every atom; \`none\` selects nothing.
+- Combine with \`and\`, \`or\`, \`not\`, and parentheses.
+
+Valid examples:
+- \`element == "C"\` — all carbons
+- \`element != "H"\` — all non-hydrogen (heavy) atoms
+- \`index >= 10 and index <= 19\` — atoms 10–19
+- \`resname == "HOH"\` — residues named HOH
+- \`element == "O" or element == "N"\` — oxygens or nitrogens
+- \`(x > 0 and x < 10) and element == "C"\` — carbons in an x-slab
+- \`mass > 32\` — atoms heavier than sulfur
+
+### Bond query grammar
+\`\`\`
+Atom := "both" Comparison | Comparison | "(" OrExpr ")" | "all" | "none"
+Field := "bond_index" | "atom_index" | "element"
+\`\`\`
+- Fields are ONLY: \`bond_index\`, \`atom_index\`, \`element\`.
+- Prefix with \`both\` to require BOTH bonded atoms to satisfy the condition;
+  without \`both\` a bond matches if EITHER endpoint does.
+- Examples: \`both element != "H"\` (bonds between two heavy atoms),
+  \`atom_index >= 24\` (bonds touching atom 24+), \`bond_index < 10\` (first 10 bonds).
+
+### Common mistakes — DO NOT use these (left), use the megane DSL (right)
+| Other-tool / natural phrasing | megane DSL |
+| --- | --- |
+| \`name CA\`, \`protein\`, \`backbone\`, \`sidechain\` | not supported (no per-atom-name / structural selection) |
+| \`water\`, \`resname HOH WAT\` | \`resname == "HOH"\` (use an actual resname from the loaded structure) |
+| \`chain A\` | not supported (chain selection is unavailable) |
+| \`within 5 of ...\`, distance-based | not supported |
+| \`resid 1-20\`, \`index 1 to 10\` | \`index >= 1 and index <= 10\` |
+| \`element C\` (unquoted) | \`element == "C"\` |
+| \`noh\`, \`heavy\`, "non-hydrogen" | \`element != "H"\` |
+
+If a request needs an unsupported selection (atom names, chains, distance,
+secondary structure), express the closest supported approximation with
+\`element\`/\`resname\`/\`index\`, or omit the filter rather than inventing syntax.
 
 ## Common Atomic Numbers
 H=1, C=6, N=7, O=8, F=9, Na=11, Mg=12, Al=13, Si=14, P=15, S=16, Cl=17, K=19, Ca=20, Ti=22, Fe=26, Zn=30, Sr=38
@@ -204,4 +269,22 @@ User request: "Show a molecule with bonds and trajectory"
 - For modified appearance: add modify nodes to change scale/opacity.
 - You have access to pipeline skill tools. Use them to retrieve base templates and domain knowledge when relevant, then customize the result for the user's specific request.
 - If no skill matches the request, generate the pipeline from scratch using the schema above.`;
+
+  if (!structureSummary) {
+    return base;
+  }
+
+  // Append a description of the structure the user currently has loaded so that
+  // filter queries reference real element symbols / resnames instead of guesses.
+  return `${base}
+
+## Currently Loaded Structure
+
+The user already has this structure loaded. When you build a \`filter\` node, the
+\`element\` and \`resname\` values in its query MUST come from the lists below — do
+not invent resnames or elements that are not present. If the request asks for
+something not present (e.g. "water" but there is no water resname), say so in the
+explanation rather than guessing.
+
+${structureSummary}`;
 }

--- a/src/ai/structureSummary.ts
+++ b/src/ai/structureSummary.ts
@@ -1,0 +1,76 @@
+/**
+ * Builds a compact, human-readable summary of the structure the user currently
+ * has loaded, for injection into the LLM system prompt. Knowing the real
+ * element symbols and residue names present lets the model generate accurate
+ * `filter` queries instead of guessing (the #1 cause of bad selections).
+ */
+
+import type { Snapshot } from "../types";
+import { getElementSymbol } from "../constants";
+import { parseResname } from "../pipeline/selection";
+
+/** Cap the resname list so a huge structure doesn't blow up the prompt. */
+const MAX_RESNAMES = 50;
+
+/**
+ * Summarize a loaded structure as a short markdown block, or `null` when no
+ * structure is loaded (so the caller can omit the section entirely).
+ *
+ * The summary lists: atom count and index range, the element symbols present
+ * (with per-element counts), the residue names present (unique, capped), the
+ * chain IDs present, and whether a unit cell and bonds are available — exactly
+ * the facts a `filter` query can reference.
+ */
+export function summarizeStructure(
+  snapshot: Snapshot | null,
+  atomLabels: string[] | null,
+): string | null {
+  if (!snapshot || snapshot.nAtoms === 0) return null;
+
+  const lines: string[] = [];
+  lines.push(`- Atoms: ${snapshot.nAtoms} (index 0..${snapshot.nAtoms - 1})`);
+
+  // Elements present, with counts, sorted by descending count.
+  const elementCounts = new Map<string, number>();
+  for (let i = 0; i < snapshot.nAtoms; i++) {
+    const sym = getElementSymbol(snapshot.elements[i]);
+    elementCounts.set(sym, (elementCounts.get(sym) ?? 0) + 1);
+  }
+  const elementList = [...elementCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([sym, n]) => `${sym} (${n})`)
+    .join(", ");
+  lines.push(`- Elements present: ${elementList}`);
+
+  // Residue names present (unique). Only available when atom labels are loaded.
+  if (atomLabels && atomLabels.length > 0) {
+    const resnames = new Set<string>();
+    const limit = Math.min(atomLabels.length, snapshot.nAtoms);
+    for (let i = 0; i < limit; i++) {
+      const label = atomLabels[i];
+      if (label) resnames.add(parseResname(label));
+    }
+    if (resnames.size > 0) {
+      const all = [...resnames].sort();
+      const shown = all.slice(0, MAX_RESNAMES);
+      const suffix = all.length > MAX_RESNAMES ? `, … (${all.length - MAX_RESNAMES} more)` : "";
+      lines.push(`- Residue names present: ${shown.join(", ")}${suffix}`);
+    }
+  }
+
+  // Chain IDs present (ASCII bytes → characters).
+  if (snapshot.atomChainIds && snapshot.atomChainIds.length > 0) {
+    const chains = new Set<string>();
+    for (const code of snapshot.atomChainIds) {
+      if (code !== 0) chains.add(String.fromCharCode(code));
+    }
+    if (chains.size > 0) {
+      lines.push(`- Chains present: ${[...chains].sort().join(", ")}`);
+    }
+  }
+
+  lines.push(`- Unit cell: ${snapshot.box ? "yes" : "no"}`);
+  lines.push(`- Bonds: ${snapshot.nBonds}`);
+
+  return lines.join("\n");
+}

--- a/src/ai/validatePipeline.ts
+++ b/src/ai/validatePipeline.ts
@@ -9,6 +9,7 @@
 
 import type { SerializedPipeline } from "../pipeline/types";
 import { validateQuery, validateBondQuery } from "../pipeline/selection";
+import { collectSchemaErrors } from "./pipelineSchema";
 
 /**
  * Validate every `filter` node's `query` / `bond_query` against the selection
@@ -41,9 +42,21 @@ export function collectQueryErrors(pipeline: SerializedPipeline): string[] {
 }
 
 /**
- * Build a follow-up user message asking the model to fix the invalid selection
- * queries it just produced. Includes the original request, the broken pipeline,
- * and the specific errors so the model can correct only what's wrong.
+ * Collect every correctness problem with a generated pipeline: structural
+ * schema errors (unknown node types, malformed positions, missing/duplicate
+ * viewport, dangling edges) plus invalid selection queries. This is the single
+ * gate the repair round trip checks — a non-empty result means the model should
+ * be asked to fix the pipeline.
+ */
+export function collectPipelineErrors(pipeline: SerializedPipeline): string[] {
+  return [...collectSchemaErrors(pipeline), ...collectQueryErrors(pipeline)];
+}
+
+/**
+ * Build a follow-up user message asking the model to fix the problems found in
+ * the pipeline it just produced (invalid selection queries and/or structural
+ * schema errors). Includes the original request, the broken pipeline, and the
+ * specific errors so the model can correct only what's wrong.
  */
 export function buildRepairPrompt(
   originalRequest: string,
@@ -51,9 +64,11 @@ export function buildRepairPrompt(
   errors: string[],
 ): string {
   return [
-    "The pipeline you generated has invalid filter selection queries.",
-    "Only the megane selection DSL documented in the system prompt is supported",
-    "(fields element/index/x/y/z/resname/mass, quoted string values, and/or/not).",
+    "The pipeline you generated is invalid. Fix the problems listed below.",
+    "Follow the schema and the selection DSL documented in the system prompt",
+    "(filter queries may only use fields element/index/x/y/z/resname/mass with",
+    "quoted string values and and/or/not; every pipeline needs exactly one",
+    "viewport and edges must reference existing nodes).",
     "",
     "Errors:",
     ...errors.map((e) => `- ${e}`),
@@ -65,8 +80,7 @@ export function buildRepairPrompt(
     JSON.stringify(brokenPipeline),
     "```",
     "",
-    "Return the corrected pipeline as a single JSON code block first, fixing the",
-    "invalid queries (rewrite them using only the supported DSL), then one short",
-    "sentence describing what it does.",
+    "Return the corrected pipeline as a single JSON code block first, then one",
+    "short sentence describing what it does.",
   ].join("\n");
 }

--- a/src/ai/validatePipeline.ts
+++ b/src/ai/validatePipeline.ts
@@ -1,0 +1,72 @@
+/**
+ * Post-generation validation of a SerializedPipeline's selection queries, plus
+ * a repair-prompt builder. The LLM frequently emits `filter` queries that use
+ * unsupported syntax (VMD/PyMOL idioms, unquoted strings, etc.); these parse to
+ * "select all" or throw at runtime, silently breaking the selection. We catch
+ * them up front with the same validators the Filter node UI uses, then ask the
+ * model to fix only the broken queries.
+ */
+
+import type { SerializedPipeline } from "../pipeline/types";
+import { validateQuery, validateBondQuery } from "../pipeline/selection";
+
+/**
+ * Validate every `filter` node's `query` / `bond_query` against the selection
+ * DSL grammar. Returns a list of human-readable error strings (one per invalid
+ * query), or an empty array when all queries are syntactically valid.
+ */
+export function collectQueryErrors(pipeline: SerializedPipeline): string[] {
+  const errors: string[] = [];
+  for (const node of pipeline.nodes) {
+    if (node.type !== "filter") continue;
+    const n = node as { id: string; query?: unknown; bond_query?: unknown };
+
+    if (typeof n.query === "string") {
+      const r = validateQuery(n.query);
+      if (!r.valid) {
+        errors.push(`node "${n.id}" query \`${n.query}\`: ${r.error ?? "invalid query"}`);
+      }
+    }
+
+    if (typeof n.bond_query === "string" && n.bond_query.trim() !== "") {
+      const r = validateBondQuery(n.bond_query);
+      if (!r.valid) {
+        errors.push(
+          `node "${n.id}" bond_query \`${n.bond_query}\`: ${r.error ?? "invalid bond query"}`,
+        );
+      }
+    }
+  }
+  return errors;
+}
+
+/**
+ * Build a follow-up user message asking the model to fix the invalid selection
+ * queries it just produced. Includes the original request, the broken pipeline,
+ * and the specific errors so the model can correct only what's wrong.
+ */
+export function buildRepairPrompt(
+  originalRequest: string,
+  brokenPipeline: SerializedPipeline,
+  errors: string[],
+): string {
+  return [
+    "The pipeline you generated has invalid filter selection queries.",
+    "Only the megane selection DSL documented in the system prompt is supported",
+    "(fields element/index/x/y/z/resname/mass, quoted string values, and/or/not).",
+    "",
+    "Errors:",
+    ...errors.map((e) => `- ${e}`),
+    "",
+    `Original request: ${originalRequest}`,
+    "",
+    "Here is the pipeline you produced:",
+    "```json",
+    JSON.stringify(brokenPipeline),
+    "```",
+    "",
+    "Return the corrected pipeline as a single JSON code block first, fixing the",
+    "invalid queries (rewrite them using only the supported DSL), then one short",
+    "sentence describing what it does.",
+  ].join("\n");
+}

--- a/src/components/PipelineChatBox.tsx
+++ b/src/components/PipelineChatBox.tsx
@@ -16,6 +16,7 @@ import {
   RateLimitError,
 } from "../ai/client";
 import { usePipelineStore } from "../pipeline/store";
+import { summarizeStructure } from "../ai/structureSummary";
 import type { NodeSnapshotData } from "../pipeline/execute";
 import type { LoadStructureParams, SerializedPipeline } from "../pipeline/types";
 import { usePipelineUIStore } from "../stores/usePipelineUIStore";
@@ -339,6 +340,11 @@ export function PipelineChatBox({ onPipelineApplied }: { onPipelineApplied?: () 
       onPipelineApplied?.();
     };
 
+    // Summarize the currently loaded structure so the model can build filter
+    // queries from the real elements/resnames present rather than guessing.
+    const { snapshot, atomLabels } = usePipelineStore.getState();
+    const structureSummary = summarizeStructure(snapshot, atomLabels);
+
     try {
       let streamBuffer = "";
       const fullResponse = await generatePipeline(
@@ -369,6 +375,7 @@ export function PipelineChatBox({ onPipelineApplied }: { onPipelineApplied?: () 
           }
         },
         abort.signal,
+        structureSummary,
       );
 
       // Fallback: the JSON may only have closed in the final, non-streamed text

--- a/src/pipeline/selection.ts
+++ b/src/pipeline/selection.ts
@@ -256,7 +256,7 @@ class Parser {
 // --- Evaluator ---
 
 /** Extract residue name from atom label (e.g., "ALA42" → "ALA"). */
-function parseResname(label: string): string {
+export function parseResname(label: string): string {
   const match = label.match(/^([A-Za-z]+)/);
   return match ? match[1] : label;
 }

--- a/tests/ts/ai/client.test.ts
+++ b/tests/ts/ai/client.test.ts
@@ -554,6 +554,90 @@ describe("generatePipeline (demo proxy)", () => {
   });
 });
 
+describe("generatePipeline — structure summary + query repair", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const VALID_FILTER_PIPELINE = JSON.stringify({
+    version: 3,
+    nodes: [{ id: "f1", type: "filter", position: { x: 0, y: 0 }, query: 'element == "C"' }],
+    edges: [],
+  });
+  const INVALID_FILTER_PIPELINE = JSON.stringify({
+    version: 3,
+    nodes: [{ id: "f1", type: "filter", position: { x: 0, y: 0 }, query: "chain A" }],
+    edges: [],
+  });
+
+  function anthropicTextResponse(text: string): Response {
+    return makeSSEResponse([
+      { event: "content_block_delta", data: { delta: { type: "text_delta", text } } },
+      { event: "message_delta", data: { delta: { stop_reason: "end_turn" } } },
+    ]);
+  }
+
+  it("appends the structure summary to the system prompt", async () => {
+    fetchMock.mockResolvedValueOnce(anthropicTextResponse("hi"));
+    await generatePipeline(
+      ANTHROPIC_CONFIG,
+      "msg",
+      () => {},
+      undefined,
+      "STRUCTURE_SUMMARY_MARKER",
+    );
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.system).toContain("STRUCTURE_SUMMARY_MARKER");
+    expect(body.system).toContain("Currently Loaded Structure");
+  });
+
+  it("does not repair when the generated filter queries are valid", async () => {
+    fetchMock.mockResolvedValueOnce(
+      anthropicTextResponse("```json\n" + VALID_FILTER_PIPELINE + "\n```\nDone."),
+    );
+    const result = await generatePipeline(ANTHROPIC_CONFIG, "show carbons", () => {});
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).toContain("Done.");
+  });
+
+  it("runs one repair round trip when a filter query is invalid", async () => {
+    fetchMock.mockResolvedValueOnce(
+      anthropicTextResponse("```json\n" + INVALID_FILTER_PIPELINE + "\n```\nHere."),
+    );
+    fetchMock.mockResolvedValueOnce(
+      anthropicTextResponse("```json\n" + VALID_FILTER_PIPELINE + "\n```\nFixed."),
+    );
+
+    const result = await generatePipeline(ANTHROPIC_CONFIG, "show chain A", () => {});
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // The repair request's user message should reference the invalid query.
+    const repairBody = JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string);
+    const userMsg = repairBody.messages[repairBody.messages.length - 1];
+    expect(userMsg.role).toBe("user");
+    expect(userMsg.content).toContain("invalid filter selection queries");
+    expect(userMsg.content).toContain("chain A");
+    expect(result).toContain("Fixed.");
+  });
+
+  it("repairs at most once even if the repair is still invalid", async () => {
+    // Build a fresh Response each call — a stream body can only be read once.
+    fetchMock.mockImplementation(async () =>
+      anthropicTextResponse("```json\n" + INVALID_FILTER_PIPELINE + "\n```\nStill bad."),
+    );
+    const result = await generatePipeline(ANTHROPIC_CONFIG, "show chain A", () => {});
+    // One initial + one repair = 2; no further attempts.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toContain("Still bad.");
+  });
+});
+
 describe("formatActionSummary", () => {
   it("returns singular phrasing for a single node", () => {
     expect(formatActionSummary(1)).toBe("Pipeline applied — 1 node added to the editor.");

--- a/tests/ts/ai/client.test.ts
+++ b/tests/ts/ai/client.test.ts
@@ -566,14 +566,28 @@ describe("generatePipeline — structure summary + query repair", () => {
     vi.unstubAllGlobals();
   });
 
+  // Schema-valid pipelines (one viewport, edges reference real nodes) so the
+  // filter query is the only variable the repair check reacts to.
   const VALID_FILTER_PIPELINE = JSON.stringify({
     version: 3,
-    nodes: [{ id: "f1", type: "filter", position: { x: 0, y: 0 }, query: 'element == "C"' }],
-    edges: [],
+    nodes: [
+      { id: "f1", type: "filter", position: { x: 0, y: 0 }, query: 'element == "C"' },
+      { id: "v1", type: "viewport", position: { x: 0, y: 310 } },
+    ],
+    edges: [{ source: "f1", target: "v1", sourceHandle: "out", targetHandle: "particle" }],
   });
   const INVALID_FILTER_PIPELINE = JSON.stringify({
     version: 3,
-    nodes: [{ id: "f1", type: "filter", position: { x: 0, y: 0 }, query: "chain A" }],
+    nodes: [
+      { id: "f1", type: "filter", position: { x: 0, y: 0 }, query: "chain A" },
+      { id: "v1", type: "viewport", position: { x: 0, y: 310 } },
+    ],
+    edges: [{ source: "f1", target: "v1", sourceHandle: "out", targetHandle: "particle" }],
+  });
+  // Structurally invalid: references an unknown node type and has no viewport.
+  const INVALID_SCHEMA_PIPELINE = JSON.stringify({
+    version: 3,
+    nodes: [{ id: "x1", type: "not_a_real_node", position: { x: 0, y: 0 } }],
     edges: [],
   });
 
@@ -621,8 +635,25 @@ describe("generatePipeline — structure summary + query repair", () => {
     const repairBody = JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string);
     const userMsg = repairBody.messages[repairBody.messages.length - 1];
     expect(userMsg.role).toBe("user");
-    expect(userMsg.content).toContain("invalid filter selection queries");
+    expect(userMsg.content).toContain("The pipeline you generated is invalid");
     expect(userMsg.content).toContain("chain A");
+    expect(result).toContain("Fixed.");
+  });
+
+  it("runs one repair round trip when the pipeline structure is invalid", async () => {
+    fetchMock.mockResolvedValueOnce(
+      anthropicTextResponse("```json\n" + INVALID_SCHEMA_PIPELINE + "\n```\nHere."),
+    );
+    fetchMock.mockResolvedValueOnce(
+      anthropicTextResponse("```json\n" + VALID_FILTER_PIPELINE + "\n```\nFixed."),
+    );
+
+    const result = await generatePipeline(ANTHROPIC_CONFIG, "build something", () => {});
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const repairBody = JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string);
+    const userMsg = repairBody.messages[repairBody.messages.length - 1];
+    expect(userMsg.content).toContain("not_a_real_node");
+    expect(userMsg.content).toContain("viewport");
     expect(result).toContain("Fixed.");
   });
 

--- a/tests/ts/ai/pipelineSchema.test.ts
+++ b/tests/ts/ai/pipelineSchema.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { collectSchemaErrors } from "@/ai/pipelineSchema";
+import { extractPipelineJSON } from "@/ai/client";
+import { getSkills } from "@/ai/skillLoader";
+import type { SerializedPipeline } from "@/pipeline/types";
+
+function pipeline(p: Partial<SerializedPipeline>): SerializedPipeline {
+  return { version: 3, nodes: [], edges: [], ...p } as SerializedPipeline;
+}
+
+/** A minimal well-formed pipeline: one loader → viewport. */
+const VALID = pipeline({
+  nodes: [
+    { id: "l1", type: "load_structure", position: { x: 0, y: 0 } },
+    { id: "v1", type: "viewport", position: { x: 0, y: 310 } },
+  ],
+  edges: [{ source: "l1", target: "v1", sourceHandle: "particle", targetHandle: "particle" }],
+} as Partial<SerializedPipeline>);
+
+describe("collectSchemaErrors", () => {
+  it("accepts a well-formed pipeline", () => {
+    expect(collectSchemaErrors(VALID)).toEqual([]);
+  });
+
+  it("accepts a pipeline with only a viewport", () => {
+    const p = pipeline({
+      nodes: [{ id: "v1", type: "viewport", position: { x: 0, y: 0 } }],
+      edges: [],
+    } as Partial<SerializedPipeline>);
+    expect(collectSchemaErrors(p)).toEqual([]);
+  });
+
+  it("flags a wrong version", () => {
+    const p = pipeline({ version: 2 as unknown as 3, nodes: VALID.nodes, edges: VALID.edges });
+    expect(collectSchemaErrors(p).some((e) => e.includes("version"))).toBe(true);
+  });
+
+  it("flags an unknown node type", () => {
+    const p = pipeline({
+      nodes: [
+        { id: "x1", type: "bogus", position: { x: 0, y: 0 } },
+        { id: "v1", type: "viewport", position: { x: 0, y: 0 } },
+      ],
+      edges: [],
+    } as Partial<SerializedPipeline>);
+    const errors = collectSchemaErrors(p);
+    expect(errors.some((e) => e.includes("unknown node type") && e.includes("x1"))).toBe(true);
+  });
+
+  it("flags a missing or non-numeric position", () => {
+    const p = pipeline({
+      nodes: [
+        { id: "l1", type: "load_structure" },
+        { id: "v1", type: "viewport", position: { x: 0, y: 0 } },
+      ] as unknown as SerializedPipeline["nodes"],
+      edges: [],
+    });
+    expect(collectSchemaErrors(p).some((e) => e.includes("position"))).toBe(true);
+  });
+
+  it("flags a missing id and duplicate ids", () => {
+    const p = pipeline({
+      nodes: [
+        { id: "dup", type: "load_structure", position: { x: 0, y: 0 } },
+        { id: "dup", type: "viewport", position: { x: 0, y: 0 } },
+      ],
+      edges: [],
+    } as Partial<SerializedPipeline>);
+    expect(collectSchemaErrors(p).some((e) => e.includes("duplicate"))).toBe(true);
+  });
+
+  it("requires exactly one viewport — flags none", () => {
+    const p = pipeline({
+      nodes: [{ id: "l1", type: "load_structure", position: { x: 0, y: 0 } }],
+      edges: [],
+    } as Partial<SerializedPipeline>);
+    expect(collectSchemaErrors(p).some((e) => e.includes("found none"))).toBe(true);
+  });
+
+  it("requires exactly one viewport — flags duplicates", () => {
+    const p = pipeline({
+      nodes: [
+        { id: "v1", type: "viewport", position: { x: 0, y: 0 } },
+        { id: "v2", type: "viewport", position: { x: 0, y: 0 } },
+      ],
+      edges: [],
+    } as Partial<SerializedPipeline>);
+    expect(collectSchemaErrors(p).some((e) => e.includes("found 2"))).toBe(true);
+  });
+
+  it("flags edges with missing handle fields", () => {
+    const p = pipeline({
+      nodes: VALID.nodes,
+      edges: [{ source: "l1", target: "v1" }] as unknown as SerializedPipeline["edges"],
+    });
+    const errors = collectSchemaErrors(p);
+    expect(errors.some((e) => e.includes("sourceHandle"))).toBe(true);
+    expect(errors.some((e) => e.includes("targetHandle"))).toBe(true);
+  });
+
+  it("flags edges that reference nonexistent nodes", () => {
+    const p = pipeline({
+      nodes: VALID.nodes,
+      edges: [
+        { source: "ghost", target: "v1", sourceHandle: "particle", targetHandle: "particle" },
+      ],
+    } as Partial<SerializedPipeline>);
+    expect(collectSchemaErrors(p).some((e) => e.includes('source "ghost"'))).toBe(true);
+  });
+
+  it("returns early when nodes/edges are not arrays", () => {
+    const p = { version: 3, nodes: null, edges: null } as unknown as SerializedPipeline;
+    const errors = collectSchemaErrors(p);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("`nodes` and `edges` arrays");
+  });
+});
+
+describe("shipped skill templates are schema-valid", () => {
+  // The templates the model is told to fetch and customize must themselves
+  // pass the schema, otherwise every customized result starts from a broken base.
+  const skills = getSkills();
+
+  it("loads at least one skill template", () => {
+    expect(skills.length).toBeGreaterThan(0);
+  });
+
+  for (const skill of skills) {
+    it(`${skill.name} embeds a schema-valid pipeline`, () => {
+      const parsed = extractPipelineJSON(skill.content);
+      expect(collectSchemaErrors(parsed)).toEqual([]);
+    });
+  }
+});

--- a/tests/ts/ai/prompt.test.ts
+++ b/tests/ts/ai/prompt.test.ts
@@ -42,4 +42,45 @@ describe("buildSystemPrompt", () => {
   it("is deterministic — two calls return identical strings", () => {
     expect(buildSystemPrompt()).toBe(buildSystemPrompt());
   });
+
+  it("documents the atom selection query fields and operators", () => {
+    expect(prompt).toContain("Atom & Bond Selection Query Language");
+    for (const field of ["element", "index", "resname", "mass"]) {
+      expect(prompt).toContain(field);
+    }
+    // String values must be quoted; warn against the unquoted form.
+    expect(prompt).toContain('element == "C"');
+  });
+
+  it("documents the bond query `both` semantics", () => {
+    expect(prompt).toContain("bond_query");
+    expect(prompt).toContain("both");
+  });
+
+  it("warns that VMD/PyMOL idioms are unsupported", () => {
+    for (const idiom of ["name CA", "chain A", "within 5 of"]) {
+      expect(prompt).toContain(idiom);
+    }
+  });
+});
+
+describe("buildSystemPrompt with structure summary", () => {
+  const summary = "- Atoms: 10 (index 0..9)\n- Elements present: C (6), H (4)";
+
+  it("omits the structure section when no summary is given", () => {
+    expect(buildSystemPrompt()).not.toContain("Currently Loaded Structure");
+    expect(buildSystemPrompt(null)).not.toContain("Currently Loaded Structure");
+  });
+
+  it("appends the structure section when a summary is given", () => {
+    const prompt = buildSystemPrompt(summary);
+    expect(prompt).toContain("Currently Loaded Structure");
+    expect(prompt).toContain(summary);
+  });
+
+  it("keeps the base schema content alongside the structure section", () => {
+    const prompt = buildSystemPrompt(summary);
+    expect(prompt).toContain("load_structure");
+    expect(prompt).toContain('"version": 3');
+  });
 });

--- a/tests/ts/ai/structureSummary.test.ts
+++ b/tests/ts/ai/structureSummary.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { summarizeStructure } from "@/ai/structureSummary";
+import type { Snapshot } from "@/types";
+
+/** Build a minimal Snapshot for testing. Carbon=6, Hydrogen=1, Oxygen=8. */
+function makeSnapshot(elements: number[], opts: Partial<Snapshot> = {}): Snapshot {
+  const nAtoms = elements.length;
+  return {
+    nAtoms,
+    nBonds: 0,
+    nFileBonds: 0,
+    positions: new Float32Array(nAtoms * 3),
+    elements: new Uint8Array(elements),
+    bonds: new Uint32Array(0),
+    bondOrders: null,
+    box: null,
+    atomChainIds: null,
+    atomBFactors: null,
+    ...opts,
+  };
+}
+
+describe("summarizeStructure", () => {
+  it("returns null when no structure is loaded", () => {
+    expect(summarizeStructure(null, null)).toBeNull();
+  });
+
+  it("returns null for an empty structure", () => {
+    expect(summarizeStructure(makeSnapshot([]), null)).toBeNull();
+  });
+
+  it("reports atom count and index range", () => {
+    const summary = summarizeStructure(makeSnapshot([6, 6, 1]), null);
+    expect(summary).toContain("Atoms: 3 (index 0..2)");
+  });
+
+  it("lists elements with counts, sorted by descending count", () => {
+    const summary = summarizeStructure(makeSnapshot([6, 6, 6, 1, 1, 8]), null);
+    // C(3) should come before H(2) before O(1).
+    expect(summary).toContain("Elements present: C (3), H (2), O (1)");
+  });
+
+  it("lists unique residue names from atom labels", () => {
+    const snap = makeSnapshot([6, 6, 8, 8]);
+    const labels = ["ALA1", "ALA1", "HOH2", "HOH3"];
+    const summary = summarizeStructure(snap, labels);
+    expect(summary).toContain("Residue names present: ALA, HOH");
+  });
+
+  it("caps the residue name list and notes how many were omitted", () => {
+    const n = 60;
+    const elements = new Array(n).fill(6);
+    // parseResname keeps only the leading letters, so give each atom a unique
+    // two-letter prefix ("AA1", "AB1", …) to produce 60 distinct resnames.
+    const labels = Array.from({ length: n }, (_, i) => {
+      const a = String.fromCharCode(65 + Math.floor(i / 26));
+      const b = String.fromCharCode(65 + (i % 26));
+      return `${a}${b}1`;
+    });
+    const summary = summarizeStructure(makeSnapshot(elements), labels);
+    expect(summary).toContain("more)");
+    expect(summary).toContain("(10 more)"); // 60 resnames, capped at 50
+  });
+
+  it("omits the residue line when no labels are provided", () => {
+    const summary = summarizeStructure(makeSnapshot([6, 1]), null);
+    expect(summary).not.toContain("Residue names");
+  });
+
+  it("lists chain IDs when present", () => {
+    const snap = makeSnapshot([6, 6, 6], {
+      atomChainIds: new Uint8Array([65, 65, 66]), // 'A', 'A', 'B'
+    });
+    const summary = summarizeStructure(snap, null);
+    expect(summary).toContain("Chains present: A, B");
+  });
+
+  it("reports unit cell and bond presence", () => {
+    const withCell = makeSnapshot([6], { box: new Float32Array(9), nBonds: 2 });
+    const summary = summarizeStructure(withCell, null);
+    expect(summary).toContain("Unit cell: yes");
+    expect(summary).toContain("Bonds: 2");
+
+    const withoutCell = summarizeStructure(makeSnapshot([6]), null);
+    expect(withoutCell).toContain("Unit cell: no");
+  });
+});

--- a/tests/ts/ai/validatePipeline.test.ts
+++ b/tests/ts/ai/validatePipeline.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { collectQueryErrors, buildRepairPrompt } from "@/ai/validatePipeline";
+import {
+  collectQueryErrors,
+  collectPipelineErrors,
+  buildRepairPrompt,
+} from "@/ai/validatePipeline";
 import type { SerializedPipeline } from "@/pipeline/types";
 
 function pipeline(nodes: SerializedPipeline["nodes"]): SerializedPipeline {
@@ -63,6 +67,27 @@ describe("collectQueryErrors", () => {
       { id: "f2", type: "filter", position: { x: 0, y: 0 }, query: "name CA" },
     ] as SerializedPipeline["nodes"]);
     expect(collectQueryErrors(p)).toHaveLength(2);
+  });
+});
+
+describe("collectPipelineErrors", () => {
+  it("returns no errors for a structurally valid pipeline with valid queries", () => {
+    const p = pipeline([
+      { id: "f1", type: "filter", position: { x: 0, y: 0 }, query: 'element == "C"' },
+      { id: "v1", type: "viewport", position: { x: 0, y: 310 } },
+    ] as SerializedPipeline["nodes"]);
+    p.edges = [{ source: "f1", target: "v1", sourceHandle: "out", targetHandle: "particle" }];
+    expect(collectPipelineErrors(p)).toEqual([]);
+  });
+
+  it("combines schema errors and query errors", () => {
+    // No viewport (schema error) AND an invalid query (query error).
+    const p = pipeline([
+      { id: "f1", type: "filter", position: { x: 0, y: 0 }, query: "chain A" },
+    ] as SerializedPipeline["nodes"]);
+    const errors = collectPipelineErrors(p);
+    expect(errors.some((e) => e.includes("viewport"))).toBe(true);
+    expect(errors.some((e) => e.includes("chain A"))).toBe(true);
   });
 });
 

--- a/tests/ts/ai/validatePipeline.test.ts
+++ b/tests/ts/ai/validatePipeline.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { collectQueryErrors, buildRepairPrompt } from "@/ai/validatePipeline";
+import type { SerializedPipeline } from "@/pipeline/types";
+
+function pipeline(nodes: SerializedPipeline["nodes"]): SerializedPipeline {
+  return { version: 3, nodes, edges: [] };
+}
+
+describe("collectQueryErrors", () => {
+  it("returns no errors for valid filter queries", () => {
+    const p = pipeline([
+      { id: "f1", type: "filter", position: { x: 0, y: 0 }, query: 'element == "C"' },
+      { id: "f2", type: "filter", position: { x: 0, y: 0 }, query: "index >= 1 and index <= 9" },
+    ] as SerializedPipeline["nodes"]);
+    expect(collectQueryErrors(p)).toEqual([]);
+  });
+
+  it("treats empty / all / none queries as valid", () => {
+    const p = pipeline([
+      { id: "f1", type: "filter", position: { x: 0, y: 0 }, query: "" },
+      { id: "f2", type: "filter", position: { x: 0, y: 0 }, query: "all" },
+      { id: "f3", type: "filter", position: { x: 0, y: 0 }, query: "none" },
+    ] as SerializedPipeline["nodes"]);
+    expect(collectQueryErrors(p)).toEqual([]);
+  });
+
+  it("flags an invalid atom query and names the node", () => {
+    const p = pipeline([
+      { id: "bad", type: "filter", position: { x: 0, y: 0 }, query: "chain A" },
+    ] as SerializedPipeline["nodes"]);
+    const errors = collectQueryErrors(p);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('node "bad"');
+    expect(errors[0]).toContain("chain A");
+  });
+
+  it("flags an invalid bond query", () => {
+    const p = pipeline([
+      {
+        id: "b1",
+        type: "filter",
+        position: { x: 0, y: 0 },
+        query: "all",
+        bond_query: "within 5 of foo",
+      },
+    ] as SerializedPipeline["nodes"]);
+    const errors = collectQueryErrors(p);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("bond_query");
+  });
+
+  it("ignores non-filter nodes", () => {
+    const p = pipeline([
+      { id: "v1", type: "viewport", position: { x: 0, y: 0 } },
+      { id: "l1", type: "load_structure", position: { x: 0, y: 0 } },
+    ] as SerializedPipeline["nodes"]);
+    expect(collectQueryErrors(p)).toEqual([]);
+  });
+
+  it("collects multiple errors across nodes", () => {
+    const p = pipeline([
+      { id: "f1", type: "filter", position: { x: 0, y: 0 }, query: "protein" },
+      { id: "f2", type: "filter", position: { x: 0, y: 0 }, query: "name CA" },
+    ] as SerializedPipeline["nodes"]);
+    expect(collectQueryErrors(p)).toHaveLength(2);
+  });
+});
+
+describe("buildRepairPrompt", () => {
+  const broken = pipeline([
+    { id: "f1", type: "filter", position: { x: 0, y: 0 }, query: "protein" },
+  ] as SerializedPipeline["nodes"]);
+
+  it("includes the original request, errors, and the broken pipeline JSON", () => {
+    const msg = buildRepairPrompt("show the protein", broken, ['node "f1": bad']);
+    expect(msg).toContain("show the protein");
+    expect(msg).toContain('node "f1": bad');
+    expect(msg).toContain(JSON.stringify(broken));
+    expect(msg).toContain("```json");
+  });
+});

--- a/tests/ts/components/PipelineChatBox.test.tsx
+++ b/tests/ts/components/PipelineChatBox.test.tsx
@@ -59,7 +59,12 @@ import {
   replaceTrailingAssistant,
 } from "@/components/PipelineChatBox";
 import { useAIConfigStore } from "@/ai/config";
-import { generatePipeline, extractPipelineJSON, tryExtractPipeline, RateLimitError } from "@/ai/client";
+import {
+  generatePipeline,
+  extractPipelineJSON,
+  tryExtractPipeline,
+  RateLimitError,
+} from "@/ai/client";
 
 function openConfigPanel() {
   fireEvent.click(screen.getByTitle("AI Settings"));
@@ -188,6 +193,8 @@ describe("PipelineChatBox — submission", () => {
       "build me a pipeline",
       expect.any(Function),
       expect.anything(),
+      // structureSummary — null here since no structure is loaded in this test.
+      null,
     );
   });
 });


### PR DESCRIPTION
## Why

The AI chat (`PipelineChatBox`) asks an LLM to turn a natural-language request into a `SerializedPipeline` JSON. Accuracy was low, **especially for molecular selection** (the `filter` node's `query` / `bond_query`). Root causes:

1. The selection DSL grammar was barely documented in the system prompt, so the model guessed VMD/PyMOL-style syntax that megane does not support.
2. The model had no knowledge of the **actually loaded structure**, so "select the water" / "show the ligand" became guesses at residue names and elements.
3. Generated queries were never validated, so invalid selections silently fell back to "all atoms" or empty.
4. The overall pipeline JSON structure was not enforced.

## What changed

**1. Full selection DSL in the system prompt** (`src/ai/prompt.ts`)
- Documents the exact atom fields (`element/index/x/y/z/resname/mass`), operators, mandatory string quoting, `all`/`none`, and the bond `both` prefix.
- Adds a "common mistakes" mapping table that explicitly rejects unsupported idioms (`name CA`, `chain A`, `within N of`, unquoted elements, `index 1 to 10`, …) and shows the megane equivalent.

**2. Loaded-structure context injection** (`src/ai/structureSummary.ts`, new)
- `summarizeStructure(snapshot, atomLabels)` emits a compact block: atom count + index range, elements present (with counts), residue names present (unique, capped), chains, cell/bond presence.
- `buildSystemPrompt(structureSummary?)` appends it as a "Currently Loaded Structure" section instructing the model to draw `resname`/`element` values only from the real lists. `PipelineChatBox` reads `snapshot`/`atomLabels` from the pipeline store and passes it through `generatePipeline`.
- Reuses `parseResname` (now exported from `selection.ts`) and `getElementSymbol`.

**3. Post-generation validation + one repair round trip** (`src/ai/validatePipeline.ts`, `src/ai/pipelineSchema.ts`, both new)
- `collectQueryErrors` validates every filter `query`/`bond_query` with the existing `validateQuery`/`validateBondQuery`.
- `collectSchemaErrors` validates graph structure (known node types via `NODE_TYPE_LABELS`, well-formed positions, unique ids, exactly one viewport, edges referencing real nodes) — a small hand-rolled validator, no new dependency.
- `collectPipelineErrors` combines both. When `generatePipeline` extracts a pipeline with any error, it runs **one** repair round trip feeding the errors and broken JSON back to the model. Plain-text responses and the streaming/live-apply chat UX are untouched.

> Note: the originally-planned `emit_pipeline` constrained-decoding tool was dropped in favor of this schema-validate-and-repair approach because it works across all providers (incl. the free demo proxy) and keeps the streaming-apply UX and its tests intact.

## Tests
- New unit tests for the prompt content, `structureSummary`, `validatePipeline`, `pipelineSchema` (incl. a guard that the shipped skill templates are schema-valid), and the client repair round trip for both query and structural errors.
- Full vitest suite green (1485 tests); new code patch coverage ~95%, well above the 70% Codecov gate.
- `npm run lint` 0 errors; new files Prettier-clean.
- UI-regression: ran the `pipeline-editor` Playwright project (4/4 pass, incl. the chat pane). LLM calls themselves are external-network and out of automated-E2E scope; no baselines moved.

https://claude.ai/code/session_01CC9HSymL9TXRAUWpWAMUWH

---
_Generated by [Claude Code](https://claude.ai/code/session_01CC9HSymL9TXRAUWpWAMUWH)_