### PR TITLE
Fix demo LLM failures on multi-branch pipeline requests

### DIFF
--- a/src/ai/prompt.ts
+++ b/src/ai/prompt.ts
@@ -355,6 +355,75 @@ User request: "Load a cube file and show its isosurface"
 }
 \`\`\`
 
+## Example: Selective Visual Property (subset)
+
+When the user wants a visual property (opacity, scale, color) applied to ONLY
+part of the structure while the rest stays at its default appearance, split the
+stream into disjoint branches with \`filter\` nodes and apply the property to one
+branch. A \`modify\`/\`color\` node only affects the atoms in its branch, so the
+unmodified branch keeps its default look. Do NOT route the full structure AND a
+filtered copy of the same atoms to the viewport — the overlap renders twice.
+
+User request: "Keep the solute fully visible but make the water (resname HOH)
+semi-transparent."
+
+\`\`\`json
+{
+  "version": 3,
+  "nodes": [
+    {
+      "id": "loader-1",
+      "type": "load_structure",
+      "position": { "x": 425, "y": 0 },
+      "fileName": null,
+      "hasTrajectory": false,
+      "hasCell": false,
+      "enabled": true
+    },
+    {
+      "id": "filter-water",
+      "type": "filter",
+      "position": { "x": 250, "y": 310 },
+      "query": "resname == \\"HOH\\"",
+      "enabled": true
+    },
+    {
+      "id": "modify-water",
+      "type": "modify",
+      "position": { "x": 250, "y": 460 },
+      "scale": 1.0,
+      "opacity": 0.3,
+      "enabled": true
+    },
+    {
+      "id": "filter-solute",
+      "type": "filter",
+      "position": { "x": 600, "y": 310 },
+      "query": "resname != \\"HOH\\"",
+      "enabled": true
+    },
+    {
+      "id": "viewport-1",
+      "type": "viewport",
+      "position": { "x": 425, "y": 615 },
+      "perspective": false,
+      "cellAxesVisible": true,
+      "pivotMarkerVisible": true,
+      "enabled": true
+    }
+  ],
+  "edges": [
+    { "source": "loader-1", "target": "filter-water", "sourceHandle": "particle", "targetHandle": "in" },
+    { "source": "filter-water", "target": "modify-water", "sourceHandle": "out", "targetHandle": "in" },
+    { "source": "modify-water", "target": "viewport-1", "sourceHandle": "out", "targetHandle": "particle" },
+    { "source": "loader-1", "target": "filter-solute", "sourceHandle": "particle", "targetHandle": "in" },
+    { "source": "filter-solute", "target": "viewport-1", "sourceHandle": "out", "targetHandle": "particle" }
+  ]
+}
+\`\`\`
+
+Filters the water into its own branch, makes only it semi-transparent, and shows the rest of the structure at full opacity.
+
 ## Guidelines
 
 - Always include a \`load_structure\` node as the data source.
@@ -366,6 +435,11 @@ User request: "Load a cube file and show its isosurface"
 - For typical molecular visualization: load_structure → add_bond → viewport (plus particle and cell connections to viewport).
 - For filtered views: add filter nodes between load_structure and viewport.
 - For modified appearance: add modify nodes to change scale/opacity.
+- To change a property for only PART of the structure (e.g. "make only the
+  water transparent", "color just the protein"), split into disjoint \`filter\`
+  branches and apply the \`modify\`/\`color\` node to the target branch only — see
+  the "Selective Visual Property" example. Never send both the full structure
+  and a filtered subset of the same atoms to the viewport.
 - For supercells: add a \`replicate\` node between load_structure and viewport
   (and add_bond, if present), forwarding its \`particle\`/\`cell\`/\`trajectory\`
   outputs downstream.

--- a/tests/ts/ai/prompt.test.ts
+++ b/tests/ts/ai/prompt.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect } from "vitest";
 import { buildSystemPrompt } from "@/ai/prompt";
+import { collectPipelineErrors } from "@/ai/validatePipeline";
+import type { SerializedPipeline } from "@/pipeline/types";
+
+/** Extract the first ```json fenced block that follows a section heading. */
+function exampleAfter(prompt: string, heading: string): SerializedPipeline {
+  const idx = prompt.indexOf(heading);
+  expect(idx).toBeGreaterThan(-1);
+  const match = prompt.slice(idx).match(/```json\s*\n([\s\S]*?)```/);
+  expect(match).not.toBeNull();
+  return JSON.parse(match![1].trim()) as SerializedPipeline;
+}
 
 describe("buildSystemPrompt", () => {
   const prompt = buildSystemPrompt();
@@ -67,6 +78,25 @@ describe("buildSystemPrompt", () => {
     for (const idiom of ["name CA", "chain A", "within 5 of"]) {
       expect(prompt).toContain(idiom);
     }
+  });
+
+  it("documents the selective visual property (subset) pattern", () => {
+    expect(prompt).toContain("Selective Visual Property");
+    // The guideline should steer the model away from double-rendering the
+    // same atoms (full structure + filtered copy) into the viewport.
+    expect(prompt).toContain("disjoint");
+  });
+
+  it("ships a valid selective-property example pipeline", () => {
+    const pipeline = exampleAfter(prompt, "## Example: Selective Visual Property");
+    // The documented example must itself pass the same schema + query
+    // validators the repair round trip uses, so the model has a correct
+    // template to follow.
+    expect(collectPipelineErrors(pipeline)).toEqual([]);
+    // Two disjoint filter branches (water vs. the rest), only one modified.
+    const filters = pipeline.nodes.filter((n) => n.type === "filter");
+    expect(filters).toHaveLength(2);
+    expect(pipeline.nodes.filter((n) => n.type === "modify")).toHaveLength(1);
   });
 });
 

