### PR TITLE
Increase PipelineChatBox textarea height to 5 rows

### DIFF
--- a/src/components/PipelineChatBox.tsx
+++ b/src/components/PipelineChatBox.tsx
@@ -117,8 +117,8 @@ const textareaStyle: React.CSSProperties = {
   lineHeight: 1.5,
   outline: "none",
   background: "white",
-  minHeight: 32,
-  maxHeight: 64,
+  minHeight: 95,
+  maxHeight: 160,
 };
 
 const sendBtnStyle: React.CSSProperties = {
@@ -576,7 +576,7 @@ export function PipelineChatBox({ onPipelineApplied }: { onPipelineApplied?: () 
           onKeyDown={handleKeyDown}
           placeholder="Describe the pipeline you want..."
           style={textareaStyle}
-          rows={1}
+          rows={5}
           disabled={isStreaming}
         />
         {isStreaming ? (

--- a/tests/ts/components/PipelineChatBox.test.tsx
+++ b/tests/ts/components/PipelineChatBox.test.tsx
@@ -143,6 +143,18 @@ describe("PipelineChatBox — use-own-key checkbox", () => {
   });
 });
 
+describe("PipelineChatBox — input box", () => {
+  it("renders the prompt textarea five rows tall by default", () => {
+    vi.stubEnv("VITE_LLM_PROXY_URL", "https://proxy.example.com/chat");
+    render(<PipelineChatBox />);
+
+    const textarea = screen.getByPlaceholderText(
+      "Describe the pipeline you want...",
+    ) as HTMLTextAreaElement;
+    expect(textarea.rows).toBe(5);
+  });
+});
+
 describe("PipelineChatBox — submission", () => {
   beforeEach(() => {
     (generatePipeline as ReturnType<typeof vi.fn>).mockImplementation(


### PR DESCRIPTION
## Summary

Increases the default height of the prompt textarea in `PipelineChatBox` from 1 row to 5 rows, making it more suitable for multi-line prompts. Updates the corresponding min/max height CSS values from 32/64px to 95/160px to accommodate the larger textarea.

## Changes

- **`src/components/PipelineChatBox.tsx`**: 
  - Changed `rows` attribute from `1` to `5`
  - Updated `minHeight` from `32` to `95` pixels
  - Updated `maxHeight` from `64` to `160` pixels

- **`tests/ts/components/PipelineChatBox.test.tsx`**: 
  - Added new test suite "PipelineChatBox — input box" with a test verifying the textarea renders with 5 rows by default

## Test Plan

- [x] `npm test` passes — new unit test added to verify the textarea rows attribute
- [x] Manually verified the change in the browser (UI change to textarea height)

https://claude.ai/code/session_013n9mW1ZYargweMp4kku216