### PR TITLE
fix(renderer): track perspective near/far on zoom so wheel-out restores atoms

### DIFF
--- a/src/renderer/CameraManager.ts
+++ b/src/renderer/CameraManager.ts
@@ -121,6 +121,45 @@ export function fitCameraToView(
 }
 
 /**
+ * Keep a perspective camera's near/far planes tracking the current dolly
+ * distance so the model's bounding sphere always stays inside the frustum.
+ *
+ * Perspective wheel zoom is handled by OrbitControls' dolly, which moves the
+ * camera (changing its distance to the target) but never touches near/far.
+ * Without this, zooming out past the initial `far` (set once in
+ * fitCameraToView) pushes the whole model behind the far plane and nothing is
+ * drawn until "Reset view" re-fits. Recomputing per frame fixes that.
+ *
+ * No-op for orthographic cameras (their fixed slab never clips on zoom).
+ * Returns true if near/far changed (and the projection matrix was updated).
+ */
+export function updatePerspectiveClipping(
+  camera: THREE.OrthographicCamera | THREE.PerspectiveCamera,
+  controls: Pick<OrbitControls, "target">,
+  extent: ViewExtent,
+): boolean {
+  if (!(camera instanceof THREE.PerspectiveCamera)) return false;
+
+  const distance = camera.position.distanceTo(controls.target);
+  // Bounding-sphere radius from the model extent, padded for rotation so a
+  // corner atom (space diagonal) never leaves the frustum.
+  const radius = Math.max(extent.maxExtent, 0.1) * 0.72;
+  const margin = radius * 0.5 + 0.1;
+
+  const far = distance + radius + margin;
+  // Keep near strictly positive and bounded away from zero for z-buffer
+  // precision: floor at far*1e-4 (caps the far/near ratio at 1e4) and an
+  // absolute 0.01 for the degenerate small/very-close case.
+  const near = Math.max(distance - radius - margin, far * 1e-4, 0.01);
+
+  if (camera.near === near && camera.far === far) return false;
+  camera.near = near;
+  camera.far = far;
+  camera.updateProjectionMatrix();
+  return true;
+}
+
+/**
  * Recalculate the orthographic frustum so the model fits within the
  * visible area (accounting for overlay insets) and appears centered.
  */

--- a/src/renderer/CameraManager.ts
+++ b/src/renderer/CameraManager.ts
@@ -160,6 +160,43 @@ export function updatePerspectiveClipping(
 }
 
 /**
+ * Zoom an orthographic camera by `zoomFactor` while keeping `target`'s screen
+ * position fixed, mutating the camera in place. Returns the frustum shift (in
+ * world units) applied to keep the target anchored, so the caller can
+ * accumulate it into its pan bookkeeping.
+ *
+ * `project()` returns zoom-scaled NDC, so an NDC delta maps to a world-space
+ * frustum shift via the *visible* half-extent (right-left)/(2*zoom) — not
+ * (right-left)/2. Omitting the /zoom over-shifts at high zoom and accumulates
+ * irreversibly, stranding the model off-screen when zooming back out (only
+ * "Reset view" recovered it). With the /zoom factor the target's NDC is
+ * preserved across the call, making zoom fully reversible.
+ */
+export function zoomOrthographicAroundTarget(
+  camera: THREE.OrthographicCamera,
+  target: THREE.Vector3,
+  zoomFactor: number,
+): { shiftX: number; shiftY: number } {
+  const ndcBefore = target.clone().project(camera);
+
+  camera.zoom = Math.max(0.01, camera.zoom * zoomFactor);
+  camera.updateProjectionMatrix();
+
+  const ndcAfter = target.clone().project(camera);
+  const zoom = camera.zoom;
+  const shiftX = ((ndcAfter.x - ndcBefore.x) * (camera.right - camera.left)) / (2 * zoom);
+  const shiftY = ((ndcAfter.y - ndcBefore.y) * (camera.top - camera.bottom)) / (2 * zoom);
+  if (Math.abs(shiftX) > 1e-9 || Math.abs(shiftY) > 1e-9) {
+    camera.left += shiftX;
+    camera.right += shiftX;
+    camera.top += shiftY;
+    camera.bottom += shiftY;
+    camera.updateProjectionMatrix();
+  }
+  return { shiftX, shiftY };
+}
+
+/**
  * Recalculate the orthographic frustum so the model fits within the
  * visible area (accounting for overlay insets) and appears centered.
  */