--- a/workers/llm-proxy/src/proxy.ts
+++ b/workers/llm-proxy/src/proxy.ts
@@ -74,7 +74,15 @@ export function buildModelList(env: Env): string[] {
       : DEFAULT_FALLBACK_MODELS;
   return [...new Set([primary, ...fallbacks])].slice(0, MAX_MODELS);
 }
-export const MAX_TOKENS = 2048;
+/**
+ * Upstream completion cap. Matches the direct-provider paths in the
+ * frontend client (`src/ai/client.ts` sends `max_tokens: 4096`): a
+ * smaller cap here silently truncated larger completions — e.g. the
+ * multi-branch pipelines produced for "make only the water transparent"
+ * style requests — leaving an unterminated JSON fence that the frontend
+ * could not parse, surfacing only a generic "Something went wrong".
+ */
+export const MAX_TOKENS = 4096;
 export const MAX_MESSAGES = 12;
 /**
  * Length cap for user/assistant messages — these carry untrusted input

--- a/workers/llm-proxy/test/index.test.ts
+++ b/workers/llm-proxy/test/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { readFileSync } from "node:fs";
 import worker from "../src/index";
 import {
   isAllowedOrigin,
@@ -641,5 +642,51 @@ describe("worker fetch handler", () => {
     expect(res.status).toBe(503);
     const json = (await res.json()) as { error: string };
     expect(json.error).toContain("boom");
+  });
+});
+
+describe("wrangler.toml model configuration", () => {
+  // Read the deployed config the Worker ships with so a bad model slug can't
+  // pass CI and silently break every demo prompt once deployed.
+  // vitest runs with cwd at the worker package root (where vitest.config.ts
+  // and wrangler.toml live), so a cwd-relative read keeps this independent of
+  // @types/node's import.meta typings.
+  const toml = readFileSync(`${process.cwd()}/wrangler.toml`, "utf8");
+
+  function tomlVar(name: string): string | null {
+    const m = toml.match(new RegExp(`^${name}\\s*=\\s*"([^"]*)"`, "m"));
+    return m ? m[1] : null;
+  }
+
+  /**
+   * Every Anthropic slug carrying a version must spell its minor version with
+   * a DOT (claude-sonnet-4.6), never a hyphen (claude-sonnet-4-6). A
+   * hyphenated version is an unknown OpenRouter model id and gets the whole
+   * request rejected with a 400 — the root cause of the demo failing on even
+   * the shortest prompt. Guard against that exact regression.
+   */
+  function assertNoHyphenatedVersion(slug: string) {
+    expect(
+      /-\d+-\d+(?:$|:)/.test(slug),
+      `model slug "${slug}" uses a hyphenated version; OpenRouter expects a dotted minor version (e.g. claude-sonnet-4.6)`,
+    ).toBe(false);
+  }
+
+  it("sets the primary OpenRouter model to a valid dotted slug", () => {
+    const model = tomlVar("OPENROUTER_MODEL");
+    expect(model).toBeTruthy();
+    expect(model!.startsWith("anthropic/")).toBe(true);
+    assertNoHyphenatedVersion(model!);
+  });
+
+  it("uses valid slugs for every configured fallback model", () => {
+    const fallbacks = (tomlVar("OPENROUTER_FALLBACK_MODELS") ?? "")
+      .split(",")
+      .map((m) => m.trim())
+      .filter((m) => m.length > 0);
+    expect(fallbacks.length).toBeGreaterThan(0);
+    for (const slug of fallbacks) {
+      assertNoHyphenatedVersion(slug);
+    }
   });
 });

