### PR TITLE
perf: speed up LAMMPS data and GRO/TOP loading

### DIFF
--- a/crates/megane-core/src/atomic.rs
+++ b/crates/megane-core/src/atomic.rs
@@ -291,7 +291,10 @@ pub(crate) fn element_from_atom_name(name: &str) -> u8 {
     // Two-character symbol first (e.g. "CL" → "Cl", "FE" → "Fe").
     if let Some(second) = second {
         let num = if first.is_ascii() && second.is_ascii() {
-            let buf = [first.to_ascii_uppercase() as u8, second.to_ascii_lowercase() as u8];
+            let buf = [
+                first.to_ascii_uppercase() as u8,
+                second.to_ascii_lowercase() as u8,
+            ];
             symbol_to_atomic_num(std::str::from_utf8(&buf).unwrap_or(""))
         } else {
             let two: String = first.to_uppercase().chain(second.to_lowercase()).collect();

--- a/crates/megane-core/src/atomic.rs
+++ b/crates/megane-core/src/atomic.rs
@@ -370,5 +370,10 @@ mod tests {
         assert_eq!(element_from_atom_name("2HW"), 1); // Digit prefix, "Hw"→fallback "H"
         assert_eq!(element_from_atom_name("123"), 0); // No alphabetic chars
         assert_eq!(element_from_atom_name("Zz"), 0); // Unknown two-char, no single fallback
+
+        // Non-ASCII names exercise the Unicode-aware fallback paths (which can
+        // never match an ASCII element symbol, so they resolve to 0).
+        assert_eq!(element_from_atom_name("Ωz"), 0); // two-char + single-char Unicode fallback
+        assert_eq!(element_from_atom_name("Ω"), 0); // single-char Unicode fallback
     }
 }

--- a/crates/megane-core/src/atomic.rs
+++ b/crates/megane-core/src/atomic.rs
@@ -273,34 +273,43 @@ pub(crate) fn mass_to_atomic_num(mass: f32) -> u8 {
 /// Tries a two-character symbol first (e.g. "Cl", "Fe"), then falls back to
 /// the first character.
 pub(crate) fn element_from_atom_name(name: &str) -> u8 {
-    let name = name.trim();
-    if name.is_empty() {
-        return 0;
-    }
-
-    let clean: String = name.chars().filter(|c| c.is_alphabetic()).collect();
-    if clean.is_empty() {
-        return 0;
-    }
-
-    let mut chars = clean.chars();
-    let first = match chars.next() {
+    // Take the first two alphabetic characters without allocating an
+    // intermediate "cleaned" string.
+    let mut alpha = name.chars().filter(|c| c.is_alphabetic());
+    let first = match alpha.next() {
         Some(c) => c,
         None => return 0,
     };
+    let second = alpha.next();
 
-    // Try two-character symbol first (e.g. "CL" → "Cl", "FE" → "Fe")
-    if let Some(second) = chars.next() {
-        let two: String = first.to_uppercase().chain(second.to_lowercase()).collect();
-        let num = symbol_to_atomic_num(&two);
+    // Element symbols are ASCII (1–2 letters), so for the overwhelmingly
+    // common ASCII case we case-fold into a small stack buffer and avoid the
+    // per-call heap allocations. Exotic non-ASCII names keep the original
+    // Unicode-aware path (they never match an ASCII symbol anyway), so the
+    // returned atomic number is identical for every input.
+
+    // Two-character symbol first (e.g. "CL" → "Cl", "FE" → "Fe").
+    if let Some(second) = second {
+        let num = if first.is_ascii() && second.is_ascii() {
+            let buf = [first.to_ascii_uppercase() as u8, second.to_ascii_lowercase() as u8];
+            symbol_to_atomic_num(std::str::from_utf8(&buf).unwrap_or(""))
+        } else {
+            let two: String = first.to_uppercase().chain(second.to_lowercase()).collect();
+            symbol_to_atomic_num(&two)
+        };
         if num != 0 {
             return num;
         }
     }
 
-    // Fall back to single character
-    let one: String = first.to_uppercase().collect();
-    symbol_to_atomic_num(&one)
+    // Fall back to a single-character symbol.
+    if first.is_ascii() {
+        let buf = [first.to_ascii_uppercase() as u8];
+        symbol_to_atomic_num(std::str::from_utf8(&buf).unwrap_or(""))
+    } else {
+        let one: String = first.to_uppercase().collect();
+        symbol_to_atomic_num(&one)
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────
@@ -353,5 +362,10 @@ mod tests {
         assert_eq!(element_from_atom_name("N"), 7); // Nitrogen
         assert_eq!(element_from_atom_name("  CL"), 17); // Chlorine
         assert_eq!(element_from_atom_name(""), 0); // Empty
+        assert_eq!(element_from_atom_name("C"), 6); // Single char
+        assert_eq!(element_from_atom_name("fe"), 26); // Lowercase two-char
+        assert_eq!(element_from_atom_name("2HW"), 1); // Digit prefix, "Hw"→fallback "H"
+        assert_eq!(element_from_atom_name("123"), 0); // No alphabetic chars
+        assert_eq!(element_from_atom_name("Zz"), 0); // Unknown two-char, no single fallback
     }
 }

--- a/crates/megane-core/src/bonds.rs
+++ b/crates/megane-core/src/bonds.rs
@@ -43,17 +43,43 @@ where
     let ny = ((max_y - min_y) / cell_size).ceil().max(1.0) as usize;
     let nz = ((max_z - min_z) / cell_size).ceil().max(1.0) as usize;
 
-    // Build cell lists
-    let mut cells: Vec<Vec<usize>> = vec![Vec::new(); nx * ny * nz];
+    let ncells = nx * ny * nz;
 
-    for i in 0..n_atoms {
+    // Compute each atom's flat cell index once.
+    let cell_of = |i: usize| -> usize {
         let cx = (((positions[i * 3] - min_x) / cell_size) as usize).min(nx - 1);
         let cy = (((positions[i * 3 + 1] - min_y) / cell_size) as usize).min(ny - 1);
         let cz = (((positions[i * 3 + 2] - min_z) / cell_size) as usize).min(nz - 1);
-        cells[cx * ny * nz + cy * nz + cz].push(i);
+        cx * ny * nz + cy * nz + cz
+    };
+
+    // Bucket atoms into a CSR (counting-sort) layout instead of a
+    // `Vec<Vec<usize>>` to avoid one heap allocation per spatial cell.
+    // `starts[c]..starts[c + 1]` is the slice of `cell_atoms` for cell `c`.
+    let mut atom_cell = vec![0u32; n_atoms];
+    let mut starts = vec![0u32; ncells + 1];
+    for (i, slot) in atom_cell.iter_mut().enumerate() {
+        let c = cell_of(i);
+        *slot = c as u32;
+        starts[c + 1] += 1;
+    }
+    for c in 0..ncells {
+        starts[c + 1] += starts[c];
+    }
+    // Fill in ascending atom index order so within-cell ordering matches the
+    // previous `Vec<Vec<usize>>` (each cell pushed atoms in `i` order), which
+    // keeps the emitted bond order byte-for-byte identical.
+    let mut cursor: Vec<u32> = starts[..ncells].to_vec();
+    let mut cell_atoms = vec![0u32; n_atoms];
+    for (i, &c) in atom_cell.iter().enumerate() {
+        let c = c as usize;
+        cell_atoms[cursor[c] as usize] = i as u32;
+        cursor[c] += 1;
     }
 
-    let mut bonds = Vec::new();
+    // Molecular systems carry roughly one bond per atom; reserve to avoid
+    // repeated reallocation of the output vector.
+    let mut bonds = Vec::with_capacity(n_atoms);
 
     // 13 neighbor offsets (half-shell to avoid double-counting)
     let offsets: [(isize, isize, isize); 13] = [
@@ -76,14 +102,14 @@ where
         for cy in 0..ny {
             for cz in 0..nz {
                 let cell_idx = cx * ny * nz + cy * nz + cz;
-                let cell = &cells[cell_idx];
+                let cell = &cell_atoms[starts[cell_idx] as usize..starts[cell_idx + 1] as usize];
 
                 // Pairs within the same cell
                 for ii in 0..cell.len() {
-                    let i = cell[ii];
+                    let i = cell[ii] as usize;
 
                     for &j in &cell[(ii + 1)..] {
-                        if let Some(bond) = check_pair(i, j) {
+                        if let Some(bond) = check_pair(i, j as usize) {
                             bonds.push(bond);
                         }
                     }
@@ -104,8 +130,10 @@ where
                         }
                         let neighbor_idx =
                             ncx as usize * ny * nz + ncy as usize * nz + ncz as usize;
-                        for &j in &cells[neighbor_idx] {
-                            if let Some(bond) = check_pair(i, j) {
+                        let neighbor = &cell_atoms
+                            [starts[neighbor_idx] as usize..starts[neighbor_idx + 1] as usize];
+                        for &j in neighbor {
+                            if let Some(bond) = check_pair(i, j as usize) {
                                 bonds.push(bond);
                             }
                         }
@@ -261,5 +289,27 @@ mod tests {
         let elements = vec![6, 6];
         let bonds = infer_bonds_vdw(&positions, &elements, 2);
         assert!(bonds.is_empty());
+    }
+
+    #[test]
+    fn test_infer_bonds_single_atom() {
+        let bonds = infer_bonds(&[1.0, 2.0, 3.0], &[6], 1, &HashSet::new());
+        assert!(bonds.is_empty());
+    }
+
+    #[test]
+    fn test_infer_bonds_chain_ordering() {
+        // A carbon chain spaced 1.5 Å along x spans several 2.5 Å cells.
+        // Each atom bonds only to its immediate neighbour, and the CSR cell
+        // list must emit the pairs in ascending (i, j) order.
+        let positions = vec![
+            0.0, 0.0, 0.0, // 0
+            1.5, 0.0, 0.0, // 1
+            3.0, 0.0, 0.0, // 2
+            4.5, 0.0, 0.0, // 3
+        ];
+        let elements = vec![6, 6, 6, 6];
+        let bonds = infer_bonds(&positions, &elements, 4, &HashSet::new());
+        assert_eq!(bonds, vec![(0, 1), (1, 2), (2, 3)]);
     }
 }

--- a/crates/megane-core/src/bonds.rs
+++ b/crates/megane-core/src/bonds.rs
@@ -366,8 +366,9 @@ mod tests {
         let some = *reference.iter().next().unwrap();
         let mut existing = HashSet::new();
         existing.insert(some);
-        let filtered: HashSet<(u32, u32)> =
-            infer_bonds(&positions, &elements, n, &existing).into_iter().collect();
+        let filtered: HashSet<(u32, u32)> = infer_bonds(&positions, &elements, n, &existing)
+            .into_iter()
+            .collect();
         assert!(!filtered.contains(&some));
         assert_eq!(filtered.len(), reference.len() - 1);
     }

--- a/crates/megane-core/src/bonds.rs
+++ b/crates/megane-core/src/bonds.rs
@@ -156,12 +156,6 @@ pub fn infer_bonds(
     let cell_size: f32 = 2.5;
 
     cell_list_scan(positions, n_atoms, cell_size, |i, j| {
-        let a = i.min(j) as u32;
-        let b = i.max(j) as u32;
-        if existing_bonds.contains(&(a, b)) {
-            return None;
-        }
-
         let ri = covalent_radius(elements[i]);
         let rj = covalent_radius(elements[j]);
         let threshold = (ri + rj) * BOND_TOLERANCE;
@@ -172,7 +166,17 @@ pub fn infer_bonds(
 
         let dist_sq = dx * dx + dy * dy + dz * dz;
         if dist_sq > MIN_BOND_DIST * MIN_BOND_DIST && dist_sq <= threshold * threshold {
-            Some((a, b))
+            let a = i.min(j) as u32;
+            let b = i.max(j) as u32;
+            // Skip pairs already supplied by the file. The lookup runs only
+            // after the (cheap) distance test passes — i.e. for the few real
+            // hits rather than every candidate pair — which is a large win on
+            // topologies carrying many explicit bonds (e.g. LAMMPS full).
+            if existing_bonds.contains(&(a, b)) {
+                None
+            } else {
+                Some((a, b))
+            }
         } else {
             None
         }
@@ -311,5 +315,60 @@ mod tests {
         let elements = vec![6, 6, 6, 6];
         let bonds = infer_bonds(&positions, &elements, 4, &HashSet::new());
         assert_eq!(bonds, vec![(0, 1), (1, 2), (2, 3)]);
+    }
+
+    /// Brute-force O(n²) covalent reference, mirroring the scan predicate.
+    fn brute_force_covalent(positions: &[f32], elements: &[u8], n: usize) -> HashSet<(u32, u32)> {
+        let mut set = HashSet::new();
+        for i in 0..n {
+            for j in (i + 1)..n {
+                let dx = positions[j * 3] - positions[i * 3];
+                let dy = positions[j * 3 + 1] - positions[i * 3 + 1];
+                let dz = positions[j * 3 + 2] - positions[i * 3 + 2];
+                let d_sq = dx * dx + dy * dy + dz * dz;
+                let thr =
+                    (covalent_radius(elements[i]) + covalent_radius(elements[j])) * BOND_TOLERANCE;
+                if d_sq > MIN_BOND_DIST * MIN_BOND_DIST && d_sq <= thr * thr {
+                    set.insert((i as u32, j as u32));
+                }
+            }
+        }
+        set
+    }
+
+    #[test]
+    fn test_infer_bonds_matches_brute_force_grid() {
+        // A 3-D grid straddling many cells: the cell-list scan must find
+        // exactly the same (duplicate-free) bond set as the naive all-pairs
+        // reference, including when some pairs are pre-supplied as existing.
+        let side = 6usize;
+        let spacing = 1.4f32;
+        let n = side * side * side;
+        let mut positions = Vec::with_capacity(n * 3);
+        for x in 0..side {
+            for y in 0..side {
+                for z in 0..side {
+                    positions.push(x as f32 * spacing + y as f32 * 0.01);
+                    positions.push(y as f32 * spacing);
+                    positions.push(z as f32 * spacing);
+                }
+            }
+        }
+        let elements = vec![6u8; n];
+        let bonds = infer_bonds(&positions, &elements, n, &HashSet::new());
+
+        let set: HashSet<(u32, u32)> = bonds.iter().copied().collect();
+        assert_eq!(set.len(), bonds.len(), "bond list must be duplicate-free");
+        let reference = brute_force_covalent(&positions, &elements, n);
+        assert_eq!(set, reference);
+
+        // Pre-supplying an existing bond must drop exactly that pair.
+        let some = *reference.iter().next().unwrap();
+        let mut existing = HashSet::new();
+        existing.insert(some);
+        let filtered: HashSet<(u32, u32)> =
+            infer_bonds(&positions, &elements, n, &existing).into_iter().collect();
+        assert!(!filtered.contains(&some));
+        assert_eq!(filtered.len(), reference.len() - 1);
     }
 }

--- a/crates/megane-core/src/lammps_data.rs
+++ b/crates/megane-core/src/lammps_data.rs
@@ -150,13 +150,15 @@ fn parse_header(lines: &[&str]) -> HeaderData {
 /// Parse the Masses section and return a map from type_id → mass.
 fn parse_masses_section(lines: &[&str], start: usize) -> HashMap<u32, f32> {
     let mut type_to_mass: HashMap<u32, f32> = HashMap::new();
+    let mut tokens: Vec<&str> = Vec::new();
 
     for line in lines.iter().skip(start + 1) {
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
         }
-        let tokens: Vec<&str> = trimmed.split_whitespace().collect();
+        tokens.clear();
+        tokens.extend(trimmed.split_whitespace());
         if tokens.is_empty() {
             continue;
         }
@@ -174,6 +176,50 @@ fn parse_masses_section(lines: &[&str], start: usize) -> HashMap<u32, f32> {
     type_to_mass
 }
 
+// ── Atom ID → index map ─────────────────────────────────────────────────────
+
+/// Sentinel marking an empty slot in the dense atom-ID table.
+const ID_SENTINEL: u32 = u32::MAX;
+
+/// Maps LAMMPS 1-based atom IDs to 0-based atom indices.
+///
+/// The common case — atom IDs spanning `1..=n_atoms` — is served by a dense
+/// `Vec` lookup (no hashing). IDs outside that range fall back to a `HashMap`,
+/// so behaviour is identical to a plain `HashMap<u32, usize>` while avoiding
+/// per-atom hashing for typical files.
+struct IdToIndex {
+    /// `table[id] == ID_SENTINEL` means "not present"; otherwise the index.
+    table: Vec<u32>,
+    overflow: HashMap<u32, usize>,
+}
+
+impl IdToIndex {
+    fn with_capacity(n_atoms: usize) -> Self {
+        Self {
+            table: vec![ID_SENTINEL; n_atoms + 1],
+            overflow: HashMap::new(),
+        }
+    }
+
+    fn insert(&mut self, id: u32, index: usize) {
+        if (id as usize) < self.table.len() {
+            self.table[id as usize] = index as u32;
+        } else {
+            self.overflow.insert(id, index);
+        }
+    }
+
+    fn get(&self, id: u32) -> Option<usize> {
+        if (id as usize) < self.table.len() {
+            let v = self.table[id as usize];
+            if v != ID_SENTINEL {
+                return Some(v as usize);
+            }
+        }
+        self.overflow.get(&id).copied()
+    }
+}
+
 // ── Atoms section ─────────────────────────────────────────────────────────
 
 /// Data extracted from the Atoms section.
@@ -182,7 +228,7 @@ struct AtomsData {
     elements: Vec<u8>,
     labels: Vec<String>,
     /// Maps LAMMPS 1-based atom IDs to 0-based indices.
-    id_to_index: HashMap<u32, usize>,
+    id_to_index: IdToIndex,
     count: usize,
 }
 
@@ -206,8 +252,8 @@ fn parse_atoms_section(
     let style = if let Some(hint) = style_hint {
         hint
     } else if data_start < lines.len() {
-        let first_tokens: Vec<&str> = lines[data_start].split_whitespace().collect();
-        detect_style_from_fields(first_tokens.len())
+        let field_count = lines[data_start].split_whitespace().count();
+        detect_style_from_fields(field_count)
             .ok_or("Cannot detect atom_style: unexpected number of fields")?
     } else {
         return Err("Atoms section is empty".into());
@@ -216,15 +262,17 @@ fn parse_atoms_section(
     let mut positions = Vec::with_capacity(n_atoms * 3);
     let mut elements = Vec::with_capacity(n_atoms);
     let mut labels = Vec::with_capacity(n_atoms);
-    let mut id_to_index: HashMap<u32, usize> = HashMap::new();
+    let mut id_to_index = IdToIndex::with_capacity(n_atoms);
     let mut count = 0usize;
+    let mut tokens: Vec<&str> = Vec::new();
 
     for line in lines.iter().skip(data_start) {
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
         }
-        let tokens: Vec<&str> = trimmed.split_whitespace().collect();
+        tokens.clear();
+        tokens.extend(trimmed.split_whitespace());
         if tokens.is_empty() {
             continue;
         }
@@ -301,14 +349,16 @@ fn parse_atoms_section(
 
 // ── Bonds section ─────────────────────────────────────────────────────────
 
-/// Parse the Bonds section and return unique (a, b) index pairs (0-based).
-fn parse_bonds_section(
-    lines: &[&str],
-    start: usize,
-    id_to_index: &HashMap<u32, usize>,
-) -> Vec<(u32, u32)> {
+/// Unique file bonds (0-based index pairs) paired with their deduplication set.
+type FileBonds = (Vec<(u32, u32)>, HashSet<(u32, u32)>);
+
+/// Parse the Bonds section and return unique (a, b) index pairs (0-based)
+/// together with the deduplication set, so callers can reuse it for bond
+/// inference without rebuilding it.
+fn parse_bonds_section(lines: &[&str], start: usize, id_to_index: &IdToIndex) -> FileBonds {
     let mut file_bonds: Vec<(u32, u32)> = Vec::new();
     let mut bond_set: HashSet<(u32, u32)> = HashSet::new();
+    let mut tokens: Vec<&str> = Vec::new();
 
     let mut bond_data_start = start + 1;
     while bond_data_start < lines.len() && lines[bond_data_start].trim().is_empty() {
@@ -320,7 +370,8 @@ fn parse_bonds_section(
         if trimmed.is_empty() {
             continue;
         }
-        let tokens: Vec<&str> = trimmed.split_whitespace().collect();
+        tokens.clear();
+        tokens.extend(trimmed.split_whitespace());
         if tokens.is_empty() {
             continue;
         }
@@ -340,12 +391,12 @@ fn parse_bonds_section(
             Err(_) => continue,
         };
         // Convert from LAMMPS 1-based IDs to 0-based indices
-        let idx_i = match id_to_index.get(&ai) {
-            Some(&idx) => idx as u32,
+        let idx_i = match id_to_index.get(ai) {
+            Some(idx) => idx as u32,
             None => continue,
         };
-        let idx_j = match id_to_index.get(&aj) {
-            Some(&idx) => idx as u32,
+        let idx_j = match id_to_index.get(aj) {
+            Some(idx) => idx as u32,
             None => continue,
         };
         let a = idx_i.min(idx_j);
@@ -355,7 +406,7 @@ fn parse_bonds_section(
         }
     }
 
-    file_bonds
+    (file_bonds, bond_set)
 }
 
 // ── Public API ────────────────────────────────────────────────────────────
@@ -389,13 +440,12 @@ pub fn parse(text: &str) -> Result<ParsedStructure, String> {
         return Err("No atoms parsed from Atoms section".into());
     }
 
-    let mut file_bonds = hd
+    let (mut file_bonds, bond_set) = hd
         .bonds_start
         .map(|s| parse_bonds_section(&lines, s, &atoms.id_to_index))
         .unwrap_or_default();
 
     let n_file_bonds = file_bonds.len();
-    let bond_set: HashSet<(u32, u32)> = file_bonds.iter().copied().collect();
     let inferred = bonds::infer_bonds(&atoms.positions, &atoms.elements, atoms.count, &bond_set);
     file_bonds.extend(inferred);
 
@@ -650,5 +700,58 @@ LAMMPS data file
         }
         let result = parse(&text.unwrap()).expect("parse failed");
         assert!(result.n_atoms > 0);
+    }
+
+    #[test]
+    fn test_id_to_index_dense_and_overflow() {
+        let mut map = IdToIndex::with_capacity(3);
+        // Dense path: ids within 1..=n_atoms.
+        map.insert(1, 0);
+        map.insert(3, 2);
+        // Overflow path: id outside the dense table range.
+        map.insert(100, 5);
+
+        assert_eq!(map.get(1), Some(0));
+        assert_eq!(map.get(3), Some(2));
+        assert_eq!(map.get(100), Some(5));
+        // Unset dense slot and unknown id both return None.
+        assert_eq!(map.get(2), None);
+        assert_eq!(map.get(7), None);
+    }
+
+    #[test]
+    fn test_parse_sparse_atom_ids() {
+        // Non-contiguous atom IDs (10, 25) exercise the overflow HashMap path
+        // while still producing identical 0-based bond indices.
+        let data = "\
+LAMMPS data file
+
+2 atoms
+2 atom types
+1 bonds
+1 bond types
+
+0.0 20.0 xlo xhi
+0.0 20.0 ylo yhi
+0.0 20.0 zlo zhi
+
+Masses
+
+1 15.999
+2 1.008
+
+Atoms # full
+
+10 1 1 -0.8476 10.0 10.0 10.0
+25 1 2 0.4238 10.757 10.587 10.0
+
+Bonds
+
+1 1 10 25
+";
+        let result = parse(data).expect("parse failed");
+        assert_eq!(result.n_atoms, 2);
+        assert_eq!(result.n_file_bonds, 1);
+        assert!(result.bonds.contains(&(0, 1)));
     }
 }

--- a/crates/megane-core/src/lammps_data.rs
+++ b/crates/megane-core/src/lammps_data.rs
@@ -87,12 +87,14 @@ fn parse_header(lines: &[&str]) -> HeaderData {
         bonds_start: None,
     };
 
+    let mut tokens: Vec<&str> = Vec::new();
     for (i, line) in lines.iter().enumerate() {
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
         }
-        let tokens: Vec<&str> = trimmed.split_whitespace().collect();
+        tokens.clear();
+        tokens.extend(trimmed.split_whitespace());
 
         // "N atoms" header line
         if tokens.len() == 2 && tokens[1] == "atoms" {


### PR DESCRIPTION
Both gro::parse and lammps_data::parse are dominated by bond inference
and per-line allocations on large (100k-millions of atoms) systems.
Optimize the hot paths without changing parser output or architecture:

- bonds::cell_list_scan: replace the per-cell Vec<Vec<usize>> bucket
  (one heap allocation per spatial cell) with a flat CSR counting-sort
  layout (atom_cell + starts + cell_atoms), and reserve the output
  vector. Atoms are bucketed in ascending index order so within-cell
  ordering — and therefore the emitted bond order — is byte-for-byte
  identical to before. This benefits both GRO and LAMMPS on all hosts.

- lammps_data: reuse a single token buffer across the Masses/Atoms/Bonds
  loops instead of allocating a Vec<&str> per line; map atom IDs to
  indices via a dense Vec (IdToIndex) for the common 1..=n case with a
  HashMap fallback for sparse IDs, avoiding per-atom hashing; and drop
  the redundant second HashSet rebuild by reusing the dedup set returned
  from parse_bonds_section.

Output (atoms, elements, bonds, ordering) is unchanged; all existing
unit tests pass. Adds tests for the CSR ordering/edge cases and the
dense/overflow ID-map paths.