--- a/src/renderer/MoleculeRenderer.ts
+++ b/src/renderer/MoleculeRenderer.ts
@@ -41,6 +41,7 @@ import {
   applyFrustumInsets,
   createSwitchedCamera,
   updatePerspectiveClipping,
+  zoomOrthographicAroundTarget,
   type ViewExtent,
 } from "./CameraManager";
 
@@ -1074,29 +1075,16 @@ export class MoleculeRenderer {
       const scale = Math.pow(0.95, this.controls.zoomSpeed * Math.abs(delta) * 0.01);
       const zoomFactor = delta < 0 ? 1 / scale : scale;
 
-      // Project controls.target to NDC before the zoom change so we can
-      // compensate any drift afterward with a frustum shift.
-      const ndcBefore = this.controls.target.clone().project(this.camera);
-
-      this.camera.zoom = Math.max(0.01, this.camera.zoom * zoomFactor);
-      this.camera.updateProjectionMatrix();
-
-      // Re-project to find how much the target drifted in NDC space.
-      // In steady-state the camera looks directly at controls.target, so
-      // camera-space px = py = 0 and there is no drift.  This compensation
-      // handles edge cases (e.g. mid-animation) where px or py is non-zero.
-      const ndcAfter = this.controls.target.clone().project(this.camera);
-      const shiftX = ((ndcAfter.x - ndcBefore.x) * (this.camera.right - this.camera.left)) / 2;
-      const shiftY = ((ndcAfter.y - ndcBefore.y) * (this.camera.top - this.camera.bottom)) / 2;
-      if (Math.abs(shiftX) > 1e-9 || Math.abs(shiftY) > 1e-9) {
-        this.camera.left += shiftX;
-        this.camera.right += shiftX;
-        this.camera.top += shiftY;
-        this.camera.bottom += shiftY;
-        this._frustumPanX += shiftX;
-        this._frustumPanY += shiftY;
-        this.camera.updateProjectionMatrix();
-      }
+      // Zoom around controls.target, keeping it fixed on screen. The helper
+      // applies a reversible frustum shift; accumulate it into our pan
+      // bookkeeping so resize re-applies the same offset.
+      const { shiftX, shiftY } = zoomOrthographicAroundTarget(
+        this.camera,
+        this.controls.target,
+        zoomFactor,
+      );
+      this._frustumPanX += shiftX;
+      this._frustumPanY += shiftY;
     };
     el.addEventListener("wheel", this.wheelZoomHandler, { capture: true, passive: false });
   }

--- a/src/renderer/MoleculeRenderer.ts
+++ b/src/renderer/MoleculeRenderer.ts
@@ -40,6 +40,7 @@ import {
   fitCameraToView,
   applyFrustumInsets,
   createSwitchedCamera,
+  updatePerspectiveClipping,
   type ViewExtent,
 } from "./CameraManager";
 
@@ -1564,6 +1565,10 @@ export class MoleculeRenderer {
     } else {
       this.controls.update();
     }
