### PR TITLE
fix: recover molecular bonds that cross the periodic boundary (#558)

### DIFF
--- a/crates/megane-core/src/bonds.rs
+++ b/crates/megane-core/src/bonds.rs
@@ -146,6 +146,129 @@ where
     bonds
 }
 
+/// Invert a row-major 3×3 matrix. Returns None if singular.
+fn invert3x3(m: &[f32; 9]) -> Option<[f32; 9]> {
+    let (a, b, c, d, e, f, g, h, i) = (m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8]);
+    let det = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g);
+    if det.abs() < 1e-12 {
+        return None;
+    }
+    let inv = 1.0 / det;
+    Some([
+        (e * i - f * h) * inv,
+        (c * h - b * i) * inv,
+        (b * f - c * e) * inv,
+        (f * g - d * i) * inv,
+        (a * i - c * g) * inv,
+        (c * d - a * f) * inv,
+        (d * h - e * g) * inv,
+        (b * g - a * h) * inv,
+        (a * e - b * d) * inv,
+    ])
+}
+
+/// Shift each bonded molecule by whole lattice vectors so that no covalent bond
+/// spans the periodic boundary — i.e. every connected component becomes
+/// spatially contiguous.
+///
+/// Many CIFs list every atom wrapped into the `[0,1)` fractional cell, which
+/// physically splits a molecule that straddles a face: two bonded atoms then
+/// sit ~one lattice vector apart in Cartesian space. Distance-based bond
+/// inference (`infer_bonds`) is not periodic, so it drops those cross-boundary
+/// bonds — the molecule renders broken (Issue #558). Running this first makes
+/// the molecule whole, so ordinary (non-periodic) inference finds every bond
+/// and the bond cylinders render at their true short length rather than across
+/// the cell.
+///
+/// Connectivity for the unwrap is determined with the minimum-image convention
+/// using the same covalent-radius criterion as `infer_bonds`, so exactly the
+/// bonds that inference would otherwise find (were the molecule contiguous) are
+/// used to knit each component together. Atoms with no bonds, and molecules
+/// that are already whole, are left untouched (all lattice shifts are zero), so
+/// this is a no-op for the common contiguous case. Positions are modified in
+/// place. The unit cell is unchanged, so whole molecules may poke slightly
+/// outside the `[0,1)` box (the standard VESTA/Mercury depiction).
+pub fn unwrap_molecules(positions: &mut [f32], elements: &[u8], box_matrix: &[f32; 9]) {
+    let n = elements.len();
+    if n < 2 {
+        return;
+    }
+    let minv = match invert3x3(box_matrix) {
+        Some(m) => m,
+        None => return,
+    };
+
+    let frac = |i: usize, p: &[f32]| -> (f32, f32, f32) {
+        let (x, y, z) = (p[i * 3], p[i * 3 + 1], p[i * 3 + 2]);
+        (
+            x * minv[0] + y * minv[3] + z * minv[6],
+            x * minv[1] + y * minv[4] + z * minv[7],
+            x * minv[2] + y * minv[5] + z * minv[8],
+        )
+    };
+
+    // Adjacency with the integer lattice shift that brings the neighbour's
+    // minimum image next to the current atom. Asymmetric units are small, so a
+    // brute-force O(n²) scan is cheap and avoids periodic cell-list bookkeeping.
+    let mut adj: Vec<Vec<(usize, [i32; 3])>> = vec![Vec::new(); n];
+    for i in 0..n {
+        let (fi0, fi1, fi2) = frac(i, positions);
+        for j in (i + 1)..n {
+            let (fj0, fj1, fj2) = frac(j, positions);
+            let (mut d0, mut d1, mut d2) = (fj0 - fi0, fj1 - fi1, fj2 - fi2);
+            let (n0, n1, n2) = (d0.round(), d1.round(), d2.round());
+            d0 -= n0;
+            d1 -= n1;
+            d2 -= n2;
+            let cx = d0 * box_matrix[0] + d1 * box_matrix[3] + d2 * box_matrix[6];
+            let cy = d0 * box_matrix[1] + d1 * box_matrix[4] + d2 * box_matrix[7];
+            let cz = d0 * box_matrix[2] + d1 * box_matrix[5] + d2 * box_matrix[8];
+            let dist_sq = cx * cx + cy * cy + cz * cz;
+            let threshold =
+                (covalent_radius(elements[i]) + covalent_radius(elements[j])) * BOND_TOLERANCE;
+            if dist_sq > MIN_BOND_DIST * MIN_BOND_DIST && dist_sq <= threshold * threshold {
+                // To place j's minimum image next to i, shift j by -n lattice
+                // vectors; the reverse edge shifts i by +n relative to j.
+                adj[i].push((j, [-(n0 as i32), -(n1 as i32), -(n2 as i32)]));
+                adj[j].push((i, [n0 as i32, n1 as i32, n2 as i32]));
+            }
+        }
+    }
+
+    // Flood-fill each connected component, accumulating lattice shifts so the
+    // whole molecule is expressed in one image. The seed atom stays put.
+    let mut shift = vec![[0i32; 3]; n];
+    let mut visited = vec![false; n];
+    let mut stack: Vec<usize> = Vec::new();
+    for start in 0..n {
+        if visited[start] {
+            continue;
+        }
+        visited[start] = true;
+        stack.push(start);
+        while let Some(i) = stack.pop() {
+            for &(j, s) in &adj[i] {
+                if !visited[j] {
+                    visited[j] = true;
+                    shift[j] = [shift[i][0] + s[0], shift[i][1] + s[1], shift[i][2] + s[2]];
+                    stack.push(j);
+                }
+            }
+        }
+    }
+
+    for i in 0..n {
+        let s = shift[i];
+        if s == [0, 0, 0] {
+            continue;
+        }
+        let (sf0, sf1, sf2) = (s[0] as f32, s[1] as f32, s[2] as f32);
+        positions[i * 3] += sf0 * box_matrix[0] + sf1 * box_matrix[3] + sf2 * box_matrix[6];
+        positions[i * 3 + 1] += sf0 * box_matrix[1] + sf1 * box_matrix[4] + sf2 * box_matrix[7];
+        positions[i * 3 + 2] += sf0 * box_matrix[2] + sf1 * box_matrix[5] + sf2 * box_matrix[8];
+    }
+}
+
 /// Infer bonds using a cell-list (spatial hashing) approach.
 pub fn infer_bonds(
     positions: &[f32],
@@ -235,6 +358,87 @@ mod tests {
     fn test_infer_bonds_empty() {
         let bonds = infer_bonds(&[], &[], 0, &HashSet::new());
         assert!(bonds.is_empty());
+    }
+
+    /// A carbonyl split across the a-face (C near fract 0.05, O near fract 0.90)
+    /// loses its C–O bond under non-periodic inference; unwrapping must knit the
+    /// molecule back together so the bond is recovered (Issue #558).
+    #[test]
+    fn test_unwrap_molecules_recovers_split_bond() {
+        let a = 8.0f32;
+        let box_m = [a, 0.0, 0.0, 0.0, a, 0.0, 0.0, 0.0, a];
+        // C at 0.4 Å (fract 0.05), O at 7.16 Å (fract 0.895): 6.76 Å apart
+        // directly, 1.24 Å across the periodic boundary.
+        let mut positions = vec![0.4, 4.0, 4.0, 7.16, 4.0, 4.0];
+        let elements = vec![6u8, 8u8];
+
+        // Without unwrapping, non-periodic inference misses the bond.
+        assert!(infer_bonds(&positions, &elements, 2, &HashSet::new()).is_empty());
+
+        unwrap_molecules(&mut positions, &elements, &box_m);
+        // O is shifted by one -a lattice vector to sit next to C.
+        assert!((positions[3] - (7.16 - a)).abs() < 1e-3);
+        let bonds = infer_bonds(&positions, &elements, 2, &HashSet::new());
+        assert_eq!(bonds, vec![(0, 1)]);
+    }
+
+    /// A molecule already whole must be left exactly as-is (all shifts zero).
+    #[test]
+    fn test_unwrap_molecules_noop_for_contiguous() {
+        let box_m = [20.0, 0.0, 0.0, 0.0, 20.0, 0.0, 0.0, 0.0, 20.0];
+        let (mut positions, elements) = water_positions();
+        // Center the whole molecule inside the box.
+        for i in 0..3 {
+            positions[i * 3] += 10.0;
+            positions[i * 3 + 1] += 10.0;
+            positions[i * 3 + 2] += 10.0;
+        }
+        let before = positions.clone();
+        unwrap_molecules(&mut positions, &elements, &box_m);
+        for (a, b) in positions.iter().zip(before.iter()) {
+            assert!((a - b).abs() < 1e-6);
+        }
+    }
+
+    /// Two independent split molecules are each made whole without being merged.
+    #[test]
+    fn test_unwrap_molecules_multiple_components() {
+        let a = 8.0f32;
+        let box_m = [a, 0.0, 0.0, 0.0, a, 0.0, 0.0, 0.0, a];
+        // Molecule A (C–O) split across the a-face; molecule B (C–O) whole and
+        // far away along y.
+        let mut positions = vec![
+            0.4, 1.0, 1.0, // C  (fract 0.05)
+            7.16, 1.0, 1.0, // O  (fract 0.895) — split partner of the C above
+            3.0, 6.0, 6.0, // C  (whole molecule B)
+            4.2, 6.0, 6.0, // O
+        ];
+        let elements = vec![6u8, 8u8, 6u8, 8u8];
+        unwrap_molecules(&mut positions, &elements, &box_m);
+        let bonds = infer_bonds(&positions, &elements, 4, &HashSet::new());
+        let set: HashSet<(u32, u32)> = bonds.into_iter().collect();
+        assert!(set.contains(&(0, 1)));
+        assert!(set.contains(&(2, 3)));
+        // Molecule B was already whole — untouched.
+        assert!((positions[6] - 3.0).abs() < 1e-6 && (positions[9] - 4.2).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_unwrap_molecules_too_few_atoms_is_noop() {
+        let box_m = [10.0, 0.0, 0.0, 0.0, 10.0, 0.0, 0.0, 0.0, 10.0];
+        let mut positions = vec![9.9, 0.0, 0.0];
+        let before = positions.clone();
+        unwrap_molecules(&mut positions, &[6], &box_m);
+        assert_eq!(positions, before);
+    }
+
+    #[test]
+    fn test_unwrap_molecules_singular_box_is_noop() {
+        let box_m = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0]; // singular
+        let mut positions = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+        let before = positions.clone();
+        unwrap_molecules(&mut positions, &[6, 6], &box_m);
+        assert_eq!(positions, before);
     }
 
     #[test]

--- a/crates/megane-core/src/cif.rs
+++ b/crates/megane-core/src/cif.rs
@@ -404,7 +404,16 @@ pub fn parse(text: &str) -> Result<ParsedStructure, String> {
         return Err("CIF file contains no atom sites".to_string());
     }
 
-    // Infer bonds on the asymmetric unit.
+    // Make molecules whole before inferring bonds. CIFs frequently list every
+    // atom wrapped into the [0,1) cell, which splits a molecule that straddles
+    // a face; since bond inference is not periodic, the cross-boundary bonds
+    // would otherwise be dropped (Issue #558). Unwrapping is a no-op when the
+    // asymmetric unit is already contiguous.
+    if let Some(bm) = box_matrix.as_ref() {
+        bonds::unwrap_molecules(&mut positions, &elements, bm);
+    }
+
+    // Infer bonds on the (now whole) asymmetric unit.
     let empty_bonds = HashSet::new();
     let bonds = bonds::infer_bonds(&positions, &elements, n_atoms, &empty_bonds);
 
@@ -458,6 +467,30 @@ pub fn parse(text: &str) -> Result<ParsedStructure, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for Issue #558. `pbc_bond_split.cif` lists a single
+    /// molecule wrapped into the cell so the carbonyl oxygen sits on the far
+    /// side of the a-face from the carbon. The parser must unwrap the molecule
+    /// and recover the C–O bond that non-periodic inference would otherwise drop.
+    #[test]
+    fn test_parse_recovers_bond_across_periodic_boundary() {
+        let text = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../tests/fixtures/pbc_bond_split.cif"
+        ))
+        .expect("read fixture");
+        let s = parse(&text).unwrap();
+        assert_eq!(s.n_atoms, 4);
+        // C–O (the boundary-crossing bond) plus the two C–H bonds.
+        assert_eq!(s.bonds.len(), 3);
+        let has = |a: u32, b: u32| s.bonds.contains(&(a, b)) || s.bonds.contains(&(b, a));
+        assert!(
+            has(0, 1),
+            "C–O bond across the periodic boundary must exist"
+        );
+        assert!(has(0, 2));
+        assert!(has(0, 3));
+    }
 
     #[test]
     fn test_extract_symmetry_ops_single_column_loop() {

--- a/src/parsers/inferBondsJS.ts
+++ b/src/parsers/inferBondsJS.ts
@@ -114,6 +114,18 @@ export function inferBondsVdwJS(
   const atomCell = new Uint32Array(nAtoms);
   const cellStart = new Uint32Array(nCells + 1);
 
+  // In PBC mode, work off positions wrapped into the home cell `[0,1)`. The
+  // cell-list distance path derives its neighbor shift from the cell-index
+  // wrap (±1 box vector), which is only consistent with the atom coordinates
+  // when those coordinates already lie in the home cell. Crystal inputs do NOT
+  // satisfy this: `crystal::expand_symmetry` only centroid-wraps each symmetry
+  // image, so its atoms sit at fractional coords outside `[0,1)`. Using the raw
+  // (unwrapped) coordinates there makes a cross-face bond compute ~1 box too
+  // long and get dropped (Issue #558). Bond inference returns only index pairs,
+  // so wrapping internally changes connectivity to be correct without affecting
+  // any downstream positions.
+  const pbcPositions = usePbc ? new Float32Array(nAtoms * 3) : positions;
+
   if (usePbc) {
     const bi0 = boxInv![0],
       bi1 = boxInv![1],
@@ -124,6 +136,15 @@ export function inferBondsVdwJS(
     const bi6 = boxInv![6],
       bi7 = boxInv![7],
       bi8 = boxInv![8];
+    const b0 = box![0],
+      b1 = box![1],
+      b2 = box![2];
+    const b3 = box![3],
+      b4 = box![4],
+      b5 = box![5];
+    const b6 = box![6],
+      b7 = box![7],
+      b8 = box![8];
     const nxF = nx,
       nyF = ny,
       nzF = nz;
@@ -137,6 +158,10 @@ export function inferBondsVdwJS(
       fx = fx - Math.floor(fx);
       fy = fy - Math.floor(fy);
       fz = fz - Math.floor(fz);
+      // Store the home-cell Cartesian position for the distance loops below.
+      pbcPositions[i * 3] = b0 * fx + b3 * fy + b6 * fz;
+      pbcPositions[i * 3 + 1] = b1 * fx + b4 * fy + b7 * fz;
+      pbcPositions[i * 3 + 2] = b2 * fx + b5 * fy + b8 * fz;
       let cx = (fx * nxF) | 0;
       let cy = (fy * nyF) | 0;
       let cz = (fz * nzF) | 0;
@@ -215,12 +240,15 @@ export function inferBondsVdwJS(
     // transform (9 mults + 3 Math.round + 9 mults) for *every* candidate
     // pair — instead it's amortized over all atoms in the neighbor cell.
     //
-    // This optimization is only correct when each axis has ≥ 2 cells: with
-    // a single cell along an axis, atoms within the same cell can span the
-    // full box width, so cell-wrap-derived shifts no longer match the true
-    // minimum image. For such tiny boxes we fall back to the per-pair
-    // minimum-image transform (still correct, just less branch-friendly).
-    if (nx < 2 || ny < 2 || nz < 2) {
+    // This half-shell scheme is only correct when each axis has ≥ 3 cells.
+    // With exactly 2 cells, a cell's +1 and −1 neighbours along an axis
+    // collapse to the *same* cell but need opposite box shifts, while the
+    // half-shell visits it once (with only the +1 shift) and same-cell pairs
+    // get no shift at all — so both the wrap-around image and the direct
+    // image cannot be represented and the min-image distance is wrong (e.g.
+    // NaCl's 5.64 Å cube → 2 cells/axis produced spurious bonds). For such
+    // small boxes we fall back to the exact per-pair minimum-image transform.
+    if (nx < 3 || ny < 3 || nz < 3) {
       const bi0 = boxInv![0],
         bi1 = boxInv![1],
         bi2 = boxInv![2];
@@ -233,15 +261,15 @@ export function inferBondsVdwJS(
       // Brute-force min-image: at most a few dozen atoms per cell × few cells.
       for (let i = 0; i < nAtoms; i++) {
         const ix3 = i * 3;
-        const pix = positions[ix3];
-        const piy = positions[ix3 + 1];
-        const piz = positions[ix3 + 2];
+        const pix = pbcPositions[ix3];
+        const piy = pbcPositions[ix3 + 1];
+        const piz = pbcPositions[ix3 + 2];
         const ri = radii[i];
         for (let j = i + 1; j < nAtoms; j++) {
           const jx3 = j * 3;
-          let dx = positions[jx3] - pix;
-          let dy = positions[jx3 + 1] - piy;
-          let dz = positions[jx3 + 2] - piz;
+          let dx = pbcPositions[jx3] - pix;
+          let dy = pbcPositions[jx3 + 1] - piy;
+          let dz = pbcPositions[jx3 + 2] - piz;
           let sx = bi0 * dx + bi3 * dy + bi6 * dz;
           let sy = bi1 * dx + bi4 * dy + bi7 * dz;
           let sz = bi2 * dx + bi5 * dy + bi8 * dz;
@@ -273,16 +301,16 @@ export function inferBondsVdwJS(
           for (let a = aStart; a < aEnd; a++) {
             const i = cellAtoms[a];
             const ix3 = i * 3;
-            const pix = positions[ix3];
-            const piy = positions[ix3 + 1];
-            const piz = positions[ix3 + 2];
+            const pix = pbcPositions[ix3];
+            const piy = pbcPositions[ix3 + 1];
+            const piz = pbcPositions[ix3 + 2];
             const ri = radii[i];
             for (let b2i = a + 1; b2i < aEnd; b2i++) {
               const j = cellAtoms[b2i];
               const jx3 = j * 3;
-              const dx = positions[jx3] - pix;
-              const dy = positions[jx3 + 1] - piy;
-              const dz = positions[jx3 + 2] - piz;
+              const dx = pbcPositions[jx3] - pix;
+              const dy = pbcPositions[jx3 + 1] - piy;
+              const dz = pbcPositions[jx3 + 2] - piz;
               const distSq = dx * dx + dy * dy + dz * dz;
               const th = (ri + radii[j]) * vdwScale;
               if (distSq > minDistSq && distSq <= th * th) {
@@ -343,16 +371,16 @@ export function inferBondsVdwJS(
             for (let a = aStart; a < aEnd; a++) {
               const i = cellAtoms[a];
               const ix3 = i * 3;
-              const pix = positions[ix3];
-              const piy = positions[ix3 + 1];
-              const piz = positions[ix3 + 2];
+              const pix = pbcPositions[ix3];
+              const piy = pbcPositions[ix3 + 1];
+              const piz = pbcPositions[ix3 + 2];
               const ri = radii[i];
               for (let bb = bStart; bb < bEnd; bb++) {
                 const j = cellAtoms[bb];
                 const jx3 = j * 3;
-                const dx = positions[jx3] + shiftX - pix;
-                const dy = positions[jx3 + 1] + shiftY - piy;
-                const dz = positions[jx3 + 2] + shiftZ - piz;
+                const dx = pbcPositions[jx3] + shiftX - pix;
+                const dy = pbcPositions[jx3 + 1] + shiftY - piy;
+                const dz = pbcPositions[jx3 + 2] + shiftZ - piz;
                 const distSq = dx * dx + dy * dy + dz * dz;
                 const th = (ri + radii[j]) * vdwScale;
                 if (distSq > minDistSq && distSq <= th * th) {
@@ -431,5 +459,19 @@ export function inferBondsVdwJS(
     }
   }
 
+  console.log(
+    "IBJ-CALLED nAtoms=" +
+      nAtoms +
+      " usePbc=" +
+      usePbc +
+      " nx=" +
+      nx +
+      " ny=" +
+      ny +
+      " nz=" +
+      nz +
+      " bonds=" +
+      outLen / 2,
+  );
   return outBuf.slice(0, outLen);
 }

--- a/tests/fixtures/pbc_bond_split.cif
+++ b/tests/fixtures/pbc_bond_split.cif
@@ -1,0 +1,21 @@
+data_pbc_bond_split
+_cell_length_a   8.0
+_cell_length_b   8.0
+_cell_length_c   8.0
+_cell_angle_alpha   90.0
+_cell_angle_beta    90.0
+_cell_angle_gamma   90.0
+_symmetry_space_group_name_H-M   'P 1'
+loop_
+_symmetry_equiv_pos_as_xyz
+x,y,z
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+C1 C 0.050 0.500 0.500
+O1 O 0.895 0.500 0.500
+H1 H 0.125 0.570 0.560
+H2 H 0.125 0.430 0.440

--- a/tests/ts/parsers/inferBondsJS.test.ts
+++ b/tests/ts/parsers/inferBondsJS.test.ts
@@ -19,9 +19,15 @@ describe("inferBondsVdwJS", () => {
     const angle = (104.5 / 2) * (Math.PI / 180);
     const oh = 0.96;
     const positions = new Float32Array([
-      0, 0, 0,                                        // O
-      oh * Math.sin(angle), oh * Math.cos(angle), 0,  // H1
-      -oh * Math.sin(angle), oh * Math.cos(angle), 0, // H2
+      0,
+      0,
+      0, // O
+      oh * Math.sin(angle),
+      oh * Math.cos(angle),
+      0, // H1
+      -oh * Math.sin(angle),
+      oh * Math.cos(angle),
+      0, // H2
     ]);
     const elements = new Uint8Array([8, 1, 1]); // O, H, H
 
@@ -42,10 +48,7 @@ describe("inferBondsVdwJS", () => {
 
   it("does not bond atoms that are too far apart", () => {
     // Two carbons 10 Å apart — well beyond VDW threshold
-    const positions = new Float32Array([
-      0, 0, 0,
-      10, 0, 0,
-    ]);
+    const positions = new Float32Array([0, 0, 0, 10, 0, 0]);
     const elements = new Uint8Array([6, 6]);
 
     const bonds = inferBondsVdwJS(positions, elements, 2);
@@ -54,10 +57,7 @@ describe("inferBondsVdwJS", () => {
 
   it("does not bond atoms closer than MIN_BOND_DIST", () => {
     // Two atoms at 0.3 Å — below MIN_BOND_DIST (0.4)
-    const positions = new Float32Array([
-      0, 0, 0,
-      0.3, 0, 0,
-    ]);
+    const positions = new Float32Array([0, 0, 0, 0.3, 0, 0]);
     const elements = new Uint8Array([6, 6]);
 
     const bonds = inferBondsVdwJS(positions, elements, 2);
@@ -72,17 +72,35 @@ describe("inferBondsVdwJS", () => {
 
     const positions = new Float32Array([
       // Molecule 1
-      0, 0, 0,
-      oh * Math.sin(angle), oh * Math.cos(angle), 0,
-      -oh * Math.sin(angle), oh * Math.cos(angle), 0,
+      0,
+      0,
+      0,
+      oh * Math.sin(angle),
+      oh * Math.cos(angle),
+      0,
+      -oh * Math.sin(angle),
+      oh * Math.cos(angle),
+      0,
       // Molecule 2
-      spacing, 0, 0,
-      spacing + oh * Math.sin(angle), oh * Math.cos(angle), 0,
-      spacing - oh * Math.sin(angle), oh * Math.cos(angle), 0,
+      spacing,
+      0,
+      0,
+      spacing + oh * Math.sin(angle),
+      oh * Math.cos(angle),
+      0,
+      spacing - oh * Math.sin(angle),
+      oh * Math.cos(angle),
+      0,
       // Molecule 3
-      0, spacing, 0,
-      oh * Math.sin(angle), spacing + oh * Math.cos(angle), 0,
-      -oh * Math.sin(angle), spacing + oh * Math.cos(angle), 0,
+      0,
+      spacing,
+      0,
+      oh * Math.sin(angle),
+      spacing + oh * Math.cos(angle),
+      0,
+      -oh * Math.sin(angle),
+      spacing + oh * Math.cos(angle),
+      0,
     ]);
     const elements = new Uint8Array([8, 1, 1, 8, 1, 1, 8, 1, 1]);
 
@@ -118,15 +136,151 @@ describe("inferBondsVdwJS", () => {
 
   it("bonds carbon atoms at covalent-like distance", () => {
     // Two carbons at 1.5 Å — within VDW threshold (1.7+1.7)*0.6 = 2.04
-    const positions = new Float32Array([
-      0, 0, 0,
-      1.5, 0, 0,
-    ]);
+    const positions = new Float32Array([0, 0, 0, 1.5, 0, 0]);
     const elements = new Uint8Array([6, 6]);
 
     const bonds = inferBondsVdwJS(positions, elements, 2);
     expect(bonds.length).toBe(2); // 1 bond pair
     expect(bonds[0]).toBe(0);
     expect(bonds[1]).toBe(1);
+  });
+});
+
+/** Collect bonds as an unordered set of "a-b" keys (a < b). */
+function bondSet(bonds: Uint32Array): Set<string> {
+  const set = new Set<string>();
+  for (let i = 0; i < bonds.length; i += 2) {
+    const a = bonds[i];
+    const b = bonds[i + 1];
+    set.add(a < b ? `${a}-${b}` : `${b}-${a}`);
+  }
+  return set;
+}
+
+describe("inferBondsVdwJS — periodic boundary conditions (Issue #558)", () => {
+  // Orthorhombic 10 Å cube. min(|a|,|b|,|c|)/CELL_SIZE = 5 cells per axis,
+  // so all axes have ≥ 2 cells and the cell-list (non-brute-force) path runs.
+  const box10 = new Float32Array([10, 0, 0, 0, 10, 0, 0, 0, 10]);
+
+  it("detects a covalent bond that crosses a cell face (cell-list path)", () => {
+    // Two carbons 1.0 Å apart straddling the x = 1 face: one at fractional 0.95
+    // (x = 9.5), its partner at fractional 1.05 (x = 10.5, i.e. outside the home
+    // cell — exactly what crystal symmetry expansion produces). Before the fix
+    // the neighbor-cell shift disagreed with the unwrapped coordinate and the
+    // bond was computed ~1 box too long, so no bond was emitted.
+    const positions = new Float32Array([
+      9.5,
+      5,
+      5, // C0  frac 0.95
+      10.5,
+      5,
+      5, // C1  frac 1.05
+    ]);
+    const elements = new Uint8Array([6, 6]);
+
+    const bonds = inferBondsVdwJS(positions, elements, 2, DEFAULT_VDW_BOND_FACTOR, box10);
+    expect(bondSet(bonds)).toEqual(new Set(["0-1"]));
+  });
+
+  it("keeps a whole molecule bonded when its image straddles a face", () => {
+    // Linear C3 chain (1.4 Å spacing) whose middle/last atoms poke past x = 1.
+    // Expect the same two bonds as the identical chain placed wholly inside the
+    // cell.
+    const elements = new Uint8Array([6, 6, 6]);
+    const straddling = new Float32Array([
+      9.0,
+      5,
+      5, // frac 0.90
+      10.4,
+      5,
+      5, // frac 1.04
+      11.8,
+      5,
+      5, // frac 1.18
+    ]);
+    const inside = new Float32Array([4.0, 5, 5, 5.4, 5, 5, 6.8, 5, 5]);
+
+    const straddleBonds = bondSet(
+      inferBondsVdwJS(straddling, elements, 3, DEFAULT_VDW_BOND_FACTOR, box10),
+    );
+    const insideBonds = bondSet(
+      inferBondsVdwJS(inside, elements, 3, DEFAULT_VDW_BOND_FACTOR, box10),
+    );
+
+    expect(straddleBonds).toEqual(new Set(["0-1", "1-2"]));
+    expect(straddleBonds).toEqual(insideBonds);
+  });
+
+  it("bonds two atoms sitting near opposite faces via minimum image", () => {
+    // Carbons at fractional 0.05 (x = 0.5) and 0.90 (x = 9.0): direct span 8.5 Å,
+    // but the minimum-image distance across the x face is 1.5 Å < 2.04 Å.
+    const positions = new Float32Array([0.5, 5, 5, 9.0, 5, 5]);
+    const elements = new Uint8Array([6, 6]);
+
+    const bonds = inferBondsVdwJS(positions, elements, 2, DEFAULT_VDW_BOND_FACTOR, box10);
+    expect(bondSet(bonds)).toEqual(new Set(["0-1"]));
+  });
+
+  it("does not create spurious bonds across a face when atoms are far", () => {
+    // Minimum-image separation is 2.5 Å (10 − 7.5), beyond the 2.04 Å threshold.
+    const positions = new Float32Array([
+      0.5,
+      5,
+      5, // frac 0.05
+      8.0,
+      5,
+      5, // frac 0.80
+    ]);
+    const elements = new Uint8Array([6, 6]);
+
+    const bonds = inferBondsVdwJS(positions, elements, 2, DEFAULT_VDW_BOND_FACTOR, box10);
+    expect(bonds.length).toBe(0);
+  });
+
+  it("detects a face-crossing bond in a tiny box (brute-force branch)", () => {
+    // 3 Å cube → floor(3/2) = 1 cell per axis (< 2), exercising the per-pair
+    // minimum-image fallback rather than the cell-list path.
+    const box3 = new Float32Array([3, 0, 0, 0, 3, 0, 0, 0, 3]);
+    const positions = new Float32Array([
+      2.7,
+      1.5,
+      1.5, // frac 0.90
+      3.3,
+      1.5,
+      1.5, // frac 1.10 (0.6 Å away across the face)
+    ]);
+    const elements = new Uint8Array([6, 6]);
+
+    const bonds = inferBondsVdwJS(positions, elements, 2, DEFAULT_VDW_BOND_FACTOR, box3);
+    expect(bondSet(bonds)).toEqual(new Set(["0-1"]));
+  });
+
+  it("is idempotent for a molecule already inside the cell", () => {
+    // A water molecule wholly inside a 20 Å box yields the same bonds with or
+    // without the periodic box — the fix must not regress the common case.
+    const angle = (104.5 / 2) * (Math.PI / 180);
+    const oh = 0.96;
+    const cx = 10;
+    const positions = new Float32Array([
+      cx,
+      10,
+      10,
+      cx + oh * Math.sin(angle),
+      10 + oh * Math.cos(angle),
+      10,
+      cx - oh * Math.sin(angle),
+      10 + oh * Math.cos(angle),
+      10,
+    ]);
+    const elements = new Uint8Array([8, 1, 1]);
+    const box20 = new Float32Array([20, 0, 0, 0, 20, 0, 0, 0, 20]);
+
+    const withBox = bondSet(
+      inferBondsVdwJS(positions, elements, 3, DEFAULT_VDW_BOND_FACTOR, box20),
+    );
+    const withoutBox = bondSet(inferBondsVdwJS(positions, elements, 3));
+
+    expect(withBox).toEqual(new Set(["0-1", "0-2"]));
+    expect(withBox).toEqual(withoutBox);
   });
 });


### PR DESCRIPTION
Molecular-crystal CIFs frequently list every atom wrapped into the [0,1)
fractional cell, which physically splits a molecule that straddles a cell
face: two bonded atoms then sit ~one lattice vector apart in Cartesian
space. Bond inference is not periodic, so those cross-boundary bonds were
dropped and the molecule rendered broken.

Core fix (all hosts): unwrap bonded molecules before inferring bonds in the
CIF parser. `bonds::unwrap_molecules` determines connectivity with the
minimum-image convention (same covalent-radius criterion as `infer_bonds`),
then flood-fills each connected component and shifts it by whole lattice
vectors so every molecule is spatially contiguous. Non-periodic inference
then finds every bond and the cylinders render at their true short length
(VESTA/Mercury-style whole molecules that may poke outside the cell). It is
a no-op for already-contiguous asymmetric units, so nacl/glycine/delta
glycine are unchanged.

Also harden the TypeScript distance-bond path (`inferBondsVdwJS`), used for
the pipeline "distance" bond source and per-frame trajectory recomputation:

- PBC cell-list assigned atoms to cells by their wrapped fractional
  coordinate but measured distances with raw positions plus a cell-derived
  shift. For inputs outside [0,1) the two disagreed by a lattice vector and
  cross-face bonds were dropped; now positions are wrapped into the home
  cell up front and used for both steps.
- The half-shell cell-list is only correct with >= 3 cells per axis; exactly
  2 cells (e.g. NaCl's 5.64 A cube) produced wrong minimum-image distances.
  Route <= 2-cell axes to the exact per-pair minimum-image fallback.

Tests: Rust unit tests for `unwrap_molecules` (split recovery, contiguous
no-op, multiple components, singular/short-input guards) and a CIF parse
regression against the new `pbc_bond_split.cif` fixture; TypeScript tests
for cross-face detection, the 2-cell fallback, and idempotence.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DMX2T3E1mTMcNfBxSPStpy