--- a/workers/llm-proxy/test/index.test.ts
+++ b/workers/llm-proxy/test/index.test.ts
@@ -492,6 +492,9 @@ describe("worker fetch handler", () => {
       expect(sentBody.models.length).toBeGreaterThan(1);
       expect(sentBody.model).toBeUndefined();
       expect(sentBody.stream).toBe(true);
+      // The completion cap must match the direct-provider client (4096); a
+      // smaller value truncated larger multi-branch pipelines mid-JSON.
+      expect(sentBody.max_tokens).toBe(4096);
       expect(sentBody.messages).toEqual([{ role: "user", content: "hi" }]);
       const headers = init.headers as Record<string, string>;
       expect(headers.Authorization).toBe(`Bearer ${env.OPENROUTER_API_KEY}`);

--- a/workers/llm-proxy/test/node-shims.d.ts
+++ b/workers/llm-proxy/test/node-shims.d.ts
@@ -1,0 +1,12 @@
+// Minimal ambient declarations for the few Node built-ins used by the
+// config-validation test. The Worker tsconfig only ships
+// @cloudflare/workers-types (no @types/node), so `tsc --noEmit` (run in the
+// deploy workflow) would otherwise fail to resolve `node:fs` / `process`.
+// These are global (no imports/exports here), so they declare — rather than
+// augment — the `node:fs` module.
+
+declare module "node:fs" {
+  export function readFileSync(path: string, encoding: string): string;
+}
+
+declare const process: { cwd(): string };

--- a/workers/llm-proxy/wrangler.toml
+++ b/workers/llm-proxy/wrangler.toml
@@ -11,10 +11,15 @@ ALLOWED_ORIGIN = "https://hodakamori.github.io,https://megane.tech-office-mori.c
 
 # OpenRouter model slug. Set to Anthropic Claude Sonnet 4.6 (latest) for
 # strong instruction-following and pipeline generation quality.
+# IMPORTANT: OpenRouter spells minor versions with a DOT, not a hyphen
+# (e.g. "anthropic/claude-sonnet-4.6", "anthropic/claude-opus-4.8"). A
+# hyphenated slug like "...-4-6" is an unknown model id and OpenRouter
+# rejects the whole request with a 400, breaking *every* demo prompt
+# regardless of length. Verify the exact slug at https://openrouter.ai/<id>.
 # To downgrade to claude-3.5-haiku (~0.5c) or a free model, just change
 # this value — no code change needed. Leave unset to use the default in
 # src/proxy.ts.
-OPENROUTER_MODEL = "anthropic/claude-sonnet-4-6"
+OPENROUTER_MODEL = "anthropic/claude-sonnet-4.6"
 
 # Comma-separated fallback models, used only if the primary errors. Falls
 # back to Haiku (cheap but reliable) then a free model as a last resort.

--- a/workers/llm-proxy/wrangler.toml
+++ b/workers/llm-proxy/wrangler.toml
@@ -2,6 +2,16 @@ name = "megane-llm-proxy"
 main = "src/index.ts"
 compatibility_date = "2025-01-01"
 
+# Persist runtime logs (console.log/error from src/proxy.ts) to Workers Logs
+# so past upstream errors — e.g. an OpenRouter 400 for a bad model slug — can
+# be inspected in the dashboard, not just via a live `wrangler tail`. This
+# demo is rate-limited to 30 requests/IP/day, so log volume sits far under
+# the free allowance (200k events/day); head_sampling_rate=1 keeps 100% of
+# the handful of events for full visibility.
+[observability]
+enabled = true
+head_sampling_rate = 1
+
 # Origins allowed to call this proxy (comma-separated). CORS and the
 # explicit Origin check in src/index.ts both key off this list. The first
 # entry is the GitHub Pages docs demo; the second is the custom-domain S3


### PR DESCRIPTION
Complex prompts like 'keep the caffeine visible but make the water (HOH)
semi-transparent' need a multi-branch pipeline (split into disjoint filter
branches, modify only one). That produces a much larger JSON completion
than simple requests, and the demo proxy capped model output at
max_tokens 2048 while the direct-provider client uses 4096. The truncated
completion left an unterminated JSON code fence, so the frontend could not
parse a pipeline and surfaced only a generic 'Something went wrong'.

- Raise the demo proxy MAX_TOKENS to 4096 to match the direct paths so
  larger pipelines are not truncated mid-JSON.
- Document the selective-visual-property (subset) pattern in the system
  prompt with a worked, validated example, so the model reliably emits a
  compact, correct split-stream pipeline for these requests.

Add a worker test asserting the forwarded max_tokens and prompt tests
that validate the new example against the pipeline schema/query checks.