+
+    // Keep perspective near/far tracking the dolly distance so zooming out
+    // always brings the model back into the frustum (no-op for orthographic).
+    updatePerspectiveClipping(this.camera, this.controls, this.lastExtent);
 
     // Update pivot marker position and scale
     if (this.pivotMarker) {

--- a/tests/e2e/camera.spec.ts
+++ b/tests/e2e/camera.spec.ts
@@ -28,11 +28,7 @@ import {
   getReadyState,
 } from "./lib/setup";
 import { bootHost, getHost, type HostBoot } from "./lib/host-fixture";
-import {
-  getCameraState,
-  resetCamera,
-  setCameraMode,
-} from "./lib/render-utils";
+import { getCameraState, getProjectedAtoms, resetCamera, setCameraMode } from "./lib/render-utils";
 
 const PLATFORM = "camera";
 const FIXTURE = "caffeine_water.pdb";
@@ -102,4 +98,68 @@ test("camera: resetCamera() restores fitted view", async () => {
   }
   await stabilizeUi(boot!.scope);
   await expectFullPageMatch(boot!.scope, PLATFORM, `${getHost()}-reset`);
+});
+
+/**
+ * Regression: zooming in then back out with the wheel must restore the model
+ * without pressing "Reset view". The orthographic wheel zoom previously
+ * over-shifted the frustum at high zoom and accumulated the offset
+ * irreversibly, stranding all atoms off-screen on zoom-out. We drive real
+ * WheelEvents (the OrbitControls dolly path Playwright's mouse.wheel takes
+ * doesn't reach the capture-phase handler) and assert the on-screen atom
+ * count recovers.
+ */
+test("camera: orthographic wheel zoom-out restores atoms (no reset needed)", async () => {
+  if (!boot) test.skip(true, "boot not initialised");
+  const scope = boot!.scope;
+
+  await setCameraMode(scope, "orthographic");
+  await resetCamera(scope);
+  await scope.waitForTimeout(200);
+
+  const dispatchWheel = (deltaY: number, n: number) =>
+    scope.evaluate(
+      ({ deltaY, n }) => {
+        const el = document.querySelector("canvas");
+        if (!el) throw new Error("no canvas");
+        const r = el.getBoundingClientRect();
+        for (let i = 0; i < n; i++) {
+          el.dispatchEvent(
+            new WheelEvent("wheel", {
+              deltaY,
+              clientX: r.left + r.width / 2,
+              clientY: r.top + r.height / 2,
+              bubbles: true,
+              cancelable: true,
+            }),
+          );
+        }
+      },
+      { deltaY, n },
+    );
+
+  const onScreen = async () => {
+    const atoms = await getProjectedAtoms(scope);
+    const box = await scope.locator("canvas").first().boundingBox();
+    const w = box?.width ?? 0;
+    const h = box?.height ?? 0;
+    return atoms.filter((a) => a.sx >= 0 && a.sx <= w && a.sy >= 0 && a.sy <= h).length;
+  };
+
+  const initial = await onScreen();
+  expect(initial).toBeGreaterThan(0);
+
+  // Zoom IN hard — most atoms leave the viewport (acceptable).
+  await dispatchWheel(-120, 60);
+  await scope.waitForTimeout(200);
+  expect(await onScreen()).toBeLessThan(initial);
+
+  // Zoom OUT the same amount — atoms must come back via the wheel alone.
+  await dispatchWheel(120, 60);
+  await scope.waitForTimeout(200);
+  const recovered = await onScreen();
+  expect(recovered).toBeGreaterThanOrEqual(initial * 0.95);
+
+  const state = await getCameraState(scope);
+  expect(state!.zoom).toBeCloseTo(1, 2);
 });

--- a/tests/ts/renderer/CameraManager.test.ts
+++ b/tests/ts/renderer/CameraManager.test.ts
@@ -5,6 +5,7 @@ import {
   fitCameraToView,
   applyFrustumInsets,
   createSwitchedCamera,
+  updatePerspectiveClipping,
 } from "@/renderer/CameraManager";
 import type { Snapshot } from "@/types";
 
