### PR TITLE
docs: unify host/distribution terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </h1>
 
 <p align="center">Spectacles for atomistic data.</p>
-<p align="center"><em>1M+ atoms at 60fps. Visual pipelines. Jupyter, browser, React, VSCode.</em></p>
+<p align="center"><em>1M+ atoms at 60fps. Visual pipelines. Jupyter widget, standalone web app, React component, VS Code extension.</em></p>
 
 <p align="center">
   <a href="https://github.com/hodakamori/megane/actions/workflows/ci.yml"><img src="https://github.com/hodakamori/megane/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
@@ -32,7 +32,7 @@
 ## Features
 
 - **1M+ Atoms at 60fps** — Billboard impostor rendering scales from small molecules to massive complexes in real time. InstancedMesh for small systems auto-switches to GPU-accelerated billboard impostors for large systems. Stream XTC trajectories over WebSocket.
-- **Runs Everywhere** — Jupyter widget, CLI server, React component, and VSCode extension. Rust-based parsers for 15 formats (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, mmCIF, LAMMPS data, AMBER topology, XTC, DCD, ASE .traj, LAMMPS dump, AMBER NetCDF) shared between Python (PyO3) and browser (WASM) — parse once, run anywhere.
+- **Runs Everywhere** — Jupyter widget, standalone web app (`megane serve`), React component (npm), and VS Code extension. Rust-based parsers for 15 formats (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, mmCIF, LAMMPS data, AMBER topology, XTC, DCD, ASE .traj, LAMMPS dump, AMBER NetCDF) shared between Python (PyO3) and browser (WASM) — parse once, run anywhere.
 - **Visual Pipeline Editor** — Build visualization workflows by wiring nodes or let the AI generator build them from natural language. 16 node types with 7 typed data channels flowing through color-coded edges. Load multiple structures with layer-based rendering to compare systems side by side.
 - **Embed & Integrate** — Control the viewer from Plotly via ipywidgets events. Embed in MDX / Next.js docs. React to `frame_change`, `selection_change`, and `measurement` events. Use the framework-agnostic renderer from Vue, Svelte, or vanilla JS.
 
@@ -46,13 +46,13 @@ Trajectory streaming works over WebSocket via a binary protocol. Load an XTC fil
 
 One codebase, every environment.
 
-| Environment | How | Install |
+| Distribution | How | Install |
 |---|---|---|
