### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-28
+
+### Fixed
+
+- **Blank VSCode webview (and other Vite-built hosts).** v0.9.0 bumped Vite to 8 (rolldown), whose CI-built bundle crashed at runtime, leaving a blank panel. Reverted to the known-good Vite 6 / `@vitejs/plugin-react` 4 toolchain in both the root project and `vscode-megane`.
+- Hardened WebGL2 context creation with a clear, actionable error message.
+
+### Added
+
+- **Top-level React error boundary** on every host (VSCode webview, webapp, anywidget widget, JupyterLab structure + pipeline doc widgets) so a render/effect failure shows an actionable message instead of a blank screen.
+- **`render-smoke` CI job** (`npm run smoke:render`) that builds each Vite bundle with the locked toolchain and asserts the viewer mounts and the WebGL canvas draws — closing the gap that let the v0.9.0 blank bundle ship.
+
+### Changed
+
+- `vsce package`/`publish` now always rebuild via a `vscode:prepublish` script, so the extension can never ship stale `out/` + `media/` artifacts.
+
 ## [0.9.0] - 2026-06-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "megane-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "megane-python"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "megane-core",
  "numpy",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "megane-wasm"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "js-sys",
  "megane-core",

--- a/crates/megane-core/Cargo.toml
+++ b/crates/megane-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megane-core"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "Core molecular structure parsers (PDB, GRO, XYZ, MOL, CIF, LAMMPS, XTC, .traj)"
 authors = ["hodakamori"]

--- a/crates/megane-python/Cargo.toml
+++ b/crates/megane-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megane-python"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "PyO3 Python bindings for megane molecular parsers"
 authors = ["hodakamori"]

--- a/crates/megane-wasm/Cargo.toml
+++ b/crates/megane-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megane-wasm"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "WASM bindings for megane molecular viewer"
 authors = ["hodakamori"]

--- a/jupyterlab-megane/package-lock.json
+++ b/jupyterlab-megane/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "megane-jupyterlab",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "megane-jupyterlab",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@jupyterlab/application": "^4.0.0",

--- a/jupyterlab-megane/package.json
+++ b/jupyterlab-megane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "megane-jupyterlab",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "JupyterLab 4 extension for the megane molecular viewer",
   "license": "MIT",
   "author": "hodakamori",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "megane-viewer",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "megane-viewer",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "megane-viewer",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "description": "A fast, beautiful molecular viewer – anywidget-compatible",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "megane"
-version = "0.9.0"
+version = "0.9.1"
 description = "A fast, beautiful molecular viewer"
 requires-python = ">=3.10"
 license = "MIT"
@@ -95,7 +95,7 @@ show_missing = true
 skip_empty = true
 
 [tool.bumpversion]
-current_version = "0.9.0"
+current_version = "0.9.1"
 commit = false
 tag = false
 allow_dirty = true

--- a/python/megane/__init__.py
+++ b/python/megane/__init__.py
@@ -59,4 +59,4 @@ __all__ = [
     "view",
     "view_traj",
 ]
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1755,7 +1755,7 @@ wheels = [
 
 [[package]]
 name = "megane"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },

--- a/vscode-megane/package-lock.json
+++ b/vscode-megane/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-megane",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-megane",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@dagrejs/dagre": "^3.0.0",

--- a/vscode-megane/package.json
+++ b/vscode-megane/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-megane",
   "displayName": "megane - Molecular Viewer",
   "description": "View molecular structure files (PDB, GRO, XYZ, MOL, SDF, MOL2, CIF, mmCIF, LAMMPS data, AMBER prmtop, ASE traj, XTC, LAMMPS dump, DCD, AMBER NetCDF) with megane",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "publisher": "hodakamori",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Patch release **v0.9.1**.

Bumps the version across all 11 tracked files (via `bump-my-version`) plus `Cargo.lock` and `uv.lock`, and adds the 0.9.1 `CHANGELOG.md` entry.

This release ships the v0.9.0 **blank webview** fix (already merged in #550):
- Revert to the Vite 6 / `@vitejs/plugin-react` 4 toolchain (root + `vscode-megane`).
- Top-level React error boundary on every host.
- Hardened WebGL2 context creation.
- `vscode:prepublish` rebuild so packaging never ships stale artifacts.
- New `render-smoke` CI gate that loads each built bundle headless.

### Release steps after merge
Push the `v0.9.1` tag to trigger `publish-pypi`, `publish-npm`, `publish-vscode`, `release`, and `docs`. All publish workflows rebuild bundles from source with the pinned toolchain, so the Marketplace/PyPI/npm artifacts will contain the fixed Vite 6 bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)