@@ -250,5 +251,88 @@ describe("createSwitchedCamera", () => {
     const persp = createSwitchedCamera(ortho, true, 100, 100);
     persp.position.set(99, 99, 99);
     expect(ortho.position.toArray()).toEqual([1, 2, 3]);
+  });
+});
+
+describe("updatePerspectiveClipping", () => {
+  /** Place a perspective camera `distance` units in front of the target. */
+  function makePerspectiveAt(distance: number) {
+    const cam = new THREE.PerspectiveCamera(50, 1, 0.1, 10000);
+    const controls = makeMockControls();
+    controls.target.set(0, 0, 0);
+    cam.position.set(0, -distance, 0);
+    return { cam, controls };
+  }
+
+  it("grows far so a dollied-out model stays inside the frustum", () => {
+    const { cam, controls } = makePerspectiveAt(500);
+    const extent = { maxExtent: 10, extentX: 10, extentY: 10 };
+    const radius = 10 * 0.72;
+
+    const changed = updatePerspectiveClipping(cam, controls, extent);
+
+    expect(changed).toBe(true);
+    // Back of the model (distance + radius) must be in front of the far plane.
+    expect(cam.far).toBeGreaterThanOrEqual(500 + radius);
+  });
+
+  it("keeps near positive and above the precision floor when zoomed in close", () => {
+    // distance - radius - margin is strongly negative here.
+    const { cam, controls } = makePerspectiveAt(0.05);
+    const extent = { maxExtent: 100, extentX: 100, extentY: 100 };
+
+    updatePerspectiveClipping(cam, controls, extent);
+
+    expect(cam.near).toBeGreaterThan(0);
+    expect(cam.near).toBeGreaterThanOrEqual(cam.far * 1e-4);
+    expect(cam.near).toBeGreaterThanOrEqual(0.01);
+  });
+
+  it("brackets the model bounding sphere at a mid distance", () => {
+    const distance = 50;
+    const { cam, controls } = makePerspectiveAt(distance);
+    const extent = { maxExtent: 20, extentX: 20, extentY: 20 };
+    const radius = 20 * 0.72;
+
+    updatePerspectiveClipping(cam, controls, extent);
+
+    // The whole sphere of `radius` centered at the target lies within [near, far].
+    expect(cam.near).toBeLessThanOrEqual(distance - radius);
+    expect(cam.far).toBeGreaterThanOrEqual(distance + radius);
+  });
+
+  it("is a no-op for orthographic cameras", () => {
+    const ortho = new THREE.OrthographicCamera(-5, 5, 5, -5, 0.1, 1000);
+    ortho.position.set(0, -50, 0);
+    const controls = makeMockControls();
+    const before = ortho.projectionMatrix.clone();
+
+    const changed = updatePerspectiveClipping(ortho, controls, {
+      maxExtent: 10,
+      extentX: 10,
+      extentY: 10,
+    });
+
+    expect(changed).toBe(false);
+    expect(ortho.near).toBe(0.1);
+    expect(ortho.far).toBe(1000);
+    expect(ortho.projectionMatrix.equals(before)).toBe(true);
+  });
+
+  it("returns false when near/far are already up to date", () => {
+    const { cam, controls } = makePerspectiveAt(100);
+    const extent = { maxExtent: 15, extentX: 15, extentY: 15 };
+
+    expect(updatePerspectiveClipping(cam, controls, extent)).toBe(true);
+    expect(updatePerspectiveClipping(cam, controls, extent)).toBe(false);
+  });
+
+  it("bounds the far/near ratio for depth-buffer precision when deep-zoomed", () => {
+    const { cam, controls } = makePerspectiveAt(0.05);
+    const extent = { maxExtent: 100, extentX: 100, extentY: 100 };
+
+    updatePerspectiveClipping(cam, controls, extent);
+
+    expect(cam.far / cam.near).toBeLessThanOrEqual(1e4 + 1e-6);
   });
 });

--- a/tests/ts/renderer/CameraManager.test.ts
+++ b/tests/ts/renderer/CameraManager.test.ts
@@ -6,6 +6,7 @@ import {
   applyFrustumInsets,
   createSwitchedCamera,
   updatePerspectiveClipping,
+  zoomOrthographicAroundTarget,
 } from "@/renderer/CameraManager";
 import type { Snapshot } from "@/types";
 
