### PR TITLE
Add performance HUD showing atoms, bonds, draw calls, and FPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **Performance HUD** next to the Reset View button showing the loaded atom count, bond count, per-frame draw calls, and live render FPS. Present on every host (webapp, JupyterLab widgets, VSCode webview).
+
 ## [0.9.1] - 2026-06-28
 
 ### Fixed

--- a/src/components/MeganeViewer.tsx
+++ b/src/components/MeganeViewer.tsx
@@ -15,7 +15,8 @@ import { Timeline } from "./Timeline";
 import { Tooltip } from "./Tooltip";
 import { MeasurementPanel } from "./MeasurementPanel";
 import { MeasurementListPanel } from "./MeasurementListPanel";
-import { MoleculeRenderer } from "../renderer/MoleculeRenderer";
+import { PerfHud } from "./PerfHud";
+import { MoleculeRenderer, isMeganeTestMode } from "../renderer/MoleculeRenderer";
 import { inferBondsVdwJS, DEFAULT_VDW_BOND_FACTOR } from "../parsers/inferBondsJS";
 import type { StructureParseResult } from "../parsers/structure";
 import { processPbcBonds } from "../pipeline/executors/addBond";
@@ -391,6 +392,11 @@ export function MeganeViewer({
     useViewStateStore.getState().clearViewState();
   }, []);
 
