### PR TITLE
Add label-gated CI workflow for LLM prompt before/after comparison

### DIFF
--- a/.github/workflows/llm-prompt-eval.yml
+++ b/.github/workflows/llm-prompt-eval.yml
@@ -1,0 +1,114 @@
+name: LLM Prompt Eval
+
+# Opt-in benchmark: makes real, paid Anthropic API calls to score the LLM
+# pipeline-generator (`bench/llm/`) on the PR branch ("after") and the PR's
+# base branch ("before"), then posts a before/after comparison as a PR
+# comment. Add the `llm-eval` label to a PR to run it.
+#
+# Requires the `ANTHROPIC_API_KEY` repository secret. Note: GitHub does not
+# expose repository secrets to `pull_request` workflows triggered from forks,
+# so this only runs for PRs from branches within this repository.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  llm-prompt-eval:
+    name: LLM prompt before/after eval
+    if: contains(github.event.pull_request.labels.*.name, 'llm-eval')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout PR head (after)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: after
+
+      - name: Checkout PR base (before)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: before
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies (after)
+        working-directory: after
+        run: npm ci
+
+      - name: Install dependencies (before)
+        working-directory: before
+        run: npm ci
+
+      - name: Run benchmark (after = PR branch)
+        working-directory: after
+        env:
+          MEGANE_LLM_BENCH: "1"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          MEGANE_LLM_PROVIDER: anthropic
+          MEGANE_LLM_MODEL: ${{ vars.MEGANE_LLM_BENCH_MODEL || 'claude-haiku-4-5-20251001' }}
+        run: |
+          npx vitest run tests/ts/bench/llm.bench.test.ts
+          cp "$(ls -t bench/llm/results/*.json | head -1)" "$GITHUB_WORKSPACE/after.json"
+
+      - name: Run benchmark (before = base branch)
+        working-directory: before
+        env:
+          MEGANE_LLM_BENCH: "1"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          MEGANE_LLM_PROVIDER: anthropic
+          MEGANE_LLM_MODEL: ${{ vars.MEGANE_LLM_BENCH_MODEL || 'claude-haiku-4-5-20251001' }}
+        run: |
+          npx vitest run tests/ts/bench/llm.bench.test.ts
+          cp "$(ls -t bench/llm/results/*.json | head -1)" "$GITHUB_WORKSPACE/before.json"
+
+      - name: Compare results
+        run: node after/bench/llm/compare-results.mjs before.json after.json comparison.md
+
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: llm-prompt-eval-reports
+          path: |
+            before.json
+            after.json
+            comparison.md
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const body = fs.readFileSync("comparison.md", "utf-8");
+            const marker = "<!-- llm-prompt-eval -->";
+            const comment = `${marker}\n${body}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body && c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: comment,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: comment,
+              });
+            }

--- a/.github/workflows/llm-prompt-eval.yml
+++ b/.github/workflows/llm-prompt-eval.yml
@@ -1,11 +1,11 @@
 name: LLM Prompt Eval
 
-# Opt-in benchmark: makes real, paid Anthropic API calls to score the LLM
-# pipeline-generator (`bench/llm/`) on the PR branch ("after") and the PR's
-# base branch ("before"), then posts a before/after comparison as a PR
+# Opt-in benchmark: makes real, paid LLM API calls (via OpenRouter) to score
+# the LLM pipeline-generator (`bench/llm/`) on the PR branch ("after") and the
+# PR's base branch ("before"), then posts a before/after comparison as a PR
 # comment. Add the `llm-eval` label to a PR to run it.
 #
-# Requires the `ANTHROPIC_API_KEY` repository secret. Note: GitHub does not
+# Requires the `OPENROUTER_API_KEY` repository secret. Note: GitHub does not
 # expose repository secrets to `pull_request` workflows triggered from forks,
 # so this only runs for PRs from branches within this repository.
 
@@ -53,9 +53,9 @@ jobs:
         working-directory: after
         env:
           MEGANE_LLM_BENCH: "1"
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          MEGANE_LLM_PROVIDER: anthropic
-          MEGANE_LLM_MODEL: ${{ vars.MEGANE_LLM_BENCH_MODEL || 'claude-haiku-4-5-20251001' }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          MEGANE_LLM_PROVIDER: openrouter
+          MEGANE_LLM_MODEL: ${{ vars.MEGANE_LLM_BENCH_MODEL || 'anthropic/claude-haiku-4.5' }}
         run: |
           npx vitest run tests/ts/bench/llm.bench.test.ts
           cp "$(ls -t bench/llm/results/*.json | head -1)" "$GITHUB_WORKSPACE/after.json"
@@ -64,9 +64,9 @@ jobs:
         working-directory: before
         env:
           MEGANE_LLM_BENCH: "1"
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          MEGANE_LLM_PROVIDER: anthropic
-          MEGANE_LLM_MODEL: ${{ vars.MEGANE_LLM_BENCH_MODEL || 'claude-haiku-4-5-20251001' }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          MEGANE_LLM_PROVIDER: openrouter
+          MEGANE_LLM_MODEL: ${{ vars.MEGANE_LLM_BENCH_MODEL || 'anthropic/claude-haiku-4.5' }}
         run: |
           npx vitest run tests/ts/bench/llm.bench.test.ts
           cp "$(ls -t bench/llm/results/*.json | head -1)" "$GITHUB_WORKSPACE/before.json"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,19 @@ When invoking Playwright directly (`npx playwright test ...`), prefix with `PATH
 | `node scripts/dev-preview.mjs --screenshot` | Dev preview screenshots |
 | `node scripts/capture-screenshots.mjs` | Hero screenshot for docs |
 