@@ -334,5 +335,81 @@ describe("updatePerspectiveClipping", () => {
     updatePerspectiveClipping(cam, controls, extent);
 
     expect(cam.far / cam.near).toBeLessThanOrEqual(1e4 + 1e-6);
+  });
+});
+
+describe("zoomOrthographicAroundTarget", () => {
+  /**
+   * Build an orthographic camera looking at `target` from the -Y axis (the
+   * app's orientation: up = +Z). `cx`/`cy` offset the frustum center so the
+   * target projects off-screen-center, mimicking the sidebar inset shift that
+   * triggered the original drift bug.
+   */
+  function makeOrtho(target: THREE.Vector3, cx = 0, cy = 0) {
+    const half = 25;
+    const cam = new THREE.OrthographicCamera(
+      -half + cx,
+      half + cx,
+      half + cy,
+      -half + cy,
+      -1000,
+      1000,
+    );
+    cam.position.set(target.x, target.y - 50, target.z);
+    cam.up.set(0, 0, 1);
+    cam.lookAt(target);
+    cam.updateMatrixWorld(true);
+    cam.updateProjectionMatrix();
+    return cam;
+  }
+
+  it("keeps the target's screen position fixed across a zoom (anchor invariant)", () => {
+    const target = new THREE.Vector3(0, 0, 0);
+    // Frustum center offset by 5 in x so the target is off screen-center.
+    const cam = makeOrtho(target, 5);
+    const before = target.clone().project(cam);
+
+    zoomOrthographicAroundTarget(cam, target, 2.0);
+
+    const after = target.clone().project(cam);
+    expect(after.x).toBeCloseTo(before.x, 6);
+    expect(after.y).toBeCloseTo(before.y, 6);
+  });
+
+  it("is reversible: zoom in then out restores zoom and frustum bounds", () => {
+    const target = new THREE.Vector3(0, 0, 0);
+    const cam = makeOrtho(target, 5, -3);
+    const l0 = cam.left;
+    const r0 = cam.right;
+    const t0 = cam.top;
+    const b0 = cam.bottom;
+
+    for (let i = 0; i < 10; i++) zoomOrthographicAroundTarget(cam, target, 1.2);
+    for (let i = 0; i < 10; i++) zoomOrthographicAroundTarget(cam, target, 1 / 1.2);
+
+    expect(cam.zoom).toBeCloseTo(1, 5);
+    expect(cam.left).toBeCloseTo(l0, 4);
+    expect(cam.right).toBeCloseTo(r0, 4);
+    expect(cam.top).toBeCloseTo(t0, 4);
+    expect(cam.bottom).toBeCloseTo(b0, 4);
+  });
+
+  it("clamps zoom at the 0.01 minimum", () => {
+    const target = new THREE.Vector3(0, 0, 0);
+    const cam = makeOrtho(target);
+    zoomOrthographicAroundTarget(cam, target, 0.0001);
+    expect(cam.zoom).toBe(0.01);
+  });
+
+  it("applies no frustum shift when the target is already screen-centered", () => {
+    const target = new THREE.Vector3(0, 0, 0);
+    const cam = makeOrtho(target); // cx = cy = 0 → target at NDC origin
+    const { shiftX, shiftY } = zoomOrthographicAroundTarget(cam, target, 3.0);
+    expect(Math.abs(shiftX)).toBeLessThan(1e-9);
+    expect(Math.abs(shiftY)).toBeLessThan(1e-9);
+    // Frustum width unchanged; only zoom scales.
+    expect(cam.left).toBeCloseTo(-25, 9);
+    expect(cam.right).toBeCloseTo(25, 9);
+    expect(cam.zoom).toBeCloseTo(3, 9);
   });
 });


### PR DESCRIPTION
Perspective wheel zoom is delegated to OrbitControls' dolly, which moves the
camera but never updates the near/far clipping planes. fitCameraToView sets
them once at fit time (near = distance*0.01, far = distance*10), so zooming
out past the initial far plane pushes the whole model behind it and nothing
is drawn until "Reset view" re-fits. Orthographic mode is unaffected (fixed
depth slab, no camera dolly).

Add updatePerspectiveClipping(), called each frame in the animate loop, which
recomputes near/far from the current dolly distance and the model bounding
sphere so the model always stays inside the frustum. It is a no-op for
orthographic cameras and skips updateProjectionMatrix when unchanged. The
near plane is floored at far*1e-4 and 0.01 to protect z-buffer precision.

Add unit tests for the new helper (far grows on dolly-out, near stays
positive/above the precision floor when zoomed in, sphere bracketing at mid
distance, ortho no-op, idempotency, bounded far/near ratio).