### PR TITLE
Add caffeine-in-water transparency case to LLM prompt-eval bench

### DIFF
--- a/bench/llm/dataset.ts
+++ b/bench/llm/dataset.ts
@@ -264,6 +264,37 @@ export const DATASET: BenchCase[] = [
       minNodes: 5,
     },
   },
+  {
+    id: "multistep-water-transparent",
+    prompt:
+      "I have a caffeine molecule dissolved in water, where the water residues are named HOH. Keep the caffeine fully visible, but make the water molecules semi-transparent.",
+    tags: ["multistep", "filter", "modify", "params"],
+    rubric: {
+      requiredNodeTypes: ["load_structure", "filter", "modify", "viewport"],
+      requiredConnections: [
+        { sourceType: "filter", targetType: "modify", sourceHandle: "out", targetHandle: "in" },
+        {
+          sourceType: "modify",
+          targetType: "viewport",
+          sourceHandle: "out",
+          targetHandle: "particle",
+        },
+      ],
+      paramChecks: [
+        {
+          label: 'filter.query selects water (resname == "HOH")',
+          nodeType: "filter",
+          test: (n) => /resname\s*==\s*["']?HOH["']?/i.test(str(n, "query")),
+        },
+        {
+          label: "modify.opacity is below 1 (transparent)",
+          nodeType: "modify",
+          test: (n) => num(n, "opacity") < 1 && num(n, "opacity") > 0,
+        },
+      ],
+      minNodes: 4,
+    },
+  },
 
   // ── Multilingual robustness (Japanese) ───────────────────────────────
   {


### PR DESCRIPTION
## Summary
- Add a new `bench/llm/dataset.ts` case (`multistep-water-transparent`) covering a "caffeine dissolved in water, make the water semi-transparent" request, mirroring the project's `caffeine_water` demo where water residues are named `HOH`.
- The rubric requires `load_structure -> filter(resname == "HOH") -> modify(opacity < 1) -> viewport`.

## Test plan
- [x] `npx vitest run tests/ts/bench/bench-unit.test.ts` — 33/33 passed, confirming the new case has a valid structural shape (known node types/connections only).
- No prompt/source changes in this PR, so no E2E run required.


---
_Generated by [Claude Code](https://claude.ai/code/session_017BjfHaNzXnzHkq7Fvc3qic)_