+## LLM Prompt-Eval CI (bench/llm)
+
+`bench/llm/` is a prompt-suite + scorer that grades megane's LLM pipeline
+generator (`src/ai/prompt.ts` + skills) on a fixed dataset of requests. Adding
+the **`llm-eval`** label to a PR runs `.github/workflows/llm-prompt-eval.yml`,
+which scores the PR branch and its base branch via OpenRouter
+(`OPENROUTER_API_KEY` repository secret, model defaults to
+`anthropic/claude-haiku-4.5`, overridable via the `MEGANE_LLM_BENCH_MODEL`
+repository variable) and posts a before/after score comparison as a PR
+comment. It is opt-in (real, paid API calls) and only runs for PRs from
+branches within this repository (forks don't get secrets). See
+`bench/llm/README.md` for the full rubric and local usage.
+
 ## Skills
 
 Project-specific skills are defined in `.claude/skills/`. Each skill provides instructions for a specific workflow. Always follow the skill's instructions when performing the corresponding task.

--- a/bench/llm/README.md
+++ b/bench/llm/README.md
@@ -37,6 +37,11 @@ MEGANE_LLM_BENCH=1 OPENAI_API_KEY=sk-... \
   MEGANE_LLM_PROVIDER=openai MEGANE_LLM_MODEL=gpt-4o \
   npx vitest run tests/ts/bench/llm.bench.test.ts
 
+# OpenRouter
+MEGANE_LLM_BENCH=1 OPENROUTER_API_KEY=sk-or-... \
+  MEGANE_LLM_PROVIDER=openrouter MEGANE_LLM_MODEL=anthropic/claude-haiku-4.5 \
+  npx vitest run tests/ts/bench/llm.bench.test.ts
+
 # Demo proxy (no key; picks the model server-side)
 MEGANE_LLM_BENCH=1 MEGANE_LLM_PROVIDER=demo \
   MEGANE_LLM_PROXY_URL=https://proxy.example.com/chat \
@@ -81,10 +86,10 @@ For PRs that change the system prompt, skills, or dataset/rubrics, add the
    and per-case score deltas, plus any cases that regressed by >= 5
    percentage points.
 
-It requires the `ANTHROPIC_API_KEY` repository secret and makes real, paid API
-calls (32 generations per run: 16 cases x before/after), so it is opt-in via
-the label rather than running on every PR. The model defaults to
-`claude-haiku-4-5-20251001`; override it with the `MEGANE_LLM_BENCH_MODEL`
-repository variable. Because GitHub withholds secrets from `pull_request`
-workflows triggered by forks, this only runs for PRs from branches within the
-repository.
+It requires the `OPENROUTER_API_KEY` repository secret and makes real, paid API
+calls via OpenRouter (32 generations per run: 16 cases x before/after), so it
+is opt-in via the label rather than running on every PR. The model defaults to
+`anthropic/claude-haiku-4.5`; override it with the `MEGANE_LLM_BENCH_MODEL`
+repository variable (use any OpenRouter model slug). Because GitHub withholds
+secrets from `pull_request` workflows triggered by forks, this only runs for
+PRs from branches within the repository.

--- a/bench/llm/README.md
+++ b/bench/llm/README.md
@@ -67,3 +67,24 @@ rubrics referencing only node types/params the system prompt documents, so a
 perfect model can reach 1.0. Deterministic logic (scorer, extract, skills,
 dataset shape) is covered by `tests/ts/bench/bench-unit.test.ts`, which runs in
 the normal `npm test` suite.
+
+## CI: before/after prompt comparison
+
+For PRs that change the system prompt, skills, or dataset/rubrics, add the
+**`llm-eval`** label to run `.github/workflows/llm-prompt-eval.yml`. It:
+
+1. Runs the live benchmark on the PR branch ("after") and on the PR's base
+   commit ("before"), both with the same model.
+2. Diffs the two `bench/llm/results/*.json` reports with
+   `bench/llm/compare-results.mjs`.
+3. Posts (and updates, on subsequent pushes) a PR comment with the aggregate
+   and per-case score deltas, plus any cases that regressed by >= 5
+   percentage points.
+
+It requires the `ANTHROPIC_API_KEY` repository secret and makes real, paid API
+calls (32 generations per run: 16 cases x before/after), so it is opt-in via
+the label rather than running on every PR. The model defaults to
+`claude-haiku-4-5-20251001`; override it with the `MEGANE_LLM_BENCH_MODEL`
+repository variable. Because GitHub withholds secrets from `pull_request`
+workflows triggered by forks, this only runs for PRs from branches within the
+repository.

--- a/bench/llm/compare-results.mjs
+++ b/bench/llm/compare-results.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Compare two `bench/llm` JSON reports (the `toJSON()` shape from
+ * `bench/llm/report.ts`) and render a Markdown summary of the score
+ * differences, for posting as a PR comment.
+ *
+ * Usage:
+ *   node compare-results.mjs <before.json> <after.json> [out.md]
+ *
+ * Plain Node (no TS runner) so it can run in CI without a build step.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const DIMENSIONS = ["schema", "task", "params", "format"];
+
+/** A case is flagged as a regression when its total drops by more than this. */
+const REGRESSION_THRESHOLD = 0.05;
+
+function pct(x) {
+  return x === null || x === undefined ? "—" : `${Math.round(x * 100)}%`;
+}
+
+/** Signed percentage-point delta, or "—" when either side is missing. */
+function delta(before, after) {
+  if (before === null || before === undefined || after === null || after === undefined) {
+    return "—";
+  }
+  const d = Math.round((after - before) * 100);
+  if (d === 0) return "±0";
+  return d > 0 ? `+${d}` : `${d}`;
+}
+
+function loadReport(path) {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+export function buildComparisonMarkdown(before, after) {
+  const lines = [];
+  lines.push("## LLM prompt-eval: before vs after");
+  lines.push("");
+  lines.push(
+    `- **before**: ${before.meta.provider} / ${before.meta.model} (${before.meta.timestamp})`,
+  );
+  lines.push(`- **after**: ${after.meta.provider} / ${after.meta.model} (${after.meta.timestamp})`);
+  lines.push("");
+  lines.push("### Aggregate");
+  lines.push("");
+  lines.push("| metric | before | after | Δ |");
+  lines.push("|---|---|---|---|");
+  lines.push(
+    `| mean total | ${pct(before.aggregate.meanTotal)} | ${pct(after.aggregate.meanTotal)} | ` +
+      `${delta(before.aggregate.meanTotal, after.aggregate.meanTotal)} |`,
+  );
+  lines.push(
+    `| pass rate (>= ${pct(after.aggregate.passThreshold)}) | ${pct(before.aggregate.passRate)} | ` +
+      `${pct(after.aggregate.passRate)} | ${delta(before.aggregate.passRate, after.aggregate.passRate)} |`,
+  );
+  for (const dim of DIMENSIONS) {
+    lines.push(
+      `| ${dim} | ${pct(before.aggregate.byDimension[dim])} | ${pct(after.aggregate.byDimension[dim])} | ` +
+        `${delta(before.aggregate.byDimension[dim], after.aggregate.byDimension[dim])} |`,
+    );
+  }
+  lines.push("");
+
+  lines.push("### Per case");
+  lines.push("");
+  lines.push("| case | before | after | Δ |");
+  lines.push("|---|---|---|---|");
+  const beforeById = new Map(before.cases.map((c) => [c.id, c]));
+  const regressions = [];
+  for (const afterCase of after.cases) {
+    const beforeCase = beforeById.get(afterCase.id);
+    const b = beforeCase ? beforeCase.total : null;
+    const a = afterCase.total;
+    lines.push(`| ${afterCase.id} | ${pct(b)} | ${pct(a)} | ${delta(b, a)} |`);
+    if (b !== null && b - a >= REGRESSION_THRESHOLD) {
+      regressions.push(afterCase);
+    }
+  }
+  lines.push("");
+
+  if (regressions.length > 0) {
+    lines.push(`### Regressions (score dropped by >= ${Math.round(REGRESSION_THRESHOLD * 100)}pp)`);
+    lines.push("");
+    for (const r of regressions) {
+      lines.push(
+        `- **${r.id}**: ${r.failedChecks.length ? r.failedChecks.join("; ") : "(no failed checks recorded)"}`,
+      );
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function main() {
+  const [beforePath, afterPath, outPath] = process.argv.slice(2);
+  if (!beforePath || !afterPath) {
+    console.error("Usage: compare-results.mjs <before.json> <after.json> [out.md]");
+    process.exit(1);
+  }
+
+  const before = loadReport(beforePath);
+  const after = loadReport(afterPath);
+  const md = buildComparisonMarkdown(before, after);
+
+  if (outPath) {
+    writeFileSync(outPath, md);
+  } else {
+    process.stdout.write(md);
+  }
+}
+
+const isMain = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  main();
+}

--- a/bench/llm/providers.ts
+++ b/bench/llm/providers.ts
@@ -4,11 +4,12 @@
  * These mirror the production request shapes in `src/ai/client.ts` (same system
  * prompt via `buildSystemPrompt`, same on-demand skill tool round trips) but
  * use non-streaming requests for simplicity — the benchmark only needs the
- * final text. Supports Anthropic, OpenAI, and the demo proxy.
+ * final text. Supports Anthropic, OpenAI, OpenRouter, and the demo proxy.
  *
  * API credentials come from the environment:
  *   - ANTHROPIC_API_KEY  (provider "anthropic")
  *   - OPENAI_API_KEY     (provider "openai")
+ *   - OPENROUTER_API_KEY (provider "openrouter")
  *   - MEGANE_LLM_PROXY_URL (provider "demo")
  */
 
@@ -21,7 +22,7 @@ import {
   type BenchSkill,
 } from "./skills";
 
-export type ProviderName = "anthropic" | "openai" | "demo";
+export type ProviderName = "anthropic" | "openai" | "openrouter" | "demo";
 
 export interface ProviderConfig {
   provider: ProviderName;
@@ -57,6 +58,13 @@ export function configFromEnv(
       apiKey: env.OPENAI_API_KEY,
     };
   }
+  if (provider === "openrouter") {
+    return {
+      provider,
+      model: env.MEGANE_LLM_MODEL || "anthropic/claude-haiku-4.5",
+      apiKey: env.OPENROUTER_API_KEY,
+    };
+  }
   return { provider: "demo", model: "demo", proxyUrl: env.MEGANE_LLM_PROXY_URL };
 }
 
@@ -67,6 +75,9 @@ export function assertConfig(config: ProviderConfig): void {
   }
   if (config.provider === "openai" && !config.apiKey) {
     throw new Error("OPENAI_API_KEY is not set");
+  }
+  if (config.provider === "openrouter" && !config.apiKey) {
+    throw new Error("OPENROUTER_API_KEY is not set");
   }
   if (config.provider === "demo" && !config.proxyUrl) {
     throw new Error("MEGANE_LLM_PROXY_URL is not set");
@@ -187,7 +198,11 @@ async function runOpenAICompat(
     { role: "user", content: userMessage },
   ];
   const isDemo = config.provider === "demo";
-  const url = isDemo ? config.proxyUrl! : "https://api.openai.com/v1/chat/completions";
+  const url = isDemo
+    ? config.proxyUrl!
+    : config.provider === "openrouter"
+      ? "https://openrouter.ai/api/v1/chat/completions"
+      : "https://api.openai.com/v1/chat/completions";
 
   for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
     const body: Record<string, unknown> = { messages };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,6 +25,17 @@ export default tseslint.config(
       ...reactHooks.configs.recommended.rules,
     },
   },
+  {
+    // Plain Node CLI scripts (e.g. CI helper scripts) run outside the
+    // browser/Vite environment, so `process`/`console` need Node globals.
+    files: ["bench/**/*.mjs"],
+    languageOptions: {
+      globals: {
+        process: "readonly",
+        console: "readonly",
+      },
+    },
+  },
   eslintConfigPrettier,
   {
     rules: {


### PR DESCRIPTION
Adds .github/workflows/llm-prompt-eval.yml, which runs the live
bench/llm benchmark on a PR's head and base commits when the PR is
tagged with the `llm-eval` label, then posts a before/after score
comparison as a PR comment via bench/llm/compare-results.mjs.

Requires the ANTHROPIC_API_KEY repository secret.