-| **Jupyter** | anywidget inline viewer | `pip install megane` |
-| **JupyterLab** | Open .pdb, .gro, .xyz, .mol, .sdf, .mol2, .cif, .mmcif, .data/.lammps, .prmtop, .traj, .xtc, .dcd, .nc, .lammpstrj/.dump, .megane.json from the file browser | `pip install megane` |
-| **Browser** | `megane serve` local server | `pip install megane` |
-| **React** | `<MeganeViewer />` component | `npm install megane-viewer` |
-| **VSCode** | Custom editor for .pdb, .gro, .xyz, .mol, .sdf, .mol2, .cif, .mmcif, .data/.lammps, .prmtop, .traj, .xtc, .lammpstrj, .dump, .dcd, .nc, .megane.json | Extension |
+| **Jupyter widget** | anywidget inline viewer | `pip install megane` |
+| **JupyterLab extension** | Open .pdb, .gro, .xyz, .mol, .sdf, .mol2, .cif, .mmcif, .data/.lammps, .prmtop, .traj, .xtc, .dcd, .nc, .lammpstrj/.dump, .megane.json from the file browser | `pip install megane` |
+| **Standalone web app** | `megane serve` in the browser | `pip install megane` |
+| **React component (npm)** | `<MeganeViewer />` component | `npm install megane-viewer` |
+| **VS Code extension** | Custom editor for .pdb, .gro, .xyz, .mol, .sdf, .mol2, .cif, .mmcif, .data/.lammps, .prmtop, .traj, .xtc, .lammpstrj, .dump, .dcd, .nc, .megane.json | Extension |
 
 For a per-platform breakdown of supported formats and UI features (including known gaps), see [Platform Support](https://hodakamori.github.io/megane/platform-support).
 
@@ -96,7 +96,7 @@ npm install megane-viewer
 
 ## Quick Start
 
-### Jupyter Notebook
+### Jupyter widget
 
 ```python
 import megane
@@ -114,7 +114,7 @@ viewer.frame_index = 50  # jump to frame 50
 
 For advanced usage (filtering, multi-layer rendering, custom pipelines), see the [Pipeline API](https://hodakamori.github.io/megane/guide/pipeline#python-pipeline-api).
 
-### CLI (Docker)
+### Standalone web app (`megane serve`)
 
 ```bash
 docker build -t megane .
@@ -130,7 +130,7 @@ docker run --rm -p 8080:8080 -v ./mydata:/data megane \
   megane serve /data/protein.pdb --port 8080 --no-browser
 ```
 
-### React
+### React component (npm)
 
 ```tsx
 import { useCallback } from "react";
@@ -251,7 +251,7 @@ python/megane/           Python backend
   parsers/               Python wrappers for 13 of the 15 supported formats (mmCIF and AMBER prmtop are accessible via the raw megane_parser PyO3 extension)
   pipeline.py            Pipeline builder (NetworkX-style DAG)
   protocol.py            Binary protocol encoder
-  server.py              FastAPI WebSocket server
+  server.py              `megane serve` backend (FastAPI + WebSocket)
   widget.py              anywidget Jupyter widget
 tests/                   Tests (Python, TypeScript, E2E)
 ```

--- a/docs/docs/api/index.md
+++ b/docs/docs/api/index.md
@@ -6,9 +6,9 @@ megane provides APIs for both Python and TypeScript/JavaScript.
 
 The Python API is used for:
 
-- **Jupyter notebooks** — Interactive widget for molecular visualization
-- **CLI server** — Serve structures via WebSocket
-- **Data loading** — Parse PDB files and read XTC trajectories
+- **Jupyter widget** — Interactive viewer in a notebook cell (`MolecularViewer`)
+- **Standalone web app** — Served by `megane serve` over WebSocket
+- **Python package** — Parse structure files and read trajectories programmatically
 
 ```python
 import megane
@@ -26,9 +26,9 @@ See the [Python Pipeline API guide](/guide/pipeline/python) for full documentati
 
 The TypeScript API is used for:
 
-- **React components** — Embed the viewer in web applications
-- **Core renderer** — Framework-agnostic Three.js rendering
-- **Protocol decoding** — Parse binary WebSocket messages
+- **React component (npm)** — Embed the viewer in web applications (`MeganeViewer`)
+- **`MoleculeRenderer` core renderer** — Framework-agnostic Three.js rendering
+- **Protocol decoding** — Parse binary messages from the `megane serve` backend
 
 ```ts
 import { MeganeViewer, MoleculeRenderer } from "megane-viewer/lib";

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -31,7 +31,7 @@ maturin develop --release
 Run the frontend dev server and Python backend simultaneously:
 
 ```bash
-# Terminal 1: Start the Python WebSocket server
+# Terminal 1: Start the `megane serve` backend (FastAPI + WebSocket)
 megane serve protein.pdb --dev --port 8765
 
 # Terminal 2: Start the Vite dev server

--- a/docs/docs/dev/architecture.md
+++ b/docs/docs/dev/architecture.md
@@ -279,7 +279,7 @@ the same PR. The full per-host registration checklist lives in the
    `LoadTrajectoryNode.tsx`
 5. Register the type on every host: `jupyterlab-megane/src/filetypes.ts`
    (JupyterLab `IFileType`) and `vscode-megane/package.json`
-   (VSCode `customEditors`)
+   (VS Code `customEditors`)
 6. Wire the Python `LoadStructure` / `LoadTrajectory` dispatch in
    `python/megane/pipeline.py` (`_load_structure_file` / `_load_trajectory_data`)
 7. Update `docs/docs/platform-support.md`, `docs/docs/introduction.md`,

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -21,7 +21,7 @@ npm install megane-viewer
 
 ## Quick Start
 
-### Jupyter Notebook
+### Jupyter widget
 
 ```python
 import megane
@@ -41,7 +41,7 @@ viewer.frame_index = 50  # jump to frame 50
 
 For advanced usage (filtering, multi-layer rendering, custom pipelines), see [Python Pipeline API](/guide/pipeline/python).
 
-### CLI Server (Docker)
+### Standalone web app (`megane serve`)
 
 The easiest way to run `megane serve` locally is with Docker:
 
@@ -59,11 +59,11 @@ docker run --rm -p 8080:8080 -v ./mydata:/data megane \
   megane serve /data/protein.pdb --port 8080 --no-browser
 ```
 
-For running from source, see the [CLI Guide](/guide/cli).
+For running from source, see the [Standalone web app guide](/guide/cli).
 
-### React Component
+### React component (npm)
 
-`MeganeViewer` is pipeline-store-driven — it manages its own snapshot, bonds,
+The `MeganeViewer` React component is pipeline-store-driven — it manages its own snapshot, bonds,
 trajectory, etc. internally. Host apps just supply the file-ingestion callback
 that pushes the chosen file into the global pipeline store:
 
@@ -87,7 +87,7 @@ function App() {
 ```
 
 For multiple independent viewers per page (e.g. embedding in MDX docs), use
-`PipelineViewer` instead — see the [Web / React Guide](/guide/web).
+`PipelineViewer` instead — see the [React component (npm) guide](/guide/web).
 
 ## Supported File Formats
 
@@ -114,8 +114,8 @@ Not every host opens every extension from its native file picker — see
 
 ## Next Steps
 
-- [Jupyter Widget Guide](/guide/jupyter) — Detailed widget usage, event handling, and Plotly integration
-- [CLI Guide](/guide/cli) — All CLI options and development mode
-- [Web / React Guide](/guide/web) — Embedding in React applications, imperative renderer API
+- [Jupyter widget guide](/guide/jupyter) — Detailed widget usage, event handling, and Plotly integration
+- [Standalone web app guide](/guide/cli) — All `megane serve` options and development mode
+- [React component (npm) guide](/guide/web) — Embedding in React applications, imperative renderer API
 - [Python Pipeline API](/guide/pipeline/python) — Full Python API documentation
 - [TypeScript Pipeline API](/guide/pipeline/typescript) — Full TypeScript API documentation

--- a/docs/docs/guide/cli.md
+++ b/docs/docs/guide/cli.md
@@ -1,6 +1,6 @@
-# CLI Server
+# Standalone web app (`megane serve`)
 
-megane includes a command-line tool to serve molecular structures in a local web viewer.
+The **standalone web app** is megane's full-featured viewer. You launch it with the `megane serve` command, which starts a local server and opens the viewer in your browser. `megane serve` is the CLI launcher; the FastAPI + WebSocket process it starts is referred to as the `megane serve` backend.
 
 ## Quick Start with Docker
 
@@ -58,7 +58,7 @@ megane serve [PDB_FILE] [OPTIONS]
 
 | Argument | Description |
 |----------|-------------|
-| `PDB_FILE` | Path to a PDB file (optional; can upload from the browser). The CLI server only loads `.pdb` from this positional argument — to start with an ASE trajectory, use `--traj` instead. Once the browser is open, drag-and-drop in the standalone UI accepts every supported structure format (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, mmCIF, LAMMPS data, AMBER prmtop, ASE `.traj`, …). |
+| `PDB_FILE` | Path to a PDB file (optional; can upload from the browser). `megane serve` only loads `.pdb` from this positional argument — to start with an ASE trajectory, use `--traj` instead. Once the browser is open, drag-and-drop in the standalone web app accepts every supported structure format (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, mmCIF, LAMMPS data, AMBER prmtop, ASE `.traj`, …). |
 
 ## Options
 
@@ -116,7 +116,7 @@ In development mode, the frontend is served by the Vite dev server (typically on
 
 ## Architecture
 
-The CLI starts a [FastAPI](https://fastapi.tiangolo.com/) server with:
+`megane serve` starts the backend — a [FastAPI](https://fastapi.tiangolo.com/) server with:
 
 - **Static file serving** — The built frontend from `megane/static/app/`
 - **WebSocket endpoint** (`/ws`) — Binary protocol streaming for molecular data

--- a/docs/docs/guide/integrations.md
+++ b/docs/docs/guide/integrations.md
@@ -84,7 +84,7 @@ See [`examples/external_events.ipynb`](https://github.com/hodakamori/megane/blob
 
 Embed the megane viewer in MDX-based documentation frameworks like Next.js. Drop `<MeganeViewer />` or `<Viewport />` into your `.mdx` files — WASM parsing works out of the box with a one-line webpack config.
 
-For full code examples and Next.js configuration, see the [Web / React Guide — MDX Usage](/guide/web#mdx-usage-nextjs).
+For full code examples and Next.js configuration, see the [React component (npm) guide — MDX Usage](/guide/web#mdx-usage-nextjs).
 
 ## ipywidgets Events
 
@@ -166,4 +166,4 @@ renderer.updateFrame(frame);
 renderer.dispose();
 ```
 
-Use this to embed megane in Vue, Svelte, or any other framework — or directly in a vanilla `<div>`. See the [Web / React Guide](/guide/web#core-renderer-framework-agnostic) for detailed examples.
+Use this to embed megane in Vue, Svelte, or any other framework — or directly in a vanilla `<div>`. See the [React component (npm) guide](/guide/web#core-renderer-framework-agnostic) for detailed examples.

--- a/docs/docs/guide/jupyter.mdx
+++ b/docs/docs/guide/jupyter.mdx
@@ -1,9 +1,9 @@
 import NotebookRenderer from '@site/src/components/NotebookRenderer';
 import LiveViewer from '@site/src/components/LiveViewer';
 
-# Jupyter / Python
+# Jupyter widget
 
-Use megane inside Jupyter notebooks as an interactive widget backed by [anywidget](https://anywidget.dev/). Works in JupyterLab, Jupyter Notebook, VS Code, and Google Colab.
+Use megane inside Jupyter notebooks as an interactive widget backed by [anywidget](https://anywidget.dev/). The widget is the `MolecularViewer` object; `megane.view()` / `view_traj()` are convenience wrappers that return one. Works in JupyterLab, Jupyter Notebook, VS Code, and Google Colab.
 
 <LiveViewer data="1crn" caption="A live megane widget — drag to rotate, scroll to zoom. This is the same renderer the notebook cell mounts." />
 

--- a/docs/docs/guide/pipeline/index.md
+++ b/docs/docs/guide/pipeline/index.md
@@ -31,9 +31,9 @@ Describe the visualization you want in natural language, and megane builds the n
 
 The generator creates the appropriate LoadStructure, AddBond, Filter, Modify, and Viewport nodes, wires them together, and places them in the editor. You can then adjust parameters or add more nodes manually.
 
-## VSCode Extension Auto-Setup
+## VS Code Extension Auto-Setup
 
-When you open a supported molecular file (`.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf`, `.mol2`, `.cif`, `.mmcif`, `.data`, `.lammps`, `.prmtop`, `.traj`, `.xtc`, `.dcd`, `.lammpstrj`, `.dump`, `.nc`) in the megane VSCode extension, it automatically creates a default pipeline consisting of `LoadStructure → AddBond → Viewport`. This gives you an immediate 3D view of the structure with bonds, without needing to build a pipeline manually. You can then modify the auto-generated pipeline in the editor as needed.
+When you open a supported molecular file (`.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf`, `.mol2`, `.cif`, `.mmcif`, `.data`, `.lammps`, `.prmtop`, `.traj`, `.xtc`, `.dcd`, `.lammpstrj`, `.dump`, `.nc`) in the megane VS Code extension, it automatically creates a default pipeline consisting of `LoadStructure → AddBond → Viewport`. This gives you an immediate 3D view of the structure with bonds, without needing to build a pipeline manually. You can then modify the auto-generated pipeline in the editor as needed.
 
 ## Getting Started
 

--- a/docs/docs/guide/pipeline/json.md
+++ b/docs/docs/guide/pipeline/json.md
@@ -6,7 +6,7 @@ sidebar_label: JSON
 
 Pipelines serialize to the **SerializedPipeline v3** JSON format. This format is used by:
 
-- The **VSCode extension** (`megane.json` files)
+- The **VS Code extension** (`megane.json` files)
 - The **pipeline editor** (import/export)
 - The TypeScript `pipe.toObject()` / `pipe.toJSON()` methods
 - The Python `pipe.to_dict()` method

--- a/docs/docs/guide/pipeline/python.md
+++ b/docs/docs/guide/pipeline/python.md
@@ -73,7 +73,7 @@ from megane import (
 ```
 
 :::note
-The **Surface Mesh** node (alpha-shape envelope) is available in the visual pipeline editor but does not have a Python class. Use the standalone app, JupyterLab, or VSCode to add it interactively, or author the pipeline JSON directly.
+The **Surface Mesh** node (alpha-shape envelope) is available in the visual pipeline editor but does not have a Python class. Use the standalone app, JupyterLab, or VS Code to add it interactively, or author the pipeline JSON directly.
 :::
 
 ### LoadStructure

--- a/docs/docs/guide/web.md
+++ b/docs/docs/guide/web.md
@@ -1,8 +1,8 @@
 import LiveViewer from '@site/src/components/LiveViewer';
 
-# Web / React
+# React component (npm)
 
-megane can be embedded in React applications as a component library. It provides both high-level React components and a framework-agnostic imperative renderer.
+megane can be embedded in React applications as a component library, published to npm as `megane-viewer`. It provides both high-level React components (`MeganeViewer`, `PipelineViewer`) and the framework-agnostic `MoleculeRenderer` core renderer.
 
 <LiveViewer data="caffeine_water" caption="The megane renderer running live in this page — the same engine megane-viewer ships to your app." />
 
@@ -537,7 +537,7 @@ export default nextConfig;
 
 ## Protocol Utilities
 
-Decode binary messages from the megane WebSocket server:
+Decode binary messages from the `megane serve` backend (WebSocket):
 
 ```ts
 import {

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-**megane** is a high-performance molecular viewer that works wherever you do — Jupyter notebooks, React web apps, the command line, and VSCode.
+**megane** is a high-performance molecular viewer that works wherever you do — as a Jupyter widget, a standalone web app, an embeddable React component, and a VS Code extension.
 
 ## What can megane do?
 
@@ -11,16 +11,20 @@
 - **Integrate with Plotly**, MDX/Next.js, ipywidgets, and any framework via the framework-agnostic renderer
 - **Light, dark, and auto themes** — cycle through Light / Dark / Auto (follows OS preference) via the Theme button in the Pipeline panel; persisted across sessions
 
-## Choose your environment
+## Choose your distribution
 
-| Environment | Install | Start here |
-|-------------|---------|------------|
-| **Jupyter / Python** | `pip install megane` | [Jupyter Guide](./guide/jupyter) |
-| **Web / React** | `npm install megane-viewer` | [Web Guide](./guide/web) |
-| **CLI (Docker)** | `docker build -t megane .` | [CLI Guide](./guide/cli) |
-| **VSCode** | Install the megane extension | [Pipeline Editor](./guide/pipeline) |
+megane ships in six distributions, grouped by what you want to do — **view** your data interactively, **embed** the viewer in your own app, or **parse** files programmatically.
 
-For a side-by-side comparison of which formats and UI features each environment supports — including known gaps — see [Platform Support](./platform-support).
+| Category | Distribution | Install | Start here |
+|----------|--------------|---------|------------|
+| **View** | Standalone web app | `pip install megane`, then `megane serve` | [Standalone web app](./guide/cli) |
+| **View** | Jupyter widget | `pip install megane` | [Jupyter widget](./guide/jupyter) |
+| **View** | JupyterLab extension | `pip install megane` | [Platform Support](./platform-support) |
+| **View** | VS Code extension | Install the megane extension | [Pipeline editor](./guide/pipeline) |
+| **Embed** | React component (npm) | `npm install megane-viewer` | [React component (npm)](./guide/web) |
+| **Parse** | Python package | `pip install megane` | [Python Pipeline API](./guide/pipeline/python) |
+
+For a side-by-side comparison of which formats and UI features each distribution supports — including known gaps — see [Platform Support](./platform-support).
 
 ## Supported file formats
 

--- a/docs/docs/platform-support.md
+++ b/docs/docs/platform-support.md
@@ -1,6 +1,16 @@
 # Platform Support
 
-megane ships in five distributions. They share the same Rust parser core (compiled to WASM and PyO3), but the host UI and the set of registered file types differ. This page is the single reference for **what works on which platform**, and it is descriptive of the current state — including known gaps.
+megane ships in six distributions. They share the same Rust parser core (compiled to WASM and PyO3), but the host UI and the set of registered file types differ. This page is the single reference for **what works on which platform**, and it is descriptive of the current state — including known gaps.
+
+## Terminology
+
+The docs describe megane along one axis: the **distribution** (host) you run it in. To keep names consistent everywhere:
+
+- **Standalone web app** — the full viewer served by the `megane serve` command. `megane serve` is the CLI launcher and "the `megane serve` backend" is its FastAPI + WebSocket server; neither is a separate distribution, and Docker is just one way to run it. Do not call this host "CLI", "CLI server", or "Browser".
+- **Jupyter widget**, **JupyterLab extension**, **VS Code extension** — the three embedded-in-a-host viewers. Microsoft's editor is written "VS Code"; our distribution is the "VS Code extension".
+- **React component (npm)** — the `megane-viewer` package you embed in your own React (or, via the core renderer, non-React) app.
+- **Python package** — the PyO3 parser API. No viewer.
+- Viewer objects map to hosts: the `MolecularViewer` widget (Jupyter), the `MeganeViewer` React component (npm), and the shared `MoleculeRenderer` core renderer (framework-agnostic). `megane.view()` / `view_traj()` are convenience wrappers that return a `MolecularViewer`.
 
 ## Platforms
 
@@ -8,8 +18,9 @@ megane ships in five distributions. They share the same Rust parser core (compil
 |---|---|---|
 | **Standalone web app** | `src/index.tsx`, served by `megane serve` | Full-featured viewer with pipeline editor, drag-and-drop, file dialogs, and WebSocket trajectory streaming. |
 | **Jupyter widget** (anywidget) | `src/widget.ts` + `python/megane/widget.py` | Embedded viewer in a notebook cell, driven by Python (`MolecularViewer`). |
-| **JupyterLab labextension** | `jupyterlab-megane/src/index.ts` | Document-style viewer launched from the JupyterLab file browser. |
-| **VSCode extension** | `vscode-megane/webview/main.tsx` | Custom editor activated when a registered file type is opened in VS Code. |
+| **JupyterLab extension** (labextension) | `jupyterlab-megane/src/index.ts` | Document-style viewer launched from the JupyterLab file browser. |
+| **VS Code extension** | `vscode-megane/webview/main.tsx` | Custom editor activated when a registered file type is opened in VS Code. |
+| **React component (npm)** | `src/lib.ts`, package `megane-viewer` | Embeddable React components (`MeganeViewer`, `PipelineViewer`, `Viewport`) plus the framework-agnostic `MoleculeRenderer`. The same viewer as Standalone, minus the `megane serve` backend (no built-in WebSocket streaming). |
 | **Python package** (PyO3) | `python/megane/parsers/` | Programmatic API for parsing files into Python objects. No viewer. |
 
 ## File-format support
@@ -22,19 +33,21 @@ Legend:
 
 ### Structure formats
 
-| Format | Extensions | Standalone | Jupyter widget | JupyterLab | VSCode | Python |
-|---|---|:---:|:---:|:---:|:---:|:---:|
-| PDB | `.pdb` | ✓ | API | ✓ | ✓ | ✓ |
-| GRO | `.gro` | ✓ | API | ✓ | ✓ | ✓ |
-| XYZ | `.xyz` | ✓ | API | ✓ | ✓ | ✓ |
-| MOL | `.mol` | ✓ | API | ✓ | ✓ | ✓ |
-| SDF | `.sdf` | ✓ | API | ✓ | ✓ | ✓ |
-| MOL2 | `.mol2` | ✓ | API | ✓ | ✓ | ✓ |
-| CIF | `.cif` | ✓ | API | ✓ | ✓ | ✓ |
-| mmCIF | `.mmcif` | ✓ | API | ✓ | ✓ | API |
-| LAMMPS data | `.data`, `.lammps` | ✓ | API | ✓ | ✓ | ✓ |
-| AMBER topology | `.prmtop` | ✓ | API | ✓ | ✓ | API |
-| ASE trajectory | `.traj` | ✓ | API | ✓ | ✓ | ✓ |
+| Format | Extensions | Standalone | Jupyter widget | JupyterLab | VS Code | React (npm) | Python |
+|---|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| PDB | `.pdb` | ✓ | API | ✓ | ✓ | ✓ | ✓ |
+| GRO | `.gro` | ✓ | API | ✓ | ✓ | ✓ | ✓ |
+| XYZ | `.xyz` | ✓ | API | ✓ | ✓ | ✓ | ✓ |
+| MOL | `.mol` | ✓ | API | ✓ | ✓ | ✓ | ✓ |
+| SDF | `.sdf` | ✓ | API | ✓ | ✓ | ✓ | ✓ |
+| MOL2 | `.mol2` | ✓ | API | ✓ | ✓ | ✓ | ✓ |
+| CIF | `.cif` | ✓ | API | ✓ | ✓ | ✓ | ✓ |
+| mmCIF | `.mmcif` | ✓ | API | ✓ | ✓ | ✓ | API |
+| LAMMPS data | `.data`, `.lammps` | ✓ | API | ✓ | ✓ | ✓ | ✓ |
+| AMBER topology | `.prmtop` | ✓ | API | ✓ | ✓ | ✓ | API |
+| ASE trajectory | `.traj` | ✓ | API | ✓ | ✓ | ✓ | ✓ |
+
+The **React component (npm)** column reflects the bundled `MeganeViewer` / `PipelineViewer`, which open these formats through the same WASM parser as Standalone (`parseStructureFile`); the host app wires the upload/drag-drop callbacks. The `MoleculeRenderer` core renderer consumes already-parsed snapshots.
 
 Note: ASE `.traj` is self-contained (elements, bonds, and all frames in one file) and is loaded via the **Load Structure** node, not Load Trajectory. It is listed here because it contains multi-frame trajectory data.
 
@@ -42,12 +55,12 @@ Note: **Heterogeneous frames** — trajectories whose frames differ in atom coun
 
 ### Trajectory formats
 
-| Format | Extensions | Standalone | Jupyter widget | JupyterLab | VSCode | Python |
-|---|---|:---:|:---:|:---:|:---:|:---:|
-| XTC | `.xtc` | ✓ | API | ✓¹ | ✓¹ | ✓ |
-| DCD | `.dcd` | ✓ | API | ✓¹ | ✓¹ | ✓ |
-| LAMMPS dump | `.lammpstrj`, `.dump` | ✓ | API | ✓¹ | ✓¹ | ✓ |
-| AMBER NetCDF | `.nc` | ✓ | API | ✓¹ | ✓¹ | ✓ |
+| Format | Extensions | Standalone | Jupyter widget | JupyterLab | VS Code | React (npm) | Python |
+|---|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| XTC | `.xtc` | ✓ | API | ✓¹ | ✓¹ | ✓¹ | ✓ |
+| DCD | `.dcd` | ✓ | API | ✓¹ | ✓¹ | ✓¹ | ✓ |
+| LAMMPS dump | `.lammpstrj`, `.dump` | ✓ | API | ✓¹ | ✓¹ | ✓¹ | ✓ |
+| AMBER NetCDF | `.nc` | ✓ | API | ✓¹ | ✓¹ | ✓¹ | ✓ |
 
 ¹ Trajectory-only formats need a topology already loaded. Opening a `.xtc` /
 `.dcd` / `.lammpstrj` / `.dump` / `.nc` directly surfaces an actionable error; recover by
@@ -73,48 +86,48 @@ the **Add Bond** pipeline node to supply explicit connectivity when the
 structure file does not encode it (e.g. pairing a PDB with a PSF, or a GRO
 with a GROMACS `.top`).
 
-| Format | Extensions | Standalone (Add Bond node) | Python |
-|---|---|:---:|:---:|
-| GROMACS topology | `.top` | ✓ | ✓ |
-| CHARMM/NAMD PSF | `.psf` | ✓ | API² |
+| Format | Extensions | Standalone (Add Bond node) | React (npm) | Python |
+|---|---|:---:|:---:|:---:|
+| GROMACS topology | `.top` | ✓ | ✓ | ✓ |
+| CHARMM/NAMD PSF | `.psf` | ✓ | ✓ | API² |
 
 ² Python `AddBonds` only wires GROMACS `.top` topology via the `top=` parameter. PSF bonds are accessible programmatically via `megane.parsers.psf.parse_psf_bonds(path)` or `megane_parser.parse_psf_bonds(text)`, but cannot be passed directly to an `AddBonds` pipeline node.
 
-Sources of truth: `crates/megane-wasm/src/lib.rs` (browser parsers), `crates/megane-python/src/lib.rs` (Python parsers), `src/components/nodes/LoadStructureNode.tsx` and `src/components/nodes/LoadTrajectoryNode.tsx` (standalone accept lists), `src/components/nodes/AddBondNode.tsx` (topology accept list), `jupyterlab-megane/src/filetypes.ts` (JupyterLab `IFileType` registrations), `vscode-megane/package.json` (VSCode `customEditors`).
+Sources of truth: `crates/megane-wasm/src/lib.rs` (browser parsers), `crates/megane-python/src/lib.rs` (Python parsers), `src/components/nodes/LoadStructureNode.tsx` and `src/components/nodes/LoadTrajectoryNode.tsx` (standalone accept lists), `src/components/nodes/AddBondNode.tsx` (topology accept list), `jupyterlab-megane/src/filetypes.ts` (JupyterLab `IFileType` registrations), `vscode-megane/package.json` (VS Code `customEditors`).
 
 ## UI features
 
-| Feature | Standalone | Jupyter widget | JupyterLab | VSCode | Python |
-|---|:---:|:---:|:---:|:---:|:---:|
-| Drag-and-drop into viewer | ✓ | — | — | — | n/a |
-| Built-in file picker | ✓ | — | host | host | n/a |
-| Visual pipeline editor | ✓ | — | ✓ | ✓ (`.megane.json`) | n/a |
-| Trajectory timeline / scrubbing | ✓ | ✓ | ✓ | ✓ | n/a |
-| WebSocket trajectory streaming | ✓ | — | — | — | n/a |
-| Multi-layer rendering | ✓ | ✓ (via pipeline) | ✓ | ✓ | n/a |
-| Solvent-accessible surface (SAS) | ✓ | ✓ (via pipeline) | ✓ | ✓ | n/a |
-| Surface mesh (alpha-shape envelope) | ✓ | ✓ (via pipeline) | ✓ | ✓ | n/a |
-| Crystallographic symmetry expansion on CIF load (asymmetric unit → full cell) | ✓ | ✓ | ✓ | ✓ | ✓ (`load_cif`) |
-| Replicate supercell (pipeline node) | ✓ | ✓ (via pipeline) | ✓ | ✓ | ✓ (`Replicate`) |
-| `frame_change` callback | ✓ (React prop) | ✓ (Python event) | ✓ (status bar) | ✓ (status bar) | n/a |
-| `selection_change` / `measurement` events | ✓ (React props) | ✓ | ✓² | ✓² | n/a |
-| Programmatic frame seek (`frame_index = N`) | ✓ | ✓ | ✓³ | ✓⁴ | n/a |
-| Export downloads (render output, pipeline JSON, measurement CSV/JSON) | ✓ | ✓⁵ | ✓ | ✓ (save dialog) | n/a |
+| Feature | Standalone | Jupyter widget | JupyterLab | VS Code | React (npm) | Python |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| Drag-and-drop into viewer | ✓ | — | — | — | ✓ | n/a |
+| Built-in file picker | ✓ | — | host | host | ✓ | n/a |
+| Visual pipeline editor | ✓ | — | ✓ | ✓ (`.megane.json`) | ✓ | n/a |
+| Trajectory timeline / scrubbing | ✓ | ✓ | ✓ | ✓ | ✓ | n/a |
+| WebSocket trajectory streaming | ✓ | — | — | — | — | n/a |
+| Multi-layer rendering | ✓ | ✓ (via pipeline) | ✓ | ✓ | ✓ | n/a |
+| Solvent-accessible surface (SAS) | ✓ | ✓ (via pipeline) | ✓ | ✓ | ✓ | n/a |
+| Surface mesh (alpha-shape envelope) | ✓ | ✓ (via pipeline) | ✓ | ✓ | ✓ | n/a |
+| Crystallographic symmetry expansion on CIF load (asymmetric unit → full cell) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ (`load_cif`) |
+| Replicate supercell (pipeline node) | ✓ | ✓ (via pipeline) | ✓ | ✓ | ✓ | ✓ (`Replicate`) |
+| `frame_change` callback | ✓ (React prop) | ✓ (Python event) | ✓ (status bar) | ✓ (status bar) | ✓ (React prop) | n/a |
+| `selection_change` / `measurement` events | ✓ (React props) | ✓ | ✓² | ✓² | ✓ (React props) | n/a |
+| Programmatic frame seek (`frame_index = N`) | ✓ | ✓ | ✓³ | ✓⁴ | ✓ | n/a |
+| Export downloads (render output, pipeline JSON, measurement CSV/JSON) | ✓ | ✓⁵ | ✓ | ✓ (save dialog) | ✓ | n/a |
 
 ³ JupyterLab: call `meganeReactView.seekFrame(N)` on a `MeganeReactView` instance obtained from the widget tracker. This delegates to `usePlaybackStore.seekFrame(N)` in the viewer.
 
-⁴ VSCode: call `vscode.commands.executeCommand('megane.seekFrame', N)` from another extension, or call `meganeEditorProvider.seekFrame(N)` on an `MeganeEditorProvider` reference. The command posts a `seekFrame` message to the most recently active megane webview panel.
+⁴ VS Code: call `vscode.commands.executeCommand('megane.seekFrame', N)` from another extension, or call `meganeEditorProvider.seekFrame(N)` on an `MeganeEditorProvider` reference. The command posts a `seekFrame` message to the most recently active megane webview panel.
 
-⁵ Jupyter widget: export downloads work when the notebook runs in a browser (JupyterLab, Jupyter Notebook). Inside a VSCode notebook the widget renders in a sandboxed webview with no path to the extension host, so downloads are unavailable — see Known gaps.
+⁵ Jupyter widget: export downloads work when the notebook runs in a browser (JupyterLab, Jupyter Notebook). Inside a VS Code notebook the widget renders in a sandboxed webview with no path to the extension host, so downloads are unavailable — see Known gaps.
 
 Notes:
 
 - **host** means the parent app provides the file picker (the JupyterLab file browser, the VS Code explorer); megane itself does not render one.
-- The Jupyter widget intentionally does not mount the visual pipeline editor — pipelines are built in Python (`megane.Pipeline`) and pushed via `MolecularViewer.set_pipeline()`. Use the standalone app, JupyterLab labextension, or VSCode extension to edit pipelines visually.
+- The Jupyter widget intentionally does not mount the visual pipeline editor — pipelines are built in Python (`megane.Pipeline`) and pushed via `MolecularViewer.set_pipeline()`. Use the standalone app, JupyterLab extension, VS Code extension, or the npm `MeganeViewer` to edit pipelines visually.
 - The standalone app is the only platform with `megane serve` WebSocket streaming; other platforms load full trajectories into memory.
 - The standalone React `MeganeViewer` exposes an `onFrameChange?: (frame: number) => void` prop that fires on every trajectory frame transition — useful for keeping a host Plotly figure in sync.
 - The standalone React `MeganeViewer` also exposes `onSelectionChange?: (selection: SelectionState) => void` (fires on every atom selection change; data: `{ atoms: number[] }`) and `onMeasurementChange?: (measurement: Measurement | null) => void` (fires when a distance/angle/dihedral measurement is computed or cleared) — both mirror the Jupyter widget's `selection_change` and `measurement` events.
-- ² On **JupyterLab**, `selection_change` / `measurement` events are surfaced via `MeganeReactView.subscribeSelectionChange` and `subscribeMeasurementChange` — consumable by other JupyterLab extensions. On **VSCode**, they are forwarded to the extension host as `selectionChange` / `measurementChange` webview messages and reflected in the status bar (atom count or measurement label).
+- ² On **JupyterLab**, `selection_change` / `measurement` events are surfaced via `MeganeReactView.subscribeSelectionChange` and `subscribeMeasurementChange` — consumable by other JupyterLab extensions. On **VS Code**, they are forwarded to the extension host as `selectionChange` / `measurementChange` webview messages and reflected in the status bar (atom count or measurement label).
 
 ## Load methods / APIs
 
@@ -125,18 +138,19 @@ How data gets into the viewer on each platform:
 | **Standalone** | Drag-and-drop, file dialog, `megane serve <file>`, WebSocket | `parseStructureFile(file)` (TypeScript), pipeline node `LoadStructure` / `LoadTrajectory` |
 | **Jupyter widget** | Python only — no in-cell file picker | `MolecularViewer.load(pdb_path, xtc=, traj=)` (deprecated) or `MolecularViewer.set_pipeline(Pipeline)` (recommended) |
 | **JupyterLab** | Click a registered file type in the file browser | Internally reads `context.model` (`jupyterlab-megane/src/MeganeDocWidget.tsx`) |
-| **VSCode** | Open a registered file from the explorer; extension host posts `loadFile` / `loadPipeline` to the webview | `postMessage({ type: "loadFile", … })` (`vscode-megane/webview/main.tsx`) |
+| **VS Code** | Open a registered file from the explorer; extension host posts `loadFile` / `loadPipeline` to the webview | `postMessage({ type: "loadFile", … })` (`vscode-megane/webview/main.tsx`) |
+| **React (npm)** | Host-wired upload/drag-drop into `MeganeViewer`, or a `pipeline` prop on `PipelineViewer` (`fileUrl` fetched at mount) | `parseStructureFile(file)` / `parseStructureText(text)`, `MoleculeRenderer.loadSnapshot(snapshot)` |
 | **Python** | `from megane import …` or `from megane.parsers import …` | Top-level `megane`: `load_pdb`, `load_cif`, `load_lammps_data`, `load_traj`, `load_trajectory` (XTC), `load_xyz_trajectory`. Full set via `megane.parsers`: additionally `load_gro`, `load_mol`, `load_sdf`, `load_mol2`, `load_dcd`, `load_netcdf`, `load_lammpstrj`. Raw PyO3 functions (all formats including mmCIF and AMBER prmtop) are in the native extension `megane_parser`: `from megane import megane_parser; megane_parser.parse_mmcif(text)`, `megane_parser.parse_prmtop(text)`, etc. |
 
 ## Known gaps
 
 These are formats or features that the parser layer supports but a given platform does not yet wire into its UI. They are documented here so users do not file bugs against expected-but-absent behaviour.
 
-- **Trajectory-only opens require a topology first.** On VSCode and JupyterLab, opening a `.xtc` / `.dcd` / `.lammpstrj` / `.dump` / `.nc` file before any structure is loaded surfaces a friendly error. The recommended flow is to open the structure first, or to use the pipeline editor (always mounted on these hosts) to wire a Load Structure node.
-- **Export downloads do not work for the Jupyter widget inside a VSCode notebook.** Browsers download exports via a synthetic `<a download>` click, and the VSCode custom editor relays them to the extension host (`saveFile` webview message → native save dialog). The anywidget running inside VSCode's notebook renderer webview can do neither — the sandbox ignores anchor downloads and provides no bridge to the extension host. Use JupyterLab (or the VSCode custom editor on a structure file) to export.
+- **Trajectory-only opens require a topology first.** On VS Code and JupyterLab, opening a `.xtc` / `.dcd` / `.lammpstrj` / `.dump` / `.nc` file before any structure is loaded surfaces a friendly error. The recommended flow is to open the structure first, or to use the pipeline editor (always mounted on these hosts) to wire a Load Structure node.
+- **Export downloads do not work for the Jupyter widget inside a VS Code notebook.** Browsers download exports via a synthetic `<a download>` click, and the VS Code custom editor relays them to the extension host (`saveFile` webview message → native save dialog). The anywidget running inside VS Code's notebook renderer webview can do neither — the sandbox ignores anchor downloads and provides no bridge to the extension host. Use JupyterLab (or the VS Code custom editor on a structure file) to export.
 - **Jupyter widget has no in-cell file picker or drag-and-drop.** This is intentional — the widget is Python-driven. Use `set_pipeline()` with a `Pipeline` to load any supported format.
 - **The Replicate node does not replicate trajectory frames.** The `replicate` pipeline node builds a static supercell from the structure's particles, bonds, and cell, but trajectory frames keep the original atom count. With a trajectory connected and any replication count > 1, the static structure and playback frames differ in atom count. The default pipelines wire Replicate with `nx = ny = nz = 1` (identity), so this only surfaces once a user increases the counts on a structure that also has a trajectory. Replicate also requires a unit cell on the input — structures without a cell pass through unchanged.
-- **Jupyter widget has no visual pipeline editor.** The editor's React surface relies on host chrome (drag handles, side panel layout) that the anywidget cell cannot reliably render, so it is only shipped on the standalone app, JupyterLab labextension, and VSCode extension. Build pipelines in Python with `megane.Pipeline` and push them via `MolecularViewer.set_pipeline()`.
+- **Jupyter widget has no visual pipeline editor.** The editor's React surface relies on host chrome (drag handles, side panel layout) that the anywidget cell cannot reliably render, so it is only shipped on the standalone app, JupyterLab extension, and VS Code extension. Build pipelines in Python with `megane.Pipeline` and push them via `MolecularViewer.set_pipeline()`.
 - **`selection_change` / `measurement` events on JupyterLab use a subscription API, not a Python callback.** The JupyterLab DocWidget has no Python kernel connection, so there is no Python callback surface. Use `MeganeReactView.subscribeSelectionChange` and `subscribeMeasurementChange` from another JupyterLab extension.
 - **`frame_change` callback for JupyterLab is surfaced as a status-bar frame counter.** The JupyterLab DocWidget has no Python kernel connection, so there is no Python callback surface. Instead, when `IStatusBar` is available, the current frame index is shown in the JupyterLab status bar (right side). The `subscribeFrameChange` method on `MeganeReactView` can also be used by other JupyterLab extensions to react to frame changes.
 - **CIF symmetry expansion is automatic; mmCIF is not expanded.** The `.cif` parser applies the `_symmetry_equiv_pos_as_xyz` operations on load, expanding the asymmetric unit into the full unit cell (VESTA-style packing) on every host. CIFs without symmetry operations (or with only the identity) are returned unchanged. The mmCIF/PDBx parser deliberately does **not** auto-expand — macromolecular depositions are shown as the deposited model. To then tile multiple cells, add a `Replicate` node (`megane.Replicate(nx, ny, nz)`), which is pure translational replication of the already-expanded cell.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -24,7 +24,10 @@ const sidebars: SidebarsConfig = {
       type: "category",
       label: "Visualize Your Data",
       collapsed: false,
-      items: ["guide/jupyter", "guide/cli"],
+      items: [
+        { type: "doc", id: "guide/jupyter", label: "Jupyter widget" },
+        { type: "doc", id: "guide/cli", label: "Standalone web app" },
+      ],
     },
     {
       type: "category",
@@ -39,7 +42,10 @@ const sidebars: SidebarsConfig = {
       type: "category",
       label: "Embed the Viewer",
       collapsed: false,
-      items: ["guide/web", "guide/integrations"],
+      items: [
+        { type: "doc", id: "guide/web", label: "React component (npm)" },
+        "guide/integrations",
+      ],
     },
     {
       type: "category",
@@ -65,7 +71,7 @@ const sidebars: SidebarsConfig = {
     {
       type: "doc",
       id: "configuration",
-      label: "Development Setup",
+      label: "Configuration",
     },
   ],
 

--- a/docs/src/components/GalleryViewer.tsx
+++ b/docs/src/components/GalleryViewer.tsx
@@ -10,7 +10,7 @@ type TabId = "jupyter" | "react" | "vscode";
 const tabs: { id: TabId; label: string }[] = [
   { id: "jupyter", label: "Jupyter" },
   { id: "react", label: "React" },
-  { id: "vscode", label: "VSCode" },
+  { id: "vscode", label: "VS Code" },
 ];
 
 interface Props {

--- a/docs/src/gallery/registry.ts
+++ b/docs/src/gallery/registry.ts
@@ -759,7 +759,7 @@ viewer`,
 import { PipelineViewer, Pipeline, LoadStructure, LoadTrajectory, AddBonds, ViewportNode } from "megane-viewer/lib";
 
 // Note: PipelineViewer auto-fetches load_structure files via fileUrl.
-// For load_trajectory, use the Jupyter / VSCode integration which handles file I/O natively.
+// For load_trajectory, use the Jupyter widget / VS Code extension which handles file I/O natively.
 const pipe = new Pipeline();
 const s = pipe.addNode(new LoadStructure("/megane/structures/caffeine_water.pdb"));
 const traj = pipe.addNode(new LoadTrajectory({ xtc: "caffeine_water_vibration.xtc" }));
@@ -862,7 +862,7 @@ viewer`,
 import { PipelineViewer, Pipeline, LoadStructure, AddBonds, LoadVector, VectorOverlay, ViewportNode } from "megane-viewer/lib";
 
 // Note: load_vector reads per-atom vector data (JSON or .vec format).
-// File loading is handled natively in Jupyter and VSCode;
+// File loading is handled natively in the Jupyter widget and VS Code extension;
 // for React embedding, inject pre-loaded VectorFrame[] data via a custom hook.
 const pipe = new Pipeline();
 const s = pipe.addNode(new LoadStructure("/megane/structures/caffeine_water.pdb"));

--- a/docs/src/gallery/types.ts
+++ b/docs/src/gallery/types.ts
@@ -11,7 +11,7 @@ export interface GalleryCode {
   jupyter: string;
   /** TSX code showing PipelineViewer usage */
   react: string;
-  /** megane.json content (SerializedPipeline JSON for VSCode extension) */
+  /** megane.json content (SerializedPipeline JSON for VS Code extension) */
   vscode: string;
 }
 

--- a/docs/src/pages/gallery.tsx
+++ b/docs/src/pages/gallery.tsx
@@ -9,7 +9,7 @@ export default function GalleryPage() {
         <h1>Gallery</h1>
         <p>
           A collection of visualization examples. Each example shows a live 3D preview
-          and the code needed to reproduce it in Jupyter, React, or the VSCode extension.
+          and the code needed to reproduce it in the Jupyter widget, React component (npm), or the VS Code extension.
         </p>
 
         <GalleryIndex />

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -17,7 +17,7 @@ function Hero() {
             Spectacles for atomistic data.
           </p>
           <p className={styles.heroSubtitle}>
-            1M+ atoms at 60fps. Visual pipelines. Jupyter, browser, React, VSCode.
+            1M+ atoms at 60fps. Visual pipelines. Jupyter widget, standalone web app, React component, VS Code extension.
           </p>
           <div className={styles.heroActions}>
             <Link className="button button--primary button--lg" to="/getting-started">
@@ -57,39 +57,39 @@ function Hero() {
 const paths = [
   {
     icon: "🔬",
-    title: "Python / Jupyter",
+    title: "Jupyter widget",
     install: "pip install megane",
     isCommand: true,
     description: "Interactive widget inside Jupyter notebooks. Build pipelines in Python, display structures inline.",
     href: "/guide/jupyter",
-    label: "Jupyter Guide",
+    label: "Jupyter widget",
   },
   {
     icon: "⚛️",
-    title: "TypeScript / React",
+    title: "React component (npm)",
     install: "npm install megane-viewer",
     isCommand: true,
     description: "Drop <PipelineViewer /> into any React app. Build pipelines with the TypeScript builder API.",
     href: "/guide/web",
-    label: "React Guide",
+    label: "React component (npm)",
   },
   {
     icon: "🐳",
-    title: "Docker",
+    title: "Standalone web app",
     install: "docker build -t megane .",
     isCommand: true,
-    description: "Serve local structure files and view them instantly in the browser. No code needed.",
+    description: "Serve local structure files with `megane serve` and view them instantly in the browser. No code needed.",
     href: "/guide/cli",
-    label: "CLI Guide",
+    label: "Standalone web app",
   },
   {
     icon: "🖥️",
-    title: "VSCode",
+    title: "VS Code extension",
     install: "Install from Marketplace",
     isCommand: false,
     description: "Open .pdb, .gro, .xyz, .mol, .cif files directly in VS Code with the megane extension.",
     href: "https://marketplace.visualstudio.com/items?itemName=hodakamori.vscode-megane",
-    label: "VSCode Extension",
+    label: "VS Code extension",
   },
 ];
 
@@ -131,7 +131,7 @@ function Features() {
     {
       title: "🌍 Runs Everywhere",
       description:
-        "Jupyter widget, CLI server, React component, VSCode extension, JupyterLab labextension. Rust parsers (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, LAMMPS data, XTC, ASE .traj, LAMMPS dump) shared between Python (PyO3) and browser (WASM): parse once, run anywhere.",
+        "Jupyter widget, standalone web app, React component (npm), VS Code extension, JupyterLab extension. Rust parsers (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, LAMMPS data, XTC, ASE .traj, LAMMPS dump) shared between Python (PyO3) and browser (WASM): parse once, run anywhere.",
     },
     {
       title: "🧩 Visual Pipeline Editor",
@@ -187,29 +187,29 @@ function PillarSection() {
             <table>
               <thead>
                 <tr>
-                  <th>Environment</th>
+                  <th>Distribution</th>
                   <th>How</th>
                   <th>Install</th>
                 </tr>
               </thead>
               <tbody>
                 <tr>
-                  <td><strong>Jupyter</strong></td>
+                  <td><strong>Jupyter widget</strong></td>
                   <td>anywidget inline viewer</td>
                   <td><code>pip install megane</code></td>
                 </tr>
                 <tr>
-                  <td><strong>Browser</strong></td>
-                  <td><code>megane serve</code> local server</td>
+                  <td><strong>Standalone web app</strong></td>
+                  <td><code>megane serve</code> in the browser</td>
                   <td><code>pip install megane</code></td>
                 </tr>
                 <tr>
-                  <td><strong>React</strong></td>
+                  <td><strong>React component (npm)</strong></td>
                   <td><code>{"<MeganeViewer />"}</code> component</td>
                   <td><code>npm install megane-viewer</code></td>
                 </tr>
                 <tr>
-                  <td><strong>VSCode</strong></td>
+                  <td><strong>VS Code extension</strong></td>
                   <td>Custom editor for .pdb, .gro, .xyz, .mol, .sdf, .cif</td>
                   <td>Extension</td>
                 </tr>


### PR DESCRIPTION
The docs named megane's distributions at inconsistent granularity: the
standalone web app was variously called "CLI Server", "CLI (Docker)",
"Browser", and "Python WebSocket server"; tables mixed a language
("Jupyter / Python"), a framework ("Web / React"), and a host ("VSCode")
as peers; and "VSCode"/"VS Code" spelling was inconsistent.

Anchor everything to the distribution (host) axis that platform-support.md
already uses, organized under a two-level taxonomy (View / Embed / Parse):

- Standalone web app (launched by `megane serve`; the FastAPI + WebSocket
  process is "the `megane serve` backend", not a separate distribution)
- Jupyter widget, JupyterLab extension, VS Code extension
- React component (npm) — added as a first-class sixth distribution, with
  its own column across the platform-support.md feature tables
- Python package

Also add a Terminology section to platform-support.md, standardize on the
"VS Code" spelling for Microsoft's editor throughout, disambiguate the
viewer objects (`MolecularViewer` / `MeganeViewer` / `MoleculeRenderer`)
by host, and align sidebar labels (including Configuration).

Docs-only change: no paths under the UI-affecting list and no product code
lines, so E2E and Codecov gates do not apply. Verified with a docusaurus
build (onBrokenLinks/onBrokenAnchors: throw) — no broken links or anchors.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RYFp7oCXZMCoCdrjE6WLRK