### PR TITLE
docs: clarify framework-agnostic naming and center hero GIF

### DIFF
--- a/docs/docs/guide/framework-agnostic.md
+++ b/docs/docs/guide/framework-agnostic.md
@@ -1,6 +1,6 @@
-# Framework-Agnostic Renderer
+# Use with Vue, Svelte & Vanilla JS
 
-`MoleculeRenderer` is a plain Three.js class — the same renderer powering all megane components — that can be mounted in any framework. Use it to embed megane in Vue, Svelte, or any other framework, or directly in a vanilla `<div>`, without pulling in React.
+`MoleculeRenderer` is a plain Three.js class — the same renderer powering all megane components — that you can mount without React. Use it to embed megane in Vue, Svelte, or any other framework, or directly in a vanilla `<div>`.
 
 ```ts
 import { MoleculeRenderer } from "megane-viewer/lib";

--- a/docs/docs/guide/web.md
+++ b/docs/docs/guide/web.md
@@ -318,9 +318,9 @@ function CustomLayout({ bondConfig, trajectoryConfig, handleUpload }) {
 
 ---
 
-## Core Renderer (Framework-Agnostic)
+## Core Renderer (Vue / Svelte / vanilla JS)
 
-For non-React applications (Vue, Svelte, vanilla JS), use `MoleculeRenderer` directly — the same Three.js renderer that powers all megane components. See the [Framework-Agnostic Renderer guide](/guide/framework-agnostic) for mounting, appearance control, atom selection/measurement, and screen-space picking.
+For non-React applications (Vue, Svelte, vanilla JS), use `MoleculeRenderer` directly — the same Three.js renderer that powers all megane components. See the [guide to using megane with Vue, Svelte & vanilla JS](/guide/framework-agnostic) for mounting, appearance control, atom selection/measurement, and screen-space picking.
 
 ---
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -57,7 +57,7 @@ const sidebars: SidebarsConfig = {
         {
           type: "doc",
           id: "guide/framework-agnostic",
-          label: "Framework-agnostic renderer",
+          label: "Vue / Svelte / Vanilla JS",
         },
       ],
     },

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -53,6 +53,7 @@
 
 .heroViewer {
   width: 100%;
+  align-self: center;
 }
 
 .heroDemoGif {

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -266,7 +266,7 @@ function PillarSection() {
           megane with any widget in the Jupyter ecosystem.
         </p>
         <p>
-          <strong>Framework-agnostic</strong> — <code>MoleculeRenderer</code> is a plain
+          <strong>Vue / Svelte / vanilla JS</strong> — <code>MoleculeRenderer</code> is a plain
           Three.js class. Mount it in Vue, Svelte, or a vanilla <code>{"<div>"}</code>.
         </p>
       </section>


### PR DESCRIPTION
## Summary

Follow-up polish on the docs restructure from #564 (already merged). Two small review items:

- **Clearer naming for the framework-agnostic renderer.** "Framework-Agnostic renderer" read as jargon, so the visible label/title now names the concrete frameworks it targets:
  - Integration sidebar entry: `Framework-agnostic renderer` → **`Vue / Svelte / Vanilla JS`**
  - Page title: `Framework-Agnostic Renderer` → **`Use with Vue, Svelte & Vanilla JS`**
  - `web.md` "Core Renderer" heading and its cross-reference link text updated to match
  - Landing-page Integrate pillar: the bold `Framework-agnostic` term → `Vue / Svelte / vanilla JS`
  - The doc slug (`/guide/framework-agnostic`) is **unchanged**, so all existing links keep working. Descriptive uses of "framework-agnostic" as a technical adjective in deeper prose (architecture, API index, platform-support) are left as-is since each already spells out the frameworks nearby.
- **Center the landing hero GIF vertically.** The GIF sat at the top of the taller text column, leaving dead space below it. Added `align-self: center` to the hero viewer column so it sits centered beside the text/code-tabs.

## Test Plan

- [ ] `npm test` passes
- [ ] `cargo test -p megane-core` passes
- [x] `python -m pytest` passes (if Python changes are included) — no Python changes in this PR.
- [x] Manually verified the change in the browser (if UI changes are included) — ran `cd docs && npm run build`; succeeds with `onBrokenLinks: "throw"` / `onBrokenAnchors: "throw"`, confirming the renamed label/title and unchanged slug keep every link valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018PeSsz5bvGcgF2N1zSH45E)_