### PR TITLE
Raise system message cap from 24k to 48k chars

### DIFF
--- a/tests/ts/ai/prompt.test.ts
+++ b/tests/ts/ai/prompt.test.ts
@@ -60,6 +60,19 @@ describe("buildSystemPrompt", () => {
     expect(buildSystemPrompt()).toBe(buildSystemPrompt());
   });
 
+  it("stays under the demo-proxy system-message cap (with summary headroom)", () => {
+    // The demo Cloudflare Worker proxy rejects any system message longer than
+    // MAX_SYSTEM_MESSAGE_LENGTH (48000) with "Missing or invalid 'messages'
+    // array" — see workers/llm-proxy/src/proxy.ts. The base prompt is sent as
+    // the system message and a loaded-structure summary is appended on top, so
+    // the base must leave comfortable headroom. This guard catches prompt
+    // growth before it silently breaks the free demo (the proxy cap and this
+    // constant must be kept in sync).
+    const PROXY_SYSTEM_CAP = 48000;
+    const SUMMARY_HEADROOM = 8000;
+    expect(buildSystemPrompt().length).toBeLessThan(PROXY_SYSTEM_CAP - SUMMARY_HEADROOM);
+  });
+
   it("documents the atom selection query fields and operators", () => {
     expect(prompt).toContain("Atom & Bond Selection Query Language");
     for (const field of ["element", "index", "resname", "mass"]) {

--- a/workers/llm-proxy/src/proxy.ts
+++ b/workers/llm-proxy/src/proxy.ts
@@ -91,12 +91,16 @@ export const MAX_MESSAGES = 12;
 export const MAX_MESSAGE_LENGTH = 8000;
 /**
  * Length cap for system and tool messages. The system prompt carries the
- * full pipeline schema (~7.6k chars) and tool messages carry skill
- * templates the frontend feeds back during the tool-call round trip, so
- * both are app-generated and legitimately larger than untrusted
- * user/assistant input.
+ * full pipeline schema and worked examples (~24k chars and growing) plus an
+ * appended summary of the currently-loaded structure, and tool messages
+ * carry skill templates the frontend feeds back during the tool-call round
+ * trip. All of these are app-generated (not untrusted user input), so the
+ * cap is set well above the current prompt size to leave headroom for the
+ * structure summary and future prompt growth. A too-tight cap here silently
+ * rejected every demo-proxy request with "Missing or invalid 'messages'
+ * array" once the base prompt crossed the old 24000 limit.
  */
-export const MAX_SYSTEM_MESSAGE_LENGTH = 24000;
+export const MAX_SYSTEM_MESSAGE_LENGTH = 48000;
 /** Bounds on the optional OpenAI tool-calling fields forwarded upstream. */
 export const MAX_TOOLS = 16;
 export const MAX_TOOL_CALLS = 16;

--- a/workers/llm-proxy/test/index.test.ts
+++ b/workers/llm-proxy/test/index.test.ts
@@ -148,9 +148,10 @@ describe("sanitizeMessages", () => {
 
   it("allows a large system message but caps it at the system limit", () => {
     // A system prompt over the user limit (8000) but within the system
-    // limit (24000) must be accepted — the inlined skill templates push
-    // the generated prompt to ~13k chars.
-    const bigSystem = "s".repeat(13000);
+    // limit (48000) must be accepted. The real frontend prompt
+    // (buildSystemPrompt) is ~24k chars before the loaded-structure summary
+    // is appended, so the cap must comfortably clear that.
+    const bigSystem = "s".repeat(30000);
     const ok = sanitizeMessages({
       messages: [
         { role: "system", content: bigSystem },
@@ -158,10 +159,25 @@ describe("sanitizeMessages", () => {
       ],
     });
     expect(ok).not.toBeNull();
-    expect(ok?.[0].content).toHaveLength(13000);
+    expect(ok?.[0].content).toHaveLength(30000);
 
-    const tooBigSystem = "s".repeat(24001);
+    const tooBigSystem = "s".repeat(48001);
     expect(sanitizeMessages({ messages: [{ role: "system", content: tooBigSystem }] })).toBeNull();
+  });
+
+  it("accepts a system message at the real frontend prompt size (~24k)", () => {
+    // Regression: the base system prompt grew past the old 24000 cap, which
+    // made sanitizeMessages reject every demo-proxy request with "Missing or
+    // invalid 'messages' array". A ~24k system message plus a structure
+    // summary must stay under the limit.
+    const realisticSystem = "s".repeat(24108) + "\n## Currently Loaded Structure\n" + "x".repeat(2000);
+    const ok = sanitizeMessages({
+      messages: [
+        { role: "system", content: realisticSystem },
+        { role: "user", content: "show carbons" },
+      ],
+    });
+    expect(ok).not.toBeNull();
   });
 
   it("rejects malformed message entries", () => {


### PR DESCRIPTION
## Summary

The demo-proxy system message length cap was set to 24,000 characters, but the base system prompt (`buildSystemPrompt()`) has grown to ~24k chars before the loaded-structure summary is appended. This caused the proxy to silently reject every request with "Missing or invalid 'messages' array" once the prompt crossed the old limit.

This PR raises `MAX_SYSTEM_MESSAGE_LENGTH` from 24,000 to 48,000 characters to:
1. Accommodate the current ~24k base prompt plus the appended structure summary
2. Leave headroom for future prompt growth
3. Add regression tests to catch this issue if the prompt grows further

### Changes

**workers/llm-proxy/src/proxy.ts:**
- Increased `MAX_SYSTEM_MESSAGE_LENGTH` from 24,000 to 48,000
- Updated the comment to explain the cap is for app-generated content (system prompt schema + examples + structure summary, plus tool messages), not untrusted user input, and why a too-tight cap silently breaks the demo

**workers/llm-proxy/test/index.test.ts:**
- Updated existing test to verify a 30k system message is accepted (and 48,001 is rejected)
- Added new regression test that verifies a realistic ~26.1k system message (24,108 chars base + 2k structure summary) passes validation

**tests/ts/ai/prompt.test.ts:**
- Added guard test that ensures `buildSystemPrompt()` stays under 40k chars (48k cap minus 8k headroom for the structure summary), catching prompt growth before it silently breaks the free demo

## Test Plan

- [x] `npm test` passes (new tests added to verify the cap and regression case)
- [x] Existing proxy tests updated to reflect new limits
- [x] New regression test ensures base prompt + structure summary stays under the proxy cap

https://claude.ai/code/session_01RWC5NUE3DXSTHPD9ELRuWD