+  const getRenderStats = useCallback(() => rendererRef.current?.getStats() ?? null, []);
+  // Freeze the live FPS digits under E2E so screenshot baselines stay
+  // deterministic; the feature is fully live in production.
+  const hudStable = isMeganeTestMode();
+
   return (
     <div
       data-testid="megane-viewer"
@@ -452,6 +458,12 @@ export function MeganeViewer({
       >
         Reset View
       </button>
+      <PerfHud
+        atomCount={snapshot?.nAtoms ?? 0}
+        bondCount={bondCount}
+        getStats={getRenderStats}
+        stable={hudStable}
+      />
       <PipelineEditor
         collapsed={pipelineCollapsed}
         onToggleCollapse={handleTogglePipeline}

--- a/src/components/PerfHud.tsx
+++ b/src/components/PerfHud.tsx
@@ -1,0 +1,76 @@
+/**
+ * Small performance readout shown next to the Reset View button.
+ *
+ * Displays the loaded atom count, bond count, per-frame draw calls, and render
+ * FPS. Atom/bond counts come from React state in the parent; FPS and draw calls
+ * are polled from the renderer on an interval (NOT per render frame — the parent
+ * deliberately avoids per-frame React renders, see MeganeViewer's snapshot
+ * subscription comment).
+ */
+
+import { useEffect, useState } from "react";
+
+interface PerfHudProps {
+  atomCount: number;
+  bondCount: number;
+  getStats: () => { fps: number; drawCalls: number } | null;
+  /**
+   * When true, render a fixed FPS placeholder instead of the live value. Used by
+   * E2E so screenshot baselines stay deterministic (FPS digits vary per run).
+   */
+  stable?: boolean;
+}
+
+const POLL_MS = 500;
+
+export function PerfHud({ atomCount, bondCount, getStats, stable = false }: PerfHudProps) {
+  const [stats, setStats] = useState<{ fps: number; drawCalls: number }>({
+    fps: 0,
+    drawCalls: 0,
+  });
+
+  useEffect(() => {
+    const poll = () => {
+      const next = getStats();
+      if (next) setStats(next);
+    };
+    poll(); // populate immediately so draws/fps don't linger at 0
+    const id = window.setInterval(poll, POLL_MS);
+    return () => window.clearInterval(id);
+  }, [getStats]);
+
+  const fpsText = stable ? "--" : String(Math.round(stats.fps));
+
+  return (
+    <div
+      data-testid="perf-hud"
+      style={{
+        position: "absolute",
+        top: 12,
+        left: 92,
+        padding: "4px 8px",
+        fontSize: 11,
+        lineHeight: 1,
+        fontVariantNumeric: "tabular-nums",
+        background: "rgba(255,255,255,0.85)",
+        border: "1px solid rgba(0,0,0,0.15)",
+        borderRadius: 4,
+        color: "#374151",
+        backdropFilter: "blur(4px)",
+        WebkitBackdropFilter: "blur(4px)",
+        zIndex: 10,
+        userSelect: "none",
+        pointerEvents: "none",
+        whiteSpace: "nowrap",
+      }}
+    >
+      <span data-testid="perf-hud-atoms">Atoms {atomCount}</span>
+      {" · "}
+      <span data-testid="perf-hud-bonds">Bonds {bondCount}</span>
+      {" · "}
+      <span data-testid="perf-hud-draws">Draws {stats.drawCalls}</span>
+      {" · "}
+      <span data-testid="perf-hud-fps">{fpsText} FPS</span>
+    </div>
+  );
+}

--- a/src/renderer/FpsCounter.ts
+++ b/src/renderer/FpsCounter.ts
@@ -1,0 +1,38 @@
+/**
+ * Minimal rolling FPS counter.
+ *
+ * Fed one timestamp per rendered frame (in ms, e.g. from `performance.now()`),
+ * it recomputes frames-per-second once every `windowMs` and holds that value
+ * until the next window closes. Pure and side-effect free so the timing math is
+ * unit-testable without a WebGL context.
+ */
+export class FpsCounter {
+  private readonly windowMs: number;
+  private lastSample: number | null = null;
+  private frames = 0;
+  private _fps = 0;
+
+  constructor(windowMs = 500) {
+    this.windowMs = windowMs;
+  }
+
+  /** Record one rendered frame at time `nowMs`. */
+  tick(nowMs: number): void {
+    if (this.lastSample === null) {
+      this.lastSample = nowMs;
+      return;
+    }
+    this.frames++;
+    const elapsed = nowMs - this.lastSample;
+    if (elapsed >= this.windowMs) {
+      this._fps = (this.frames * 1000) / elapsed;
+      this.frames = 0;
+      this.lastSample = nowMs;
+    }
+  }
+
+  /** Most recently computed FPS (0 until the first window has closed). */
+  get fps(): number {
+    return this._fps;
+  }
+}

--- a/src/renderer/MoleculeRenderer.ts
+++ b/src/renderer/MoleculeRenderer.ts
@@ -35,6 +35,7 @@ import type { MeshData } from "../pipeline/types";
 import { getRadius, BALL_STICK_ATOM_SCALE, LICORICE_RADIUS } from "../constants";
 import { pickAtPixel, projectToScreen } from "./Picking";
 import { computeMeasurement } from "./Selection";
+import { FpsCounter } from "./FpsCounter";
 import { perfMark, perfMeasure, perfPushFrame, perfRendererReady } from "../perf";
 import {
   fitCameraToView,
@@ -68,6 +69,15 @@ const _testMode = (() => {
   }
   return false;
 })();
+
+/**
+ * True when running under E2E (via `?test=1`, `__MEGANE_TEST__`, or an iframed
+ * host inheriting it from the parent). Consumers use this to keep non-
+ * deterministic UI (e.g. the live FPS readout) stable for screenshot baselines.
+ */
+export function isMeganeTestMode(): boolean {
+  return _testMode;
+}
 
 interface MeganeTestReady {
   firstFrame: boolean;
@@ -203,6 +213,7 @@ export class MoleculeRenderer {
   private pivotMarker: PivotMarker | null = null;
   private useImpostor = false;
   private animationId: number | null = null;
+  private fpsCounter = new FpsCounter();
   private snapshot: Snapshot | null = null;
   private lastExtent: ViewExtent = { maxExtent: 1, extentX: 1, extentY: 1 };
   private currentPositions: Float32Array | null = null;
@@ -1410,6 +1421,19 @@ export class MoleculeRenderer {
     return this.renderer;
   }
 
+  /**
+   * Live rendering stats for the performance HUD: current FPS (updated by the
+   * rAF loop) and the draw-call count of the most recent frame. megane draws
+   * with instanced meshes, so draw calls — not a scene mesh-object count — are
+   * the meaningful GPU-load metric.
+   */
+  getStats(): { fps: number; drawCalls: number } {
+    return {
+      fps: this.fpsCounter.fps,
+      drawCalls: this.renderer?.info.render.calls ?? 0,
+    };
+  }
+
   /** Get the label overlay canvas. */
   getLabelOverlay(): LabelOverlay | null {
     return this.labelOverlay;
@@ -1739,8 +1763,13 @@ export class MoleculeRenderer {
 
     _signalRender(this.snapshot != null);
 
+    // Update the live FPS counter (drives the performance HUD; cheap and
+    // always on, unlike the __MEGANE_PERF__-gated frame buffer below).
+    const now = performance.now();
+    this.fpsCounter.tick(now);
+
     // Performance hooks (no-op unless window.__MEGANE_PERF__ is set)
-    perfPushFrame(performance.now());
+    perfPushFrame(now);
     if (this.firstFramePending) {
       this.firstFramePending = false;
       perfMark("megane:mount:firstFrame");

--- a/tests/e2e/webapp.spec.ts
+++ b/tests/e2e/webapp.spec.ts
@@ -47,6 +47,21 @@ test.describe("webapp: caffeine_water default", () => {
     await expectViewerRegionMatch(page, PLATFORM, "default-view-viewer");
   });
 
+  test("performance HUD reports atom/bond/draw counts", async ({ page }) => {
+    const hud = page.locator('[data-testid="perf-hud"]');
+    await expect(hud).toBeVisible();
+    // Atom / bond counts come straight from the loaded snapshot.
+    await expect(page.locator('[data-testid="perf-hud-atoms"]')).toHaveText(
+      `Atoms ${ATOM_COUNT_CAFFEINE}`,
+    );
+    await expect(page.locator('[data-testid="perf-hud-bonds"]')).toContainText("Bonds");
+    // Draw calls come from the renderer once a frame has been drawn (> 0).
+    const drawsText = await page.locator('[data-testid="perf-hud-draws"]').textContent();
+    expect(Number(drawsText?.replace(/\D/g, ""))).toBeGreaterThan(0);
+    // FPS is frozen to a placeholder under test mode for deterministic baselines.
+    await expect(page.locator('[data-testid="perf-hud-fps"]')).toHaveText("-- FPS");
+  });
+
   test("frame slider seek advances renderer state", async ({ page }) => {
     const before = await getReadyState(page);
 

--- a/tests/ts/components/PerfHud.test.tsx
+++ b/tests/ts/components/PerfHud.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, act } from "@testing-library/react";
+import { PerfHud } from "@/components/PerfHud";
+
+describe("PerfHud", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("renders atom and bond counts from props immediately", () => {
+    render(<PerfHud atomCount={1234} bondCount={56} getStats={() => null} />);
+    expect(screen.getByTestId("perf-hud-atoms")).toHaveTextContent("Atoms 1234");
+    expect(screen.getByTestId("perf-hud-bonds")).toHaveTextContent("Bonds 56");
+  });
+
+  it("polls getStats immediately and shows rounded fps and draw calls", () => {
+    const getStats = vi.fn(() => ({ fps: 59.6, drawCalls: 7 }));
+    render(<PerfHud atomCount={10} bondCount={2} getStats={getStats} />);
+    // The effect polls once on mount, so values populate without waiting.
+    expect(getStats).toHaveBeenCalled();
+    expect(screen.getByTestId("perf-hud-fps")).toHaveTextContent("60 FPS");
+    expect(screen.getByTestId("perf-hud-draws")).toHaveTextContent("Draws 7");
+    // Subsequent interval ticks keep it updated.
+    const callsAfterMount = getStats.mock.calls.length;
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(getStats.mock.calls.length).toBeGreaterThan(callsAfterMount);
+  });
+
+  it("ignores null stats (renderer not ready)", () => {
+    const getStats = vi.fn(() => null);
+    render(<PerfHud atomCount={0} bondCount={0} getStats={getStats} />);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(screen.getByTestId("perf-hud-fps")).toHaveTextContent("0 FPS");
+  });
+
+  it("renders a fixed fps placeholder when stable", () => {
+    const getStats = vi.fn(() => ({ fps: 42, drawCalls: 3 }));
+    render(<PerfHud atomCount={5} bondCount={1} getStats={getStats} stable />);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    // FPS frozen, but draw calls (deterministic) still update.
+    expect(screen.getByTestId("perf-hud-fps")).toHaveTextContent("-- FPS");
+    expect(screen.getByTestId("perf-hud-draws")).toHaveTextContent("Draws 3");
+  });
+
+  it("stops polling after unmount", () => {
+    const getStats = vi.fn(() => ({ fps: 30, drawCalls: 1 }));
+    const { unmount } = render(<PerfHud atomCount={1} bondCount={1} getStats={getStats} />);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    const callsBefore = getStats.mock.calls.length;
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(getStats.mock.calls.length).toBe(callsBefore);
+  });
+});

--- a/tests/ts/renderer/FpsCounter.test.ts
+++ b/tests/ts/renderer/FpsCounter.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { FpsCounter } from "@/renderer/FpsCounter";
+
+describe("FpsCounter", () => {
+  it("reports 0 before the first window closes", () => {
+    const c = new FpsCounter(500);
+    expect(c.fps).toBe(0);
+    // First tick only seeds the baseline timestamp.
+    c.tick(0);
+    expect(c.fps).toBe(0);
+    // A few frames within the window — still no computed value yet.
+    c.tick(100);
+    c.tick(200);
+    expect(c.fps).toBe(0);
+  });
+
+  it("computes fps once a full window elapses", () => {
+    const c = new FpsCounter(500);
+    c.tick(0); // seed
+    // 30 frames spread evenly to exactly 500ms → 60 fps.
+    for (let i = 1; i <= 30; i++) {
+      c.tick((500 / 30) * i);
+    }
+    expect(Math.round(c.fps)).toBe(60);
+  });
+
+  it("recomputes on each subsequent window and resets the frame count", () => {
+    const c = new FpsCounter(1000);
+    c.tick(0); // seed
+    // Window 1: 10 frames over 1000ms → 10 fps.
+    for (let i = 1; i <= 10; i++) c.tick(100 * i);
+    expect(Math.round(c.fps)).toBe(10);
+    // Window 2: 30 frames over the next 1000ms → 30 fps (count reset, no carry-over).
+    for (let i = 1; i <= 30; i++) c.tick(1000 + (1000 / 30) * i);
+    expect(Math.round(c.fps)).toBe(30);
+  });
+
+  it("holds the last value until the next window closes", () => {
+    const c = new FpsCounter(500);
+    c.tick(0);
+    for (let i = 1; i <= 30; i++) c.tick((500 / 30) * i);
+    const first = c.fps;
+    // A couple more frames that do not yet complete the next window.
+    c.tick(510);
+    c.tick(520);
+    expect(c.fps).toBe(first);
+  });
+
+  it("defaults to a 500ms window", () => {
+    const c = new FpsCounter();
+    c.tick(0);
+    for (let i = 1; i <= 30; i++) c.tick((500 / 30) * i);
+    expect(Math.round(c.fps)).toBe(60);
+  });
+});

--- a/tests/ts/renderer/MoleculeRendererStats.test.ts
+++ b/tests/ts/renderer/MoleculeRendererStats.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { MoleculeRenderer, isMeganeTestMode } from "@/renderer/MoleculeRenderer";
+
+/**
+ * getStats() feeds the performance HUD. mount() needs a real WebGL context that
+ * jsdom does not provide, so — like the camera-state tests — we instantiate the
+ * class without mounting and inject minimal stand-ins for the two fields
+ * getStats() reads.
+ */
+describe("MoleculeRenderer.getStats", () => {
+  it("returns zeros before mount (no renderer, fresh counter)", () => {
+    const r = new MoleculeRenderer();
+    expect(r.getStats()).toEqual({ fps: 0, drawCalls: 0 });
+  });
+
+  it("reads draw calls from renderer.info and fps from the counter", () => {
+    const r = new MoleculeRenderer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internals = r as any;
+    internals.renderer = { info: { render: { calls: 12 } } };
+    internals.fpsCounter = { fps: 55 };
+    expect(r.getStats()).toEqual({ fps: 55, drawCalls: 12 });
+  });
+});
+
+describe("isMeganeTestMode", () => {
+  it("returns a boolean", () => {
+    expect(typeof isMeganeTestMode()).toBe("boolean");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a performance HUD component displayed next to the Reset View button that shows:
- Loaded atom count
- Loaded bond count  
- Per-frame draw calls (from the renderer)
- Live render FPS (updated via a new `FpsCounter` class)

The HUD is present on all hosts (webapp, JupyterLab widgets, VSCode webview). Under E2E test mode, the FPS digits are frozen to a placeholder (`--`) to keep screenshot baselines deterministic, while atom/bond/draw counts remain live.

### Implementation Details

- **`FpsCounter`** (`src/renderer/FpsCounter.ts`): A pure, side-effect-free rolling FPS counter that recomputes once per configurable window (default 500ms) and holds that value until the next window closes. Fully unit-testable without a WebGL context.
- **`PerfHud`** (`src/components/PerfHud.tsx`): React component that displays the metrics. Polls renderer stats on a 500ms interval (not per-frame, to avoid forcing React renders in the parent). Accepts a `stable` prop to freeze FPS for E2E.
- **`MoleculeRenderer.getStats()`**: New method that returns current FPS (from the counter) and draw-call count (from `renderer.info.render.calls`).
- **`isMeganeTestMode()`**: Exported helper to detect E2E mode (`?test=1`, `__MEGANE_TEST__`, or inherited from parent iframe).
- **`MeganeViewer`**: Integrates the HUD, passing atom/bond counts from state and a callback to fetch live stats from the renderer.

## Test Plan

- [x] `npm test` passes — added comprehensive unit tests for `FpsCounter`, `PerfHud` component, and `MoleculeRenderer.getStats()`
- [x] E2E test added (`tests/e2e/webapp.spec.ts`) verifying HUD visibility, atom/bond/draw counts, and FPS placeholder under test mode
- [x] Manually verified in the browser (HUD renders, updates live, freezes FPS under `?test=1`)

All new code is covered by unit and E2E tests. No changes to existing functionality.

https://claude.ai/code/session_01Q6p81GLzkEeHMpJaDrQMZ9