### PR TITLE
feat(pipeline): add Selection Inspector for intuitive atom selection

### DIFF
--- a/docs/docs/guide/pipeline/inspector.md
+++ b/docs/docs/guide/pipeline/inspector.md
@@ -1,0 +1,53 @@
+# Selection Inspector
+
+The **Selection Inspector** is a lightweight third tab in the pipeline panel
+(alongside **Editor** and **Chat**) for the most common task in molecular
+visualization: *select a subset of atoms and change how it looks*. It is
+inspired by OVITO's Expression Select, but you rarely have to type an
+expression — you build selections by clicking chips for the elements, residues,
+and chains that are actually present in your structure, or by picking atoms
+directly in the 3D view.
+
+Everything the Inspector does is compiled straight into ordinary pipeline nodes,
+so a selection you make here appears as a `filter` → `color` / `representation`
+/ `modify` chain in the **Editor** tab. The Inspector is just a friendlier front
+end to the same pipeline — nothing is hidden or parallel.
+
+## Layers
+
+Each **layer** is one "select these atoms, style them like this" rule. Add as
+many as you need — e.g. a layer that colors the protein backbone, another that
+draws the ligand as licorice, another that hides the solvent. Layers are drawn
+on top of the base structure, so atoms no layer selects keep their default
+appearance.
+
+## Building a selection
+
+- **Chips** — click the elements, residues, or chains present in the loaded
+  structure. Selected categories are AND-ed together (e.g. carbons *and* chain A).
+- **Within (Å)** — expand the current selection to every atom within a distance
+  of it (`within R of (…)`), handy for "everything around the active site".
+- **Expression** — the raw selection expression is always shown and editable for
+  full control. Editing it directly overrides the chips.
+- **From the 3D view** — turn on **Box select** and drag a rectangle in the
+  viewer to select atoms, or click an atom and choose *same element / same
+  residue / same chain / same molecule / just this*. The current selection is
+  highlighted live in green.
+
+The selection language supports the fields `element`, `index`, `x`/`y`/`z`,
+`resname`, `resid`, `chain`, `mass`, and `molecule_id`, combined with
+`and` / `or` / `not`, parentheses, and `within R of (…)`.
+
+## Appearance
+
+For the active layer you can set the **color** (uniform or by
+element/residue/chain/B-factor), the **representation** (ball, licorice,
+cartoon, surface, line…), the atom **size** and **opacity**, and toggle
+**visibility**. Changes apply immediately and are reflected in the Editor tab.
+
+## Availability
+
+The Inspector is available everywhere the visual pipeline editor is — the
+standalone web app, the JupyterLab extension, and the VS Code extension. It is
+not shown in the in-cell Jupyter widget, which does not mount the pipeline
+editor.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -38,6 +38,7 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       items: [
         "guide/pipeline/index",
+        "guide/pipeline/inspector",
         "guide/pipeline/python",
         "guide/pipeline/typescript",
         "guide/pipeline/json",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -171,6 +171,11 @@ export default defineConfig({
       use: { baseURL: `http://127.0.0.1:${PORT_WEBAPP}` },
     },
     {
+      name: "inspector",
+      testMatch: /inspector\.spec\.ts$/,
+      use: { baseURL: `http://127.0.0.1:${PORT_WEBAPP}` },
+    },
+    {
       name: "pipeline-file",
       testMatch: /pipeline-file\.spec\.ts$/,
       use: { baseURL: `http://127.0.0.1:${PORT_WEBAPP}` },

--- a/src/ai/prompt.ts
+++ b/src/ai/prompt.ts
@@ -114,19 +114,28 @@ Query      := OrExpr
 OrExpr     := AndExpr ("or" AndExpr)*
 AndExpr    := NotExpr ("and" NotExpr)*
 NotExpr    := "not" NotExpr | Atom
-Atom       := Comparison | "(" OrExpr ")" | "all" | "none"
+Atom       := Comparison | Within | "(" OrExpr ")" | "all" | "none"
+Within     := "within" Number "of" Atom
 Comparison := Field Op Value
-Field      := "element" | "index" | "x" | "y" | "z" | "resname" | "mass" | "molecule_id"
+Field      := "element" | "index" | "x" | "y" | "z" | "resname" | "resid"
+            | "chain" | "mass" | "molecule_id"
 Op         := "==" | "!=" | ">" | "<" | ">=" | "<="
 Value      := QuotedString | Number
 \`\`\`
-- Fields are ONLY: \`element\`, \`index\`, \`x\`, \`y\`, \`z\`, \`resname\`, \`mass\`, \`molecule_id\`. No other field exists.
+- Fields are ONLY: \`element\`, \`index\`, \`x\`, \`y\`, \`z\`, \`resname\`, \`resid\`, \`chain\`, \`mass\`, \`molecule_id\`. No other field exists.
 - String values MUST be double-quoted: \`element == "C"\` (NOT \`element == C\`).
-  This applies to \`element\` and \`resname\`.
+  This applies to \`element\`, \`resname\`, and \`chain\`.
 - \`element\` compares the element symbol ("C", "Fe", …). \`index\` is the 0-based
   atom index. \`x\`/\`y\`/\`z\` are Cartesian coordinates (Å). \`mass\` is atomic mass.
   \`molecule_id\` is the 0-based connected-component (molecule) ID derived from
   bond connectivity — the molecule containing atom 0 is \`molecule_id == 0\`.
+- \`resname\` is the residue name (e.g. "ALA", "HOH"). \`resid\` is the residue
+  sequence number (e.g. \`resid == 42\`). \`chain\` is the single-character chain ID
+  (e.g. \`chain == "A"\`). \`resid\`/\`chain\` need the structure to carry that info
+  (proteins/PDB); atoms without it never match.
+- \`within R of (SEL)\` selects atoms within R ångström of ANY atom matched by the
+  inner expression SEL (the matched atoms are included). Use it for distance /
+  "around" selections, e.g. everything near a ligand or an active site.
 - An empty query or \`all\` selects every atom; \`none\` selects nothing.
 - Combine with \`and\`, \`or\`, \`not\`, and parentheses.
 
@@ -135,10 +144,14 @@ Valid examples:
 - \`element != "H"\` — all non-hydrogen (heavy) atoms
 - \`index >= 10 and index <= 19\` — atoms 10–19
 - \`resname == "HOH"\` — residues named HOH
+- \`resid == 42\` — every atom of residue 42
+- \`chain == "A"\` — every atom on chain A
 - \`element == "O" or element == "N"\` — oxygens or nitrogens
 - \`(x > 0 and x < 10) and element == "C"\` — carbons in an x-slab
 - \`mass > 32\` — atoms heavier than sulfur
 - \`not molecule_id == 0\` — every molecule except the first one
+- \`within 5 of (resname == "HEM")\` — everything within 5 Å of a HEM residue
+- \`element != "H" and within 4 of (chain == "B")\` — heavy atoms near chain B
 
 ### Bond query grammar
 \`\`\`
@@ -158,15 +171,17 @@ Field := "bond_index" | "atom_index" | "element" | "molecule_id"
 | --- | --- |
 | \`name CA\`, \`protein\`, \`backbone\`, \`sidechain\` | not supported (no per-atom-name / structural selection) |
 | \`water\`, \`resname HOH WAT\` | \`resname == "HOH"\` (use an actual resname from the loaded structure) |
-| \`chain A\` | not supported (chain selection is unavailable) |
-| \`within 5 of ...\`, distance-based | not supported |
-| \`resid 1-20\`, \`index 1 to 10\` | \`index >= 1 and index <= 10\` |
+| \`chain A\` | \`chain == "A"\` |
+| \`within 5 of resname LIG\` | \`within 5 of (resname == "LIG")\` (parenthesize the inner selection) |
+| \`resid 1-20\` | \`resid >= 1 and resid <= 20\` |
+| \`index 1 to 10\` | \`index >= 1 and index <= 10\` |
 | \`element C\` (unquoted) | \`element == "C"\` |
 | \`noh\`, \`heavy\`, "non-hydrogen" | \`element != "H"\` |
 
-If a request needs an unsupported selection (atom names, chains, distance,
-secondary structure), express the closest supported approximation with
-\`element\`/\`resname\`/\`index\`, or omit the filter rather than inventing syntax.
+If a request needs an unsupported selection (atom names, secondary structure),
+express the closest supported approximation with
+\`element\`/\`resname\`/\`resid\`/\`chain\`/\`index\`, or omit the filter rather than
+inventing syntax.
 
 ## Common Atomic Numbers
 H=1, C=6, N=7, O=8, F=9, Na=11, Mg=12, Al=13, Si=14, P=15, S=16, Cl=17, K=19, Ca=20, Ti=22, Fe=26, Zn=30, Sr=38

--- a/src/ai/structureSummary.ts
+++ b/src/ai/structureSummary.ts
@@ -3,6 +3,10 @@
  * has loaded, for injection into the LLM system prompt. Knowing the real
  * element symbols and residue names present lets the model generate accurate
  * `filter` queries instead of guessing (the #1 cause of bad selections).
+ *
+ * The same underlying facts (`getStructureFacts`) drive the Selection Inspector
+ * UI, which turns them into clickable element/residue/chain chips so the user
+ * never has to type a raw expression against values they can't see.
  */
 
 import type { Snapshot } from "../types";
@@ -11,6 +15,79 @@ import { parseResname } from "../pipeline/selection";
 
 /** Cap the resname list so a huge structure doesn't blow up the prompt. */
 const MAX_RESNAMES = 50;
+
+/** One element symbol and how many atoms carry it. */
+export interface ElementFact {
+  symbol: string;
+  count: number;
+}
+
+/**
+ * Structured facts about a loaded structure — the values a `filter` query (and
+ * the Inspector chip UI) can reference. Element counts are sorted descending;
+ * resnames and chains are sorted ascending and de-duplicated.
+ */
+export interface StructureFacts {
+  nAtoms: number;
+  /** Element symbols present with per-element counts, most common first. */
+  elements: ElementFact[];
+  /** Unique residue names present (empty when no labels are loaded). */
+  resnames: string[];
+  /** Unique chain IDs present (empty when the format carries no chain info). */
+  chains: string[];
+  hasCell: boolean;
+  nBonds: number;
+}
+
+/**
+ * Extract structured facts from a loaded structure, or `null` when nothing is
+ * loaded. Shared by the LLM prompt summary and the Inspector's selection chips.
+ */
+export function getStructureFacts(
+  snapshot: Snapshot | null,
+  atomLabels: string[] | null,
+): StructureFacts | null {
+  if (!snapshot || snapshot.nAtoms === 0) return null;
+
+  // Elements present, with counts, sorted by descending count.
+  const elementCounts = new Map<string, number>();
+  for (let i = 0; i < snapshot.nAtoms; i++) {
+    const sym = getElementSymbol(snapshot.elements[i]);
+    elementCounts.set(sym, (elementCounts.get(sym) ?? 0) + 1);
+  }
+  const elements: ElementFact[] = [...elementCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([symbol, count]) => ({ symbol, count }));
+
+  // Residue names present (unique). Only available when atom labels are loaded.
+  const resnameSet = new Set<string>();
+  if (atomLabels && atomLabels.length > 0) {
+    const limit = Math.min(atomLabels.length, snapshot.nAtoms);
+    for (let i = 0; i < limit; i++) {
+      const label = atomLabels[i];
+      if (label) resnameSet.add(parseResname(label));
+    }
+  }
+  const resnames = [...resnameSet].sort();
+
+  // Chain IDs present (ASCII bytes → characters; 0 = no chain).
+  const chainSet = new Set<string>();
+  if (snapshot.atomChainIds && snapshot.atomChainIds.length > 0) {
+    for (const code of snapshot.atomChainIds) {
+      if (code !== 0) chainSet.add(String.fromCharCode(code));
+    }
+  }
+  const chains = [...chainSet].sort();
+
+  return {
+    nAtoms: snapshot.nAtoms,
+    elements,
+    resnames,
+    chains,
+    hasCell: snapshot.box != null,
+    nBonds: snapshot.nBonds,
+  };
+}
 
 /**
  * Summarize a loaded structure as a short markdown block, or `null` when no
@@ -25,52 +102,30 @@ export function summarizeStructure(
   snapshot: Snapshot | null,
   atomLabels: string[] | null,
 ): string | null {
-  if (!snapshot || snapshot.nAtoms === 0) return null;
+  const facts = getStructureFacts(snapshot, atomLabels);
+  if (!facts) return null;
 
   const lines: string[] = [];
-  lines.push(`- Atoms: ${snapshot.nAtoms} (index 0..${snapshot.nAtoms - 1})`);
+  lines.push(`- Atoms: ${facts.nAtoms} (index 0..${facts.nAtoms - 1})`);
 
-  // Elements present, with counts, sorted by descending count.
-  const elementCounts = new Map<string, number>();
-  for (let i = 0; i < snapshot.nAtoms; i++) {
-    const sym = getElementSymbol(snapshot.elements[i]);
-    elementCounts.set(sym, (elementCounts.get(sym) ?? 0) + 1);
-  }
-  const elementList = [...elementCounts.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .map(([sym, n]) => `${sym} (${n})`)
-    .join(", ");
+  const elementList = facts.elements.map((e) => `${e.symbol} (${e.count})`).join(", ");
   lines.push(`- Elements present: ${elementList}`);
 
-  // Residue names present (unique). Only available when atom labels are loaded.
-  if (atomLabels && atomLabels.length > 0) {
-    const resnames = new Set<string>();
-    const limit = Math.min(atomLabels.length, snapshot.nAtoms);
-    for (let i = 0; i < limit; i++) {
-      const label = atomLabels[i];
-      if (label) resnames.add(parseResname(label));
-    }
-    if (resnames.size > 0) {
-      const all = [...resnames].sort();
-      const shown = all.slice(0, MAX_RESNAMES);
-      const suffix = all.length > MAX_RESNAMES ? `, … (${all.length - MAX_RESNAMES} more)` : "";
-      lines.push(`- Residue names present: ${shown.join(", ")}${suffix}`);
-    }
+  if (facts.resnames.length > 0) {
+    const shown = facts.resnames.slice(0, MAX_RESNAMES);
+    const suffix =
+      facts.resnames.length > MAX_RESNAMES
+        ? `, … (${facts.resnames.length - MAX_RESNAMES} more)`
+        : "";
+    lines.push(`- Residue names present: ${shown.join(", ")}${suffix}`);
   }
 
-  // Chain IDs present (ASCII bytes → characters).
-  if (snapshot.atomChainIds && snapshot.atomChainIds.length > 0) {
-    const chains = new Set<string>();
-    for (const code of snapshot.atomChainIds) {
-      if (code !== 0) chains.add(String.fromCharCode(code));
-    }
-    if (chains.size > 0) {
-      lines.push(`- Chains present: ${[...chains].sort().join(", ")}`);
-    }
+  if (facts.chains.length > 0) {
+    lines.push(`- Chains present: ${facts.chains.join(", ")}`);
   }
 
-  lines.push(`- Unit cell: ${snapshot.box ? "yes" : "no"}`);
-  lines.push(`- Bonds: ${snapshot.nBonds}`);
+  lines.push(`- Unit cell: ${facts.hasCell ? "yes" : "no"}`);
+  lines.push(`- Bonds: ${facts.nBonds}`);
 
   return lines.join("\n");
 }

--- a/src/components/MeganeViewer.tsx
+++ b/src/components/MeganeViewer.tsx
@@ -21,6 +21,10 @@ import { inferBondsVdwJS, DEFAULT_VDW_BOND_FACTOR } from "../parsers/inferBondsJ
 import type { StructureParseResult } from "../parsers/structure";
 import { processPbcBonds } from "../pipeline/executors/addBond";
 import { usePipelineStore } from "../pipeline/store";
+import { usePipelineUIStore } from "../stores/usePipelineUIStore";
+import { useInspectorInteractionStore } from "../stores/useInspectorInteractionStore";
+import { getElementSymbol } from "../constants";
+import { parseResname, computeMoleculeIds } from "../pipeline/selection";
 import { usePlaybackStore } from "../stores/usePlaybackStore";
 import { useViewStateStore } from "../stores/useViewStateStore";
 import { applyViewportState, applyVectorsForFrame } from "../pipeline/apply";
@@ -125,6 +129,30 @@ export function MeganeViewer({
   // Shared atom selection & measurement
   const { selection, measurement, handleAtomRightClick, handleClearSelection, handleFrameUpdated } =
     useAtomSelection(rendererRef, onMeasurementChange, onSelectionChange);
+
+  // Selection Inspector ⇄ 3D view bridge.
+  const inspectorActive = usePipelineUIStore((s) => s.mode === "inspector");
+  const previewIndices = useInspectorInteractionStore((s) => s.previewIndices);
+  const boxSelectActive = useInspectorInteractionStore((s) => s.boxSelectActive);
+  const publishBoxResult = useInspectorInteractionStore((s) => s.publishBoxResult);
+  const publishPickedAtom = useInspectorInteractionStore((s) => s.publishPickedAtom);
+
+  const handleInspectorPick = useCallback(
+    (atomIndex: number) => {
+      const { snapshot: snap, atomLabels } = usePipelineStore.getState();
+      if (!snap) return;
+      const chainCode = snap.atomChainIds?.[atomIndex] ?? 0;
+      const molIds = snap.bonds.length > 0 ? computeMoleculeIds(snap.bonds, snap.nAtoms) : null;
+      publishPickedAtom({
+        index: atomIndex,
+        element: getElementSymbol(snap.elements[atomIndex]),
+        resname: atomLabels?.[atomIndex] ? parseResname(atomLabels[atomIndex]) : null,
+        chain: chainCode === 0 ? null : String.fromCharCode(chainCode),
+        moleculeId: molIds ? molIds[atomIndex] : null,
+      });
+    },
+    [publishPickedAtom],
+  );
 
   useEffect(() => {
     pipelineCollapsedRef.current = pipelineCollapsed;
@@ -420,6 +448,11 @@ export function MeganeViewer({
         onHover={setHoverInfo}
         onAtomRightClick={handleAtomRightClick}
         onFrameUpdated={handleFrameUpdated}
+        previewIndices={previewIndices}
+        boxSelectActive={boxSelectActive}
+        onBoxSelect={publishBoxResult}
+        onInspectorPick={handleInspectorPick}
+        inspectorActive={inspectorActive}
       />
       <div
         ref={tourAnchorRef}

--- a/src/components/PipelineEditor.tsx
+++ b/src/components/PipelineEditor.tsx
@@ -52,6 +52,7 @@ import { StreamingNode } from "./nodes/StreamingNode";
 import { LoadVolumetricNode } from "./nodes/LoadVolumetricNode";
 import { IsosurfaceNode } from "./nodes/IsosurfaceNode";
 import { PipelineChatBox } from "./PipelineChatBox";
+import { PipelineInspector } from "./PipelineInspector";
 import { RenderModal } from "./RenderModal";
 import { ShareDialog } from "./ShareDialog";
 import { startTour, startPipelineTutorial } from "../tour/MeganeTour";
@@ -853,6 +854,7 @@ function PipelineEditorInner({
 
   const TAB_OPTIONS: { value: PipelinePanelMode; label: string }[] = [
     { value: "editor", label: "Editor" },
+    { value: "inspector", label: "Inspector" },
     { value: "chat", label: "Chat" },
   ];
 
@@ -1061,6 +1063,22 @@ function PipelineEditorInner({
               />
             </ReactFlow>
           </div>
+        </div>
+        <div
+          role="tabpanel"
+          id="pipeline-tabpanel-inspector"
+          aria-labelledby="pipeline-tab-inspector"
+          aria-hidden={mode !== "inspector"}
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            flexDirection: "column",
+            background: "var(--megane-surface-solid)",
+            visibility: mode === "inspector" ? "visible" : "hidden",
+          }}
+        >
+          <PipelineInspector />
         </div>
         <div
           role="tabpanel"

--- a/src/components/PipelineInspector.tsx
+++ b/src/components/PipelineInspector.tsx
@@ -1,0 +1,653 @@
+/**
+ * Selection Inspector — a lightweight third editing surface (alongside the
+ * visual pipeline Editor and the AI Chat) for "select a subset, change how it
+ * looks", inspired by OVITO's Expression Select.
+ *
+ * The user builds selections from structure-aware chips (the actual elements /
+ * residues / chains present) or a raw expression, tunes appearance (color,
+ * representation, size, opacity, visibility), and the panel compiles each
+ * "layer" straight into ordinary pipeline nodes via `setInspectorLayers`. Those
+ * nodes appear verbatim in the Editor tab — editing here *is* editing the
+ * pipeline (see `pipeline/inspectorSync.ts`).
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { usePipelineStore } from "../pipeline/store";
+import { usePipelineUIStore } from "../stores/usePipelineUIStore";
+import { getStructureFacts } from "../ai/structureSummary";
+import { evaluateSelection, validateQuery } from "../pipeline/selection";
+import {
+  buildQueryFromChips,
+  quickSelectExpression,
+  indicesToExpression,
+  type QuickSelectKind,
+} from "../pipeline/inspectorQuery";
+import { useInspectorInteractionStore } from "../stores/useInspectorInteractionStore";
+import {
+  defaultInspectorAppearance,
+  layersFromGraph,
+  type InspectorLayer,
+  type InspectorAppearance,
+} from "../pipeline/inspectorSync";
+import type { ColorMode, RepresentationMode } from "../pipeline/types";
+
+const COLOR_MODE_LABELS: Record<ColorMode, string> = {
+  uniform: "Uniform",
+  byElement: "Element",
+  byResidue: "Residue",
+  byChain: "Chain",
+  byBFactor: "B-Factor",
+  byProperty: "Property",
+};
+
+const REP_LABELS: Record<RepresentationMode, string> = {
+  atoms: "Ball",
+  licorice: "Licorice",
+  cartoon: "Cartoon",
+  both: "Ball + Stick",
+  surface: "Surface",
+  line: "Line",
+};
+
+const panelStyle: React.CSSProperties = {
+  flex: 1,
+  overflowY: "auto",
+  padding: 12,
+  display: "flex",
+  flexDirection: "column",
+  gap: 12,
+  fontSize: 13,
+  color: "var(--megane-text, #1e293b)",
+};
+
+const sectionStyle: React.CSSProperties = {
+  border: "1px solid var(--megane-border-solid, #e2e8f0)",
+  borderRadius: 8,
+  padding: 10,
+  display: "flex",
+  flexDirection: "column",
+  gap: 8,
+  background: "var(--megane-surface-solid, #fff)",
+};
+
+const sectionTitleStyle: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  letterSpacing: 0.4,
+  textTransform: "uppercase",
+  color: "#64748b",
+};
+
+const chipRowStyle: React.CSSProperties = { display: "flex", flexWrap: "wrap", gap: 6 };
+
+const selectStyle: React.CSSProperties = {
+  fontSize: 13,
+  color: "#334155",
+  background: "#f1f5f9",
+  border: "1px solid #cbd5e1",
+  borderRadius: 4,
+  padding: "3px 6px",
+};
+
+function chipStyle(active: boolean): React.CSSProperties {
+  return {
+    fontSize: 12,
+    padding: "3px 9px",
+    borderRadius: 999,
+    cursor: "pointer",
+    border: active ? "1px solid #2563eb" : "1px solid #cbd5e1",
+    background: active ? "#2563eb" : "#f1f5f9",
+    color: active ? "#fff" : "#334155",
+    userSelect: "none",
+  };
+}
+
+function toggle<T>(set: Set<T>, value: T): Set<T> {
+  const next = new Set(set);
+  if (next.has(value)) next.delete(value);
+  else next.add(value);
+  return next;
+}
+
+function newLayer(existing: InspectorLayer[]): InspectorLayer {
+  let max = 0;
+  for (const l of existing) {
+    const m = l.id.match(/(\d+)$/);
+    if (m) max = Math.max(max, parseInt(m[1], 10));
+  }
+  const n = max + 1;
+  return {
+    id: `layer-${n}`,
+    name: `Layer ${n}`,
+    query: "",
+    appearance: defaultInspectorAppearance(),
+  };
+}
+
+export function PipelineInspector() {
+  // The rendered snapshot lives on the primary particle stream (as in
+  // MeganeViewer); fall back to the legacy top-level `snapshot` for hosts that
+  // set it directly (Jupyter widget / tests).
+  const snapshot = usePipelineStore((s) => s.viewportState.particles[0]?.source ?? s.snapshot);
+  const atomLabels = usePipelineStore((s) => s.atomLabels);
+  const setInspectorLayers = usePipelineStore((s) => s.setInspectorLayers);
+  const setMode = usePipelineUIStore((s) => s.setMode);
+  const isActiveMode = usePipelineUIStore((s) => s.mode === "inspector");
+
+  const setPreviewIndices = useInspectorInteractionStore((s) => s.setPreviewIndices);
+  const boxSelectActive = useInspectorInteractionStore((s) => s.boxSelectActive);
+  const setBoxSelectActive = useInspectorInteractionStore((s) => s.setBoxSelectActive);
+  const boxResult = useInspectorInteractionStore((s) => s.boxResult);
+  const pickedAtom = useInspectorInteractionStore((s) => s.pickedAtom);
+
+  const facts = useMemo(() => getStructureFacts(snapshot, atomLabels), [snapshot, atomLabels]);
+
+  const [layers, setLayersState] = useState<InspectorLayer[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  // Per-active-layer chip composer state. Reset whenever the active layer
+  // changes (we don't parse arbitrary raw expressions back into chips).
+  const [chipEls, setChipEls] = useState<Set<string>>(new Set());
+  const [chipRes, setChipRes] = useState<Set<string>>(new Set());
+  const [chipChains, setChipChains] = useState<Set<string>>(new Set());
+  const [withinR, setWithinR] = useState<string>("");
+  const [customQuery, setCustomQuery] = useState(false);
+
+  // Hydrate from any Inspector nodes already in the graph, once on mount.
+  const hydrated = useRef(false);
+  useEffect(() => {
+    if (hydrated.current) return;
+    hydrated.current = true;
+    const existing = layersFromGraph(usePipelineStore.getState().nodes);
+    if (existing.length > 0) {
+      setLayersState(existing);
+      setActiveId(existing[0].id);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Reset the chip composer when switching layers.
+    setChipEls(new Set());
+    setChipRes(new Set());
+    setChipChains(new Set());
+    setWithinR("");
+    setCustomQuery(false);
+  }, [activeId]);
+
+  const active = layers.find((l) => l.id === activeId) ?? null;
+
+  function commit(next: InspectorLayer[]) {
+    setLayersState(next);
+    setInspectorLayers(next);
+  }
+
+  function updateActive(mutate: (l: InspectorLayer) => InspectorLayer) {
+    if (!active) return;
+    commit(layers.map((l) => (l.id === active.id ? mutate(l) : l)));
+  }
+
+  function updateAppearance(patch: Partial<InspectorAppearance>) {
+    updateActive((l) => ({ ...l, appearance: { ...l.appearance, ...patch } }));
+  }
+
+  function regenerateFromChips(
+    els: Set<string>,
+    res: Set<string>,
+    chains: Set<string>,
+    radius: string,
+  ) {
+    const r = radius.trim() === "" ? null : Number(radius);
+    const query = buildQueryFromChips({
+      elements: [...els],
+      resnames: [...res],
+      chains: [...chains],
+      withinRadius: r,
+    });
+    updateActive((l) => ({ ...l, query }));
+  }
+
+  function handleAddLayer() {
+    const layer = newLayer(layers);
+    const next = [...layers, layer];
+    commit(next);
+    setActiveId(layer.id);
+  }
+
+  function handleDeleteLayer(id: string) {
+    const next = layers.filter((l) => l.id !== id);
+    commit(next);
+    if (activeId === id) setActiveId(next.length > 0 ? next[next.length - 1].id : null);
+  }
+
+  const queryValidation = active ? validateQuery(active.query) : { valid: true };
+  const activeQuery = active?.query ?? "";
+  const selectedCount = useMemo(() => {
+    if (!snapshot || !active || !queryValidation.valid) return null;
+    try {
+      const sel = evaluateSelection(active.query, snapshot, atomLabels);
+      return sel === null ? snapshot.nAtoms : sel.size;
+    } catch {
+      return null;
+    }
+  }, [snapshot, atomLabels, active, queryValidation.valid]);
+
+  function setActiveQuery(query: string) {
+    setCustomQuery(true);
+    updateActive((l) => ({ ...l, query }));
+  }
+
+  // Publish the active selection to the 3D view as a live green highlight —
+  // only while the Inspector tab is showing.
+  useEffect(() => {
+    if (!isActiveMode || !snapshot || !active || !queryValidation.valid) {
+      setPreviewIndices(null);
+      return;
+    }
+    try {
+      const sel = evaluateSelection(activeQuery, snapshot, atomLabels);
+      // A null selection means "all atoms" — don't flood the view with green.
+      setPreviewIndices(sel === null ? null : [...sel]);
+    } catch {
+      setPreviewIndices(null);
+    }
+    return () => setPreviewIndices(null);
+  }, [isActiveMode, snapshot, atomLabels, activeQuery, active?.id, queryValidation.valid]);
+
+  // Consume a completed 3D box selection into the active layer's expression.
+  const lastBoxToken = useRef(0);
+  useEffect(() => {
+    if (!boxResult || boxResult.token === lastBoxToken.current) return;
+    lastBoxToken.current = boxResult.token;
+    if (!isActiveMode || !active) return;
+    setActiveQuery(indicesToExpression(boxResult.indices));
+    setBoxSelectActive(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [boxResult]);
+
+  function applyQuickSelect(kind: QuickSelectKind) {
+    if (!pickedAtom) return;
+    const expr = quickSelectExpression(kind, pickedAtom);
+    if (expr) setActiveQuery(expr);
+  }
+
+  if (!facts) {
+    return (
+      <div style={panelStyle} data-testid="pipeline-inspector">
+        <div style={{ color: "#64748b", fontSize: 13 }}>
+          Load a structure to start selecting atoms.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={panelStyle} data-testid="pipeline-inspector">
+      {/* Layer list */}
+      <div style={sectionStyle}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <span style={sectionTitleStyle}>Layers</span>
+          <button
+            data-testid="inspector-add-layer"
+            onClick={handleAddLayer}
+            style={{ ...selectStyle, cursor: "pointer" }}
+          >
+            + Add selection
+          </button>
+        </div>
+        {layers.length === 0 ? (
+          <div style={{ color: "#94a3b8", fontSize: 12 }}>
+            No selections yet — add one to color or restyle a subset of atoms.
+          </div>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            {layers.map((l) => (
+              <div
+                key={l.id}
+                data-testid={`inspector-layer-${l.id}`}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  padding: "4px 6px",
+                  borderRadius: 6,
+                  cursor: "pointer",
+                  background: l.id === activeId ? "#e0e7ff" : "transparent",
+                }}
+                onClick={() => setActiveId(l.id)}
+              >
+                <span
+                  style={{
+                    width: 12,
+                    height: 12,
+                    borderRadius: 3,
+                    background: l.appearance.colorEnabled ? l.appearance.uniformColor : "#cbd5e1",
+                    flexShrink: 0,
+                  }}
+                />
+                <span style={{ flex: 1, fontSize: 12 }}>{l.name}</span>
+                <code
+                  style={{
+                    fontSize: 10,
+                    color: "#64748b",
+                    maxWidth: 120,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {l.query || "all"}
+                </code>
+                <button
+                  data-testid={`inspector-delete-${l.id}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDeleteLayer(l.id);
+                  }}
+                  style={{
+                    border: "none",
+                    background: "none",
+                    cursor: "pointer",
+                    color: "#94a3b8",
+                  }}
+                  aria-label={`Delete ${l.name}`}
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {active && (
+        <>
+          {/* Selection builder */}
+          <div style={sectionStyle} data-testid="inspector-selection">
+            <span style={sectionTitleStyle}>Selection</span>
+
+            {/* Pick from the 3D view */}
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 6, alignItems: "center" }}>
+              <span
+                data-testid="inspector-box-toggle"
+                style={chipStyle(!!boxSelectActive)}
+                onClick={() => setBoxSelectActive(!boxSelectActive)}
+              >
+                {boxSelectActive ? "Box select: ON — drag in 3D" : "▣ Box select in 3D"}
+              </span>
+              {pickedAtom && (
+                <>
+                  <span style={{ fontSize: 11, color: "#64748b" }}>Atom #{pickedAtom.index}:</span>
+                  <span
+                    data-testid="inspector-quick-element"
+                    style={chipStyle(false)}
+                    onClick={() => applyQuickSelect("element")}
+                  >
+                    same element
+                  </span>
+                  {pickedAtom.resname && (
+                    <span style={chipStyle(false)} onClick={() => applyQuickSelect("resname")}>
+                      same residue
+                    </span>
+                  )}
+                  {pickedAtom.chain && (
+                    <span style={chipStyle(false)} onClick={() => applyQuickSelect("chain")}>
+                      same chain
+                    </span>
+                  )}
+                  {pickedAtom.moleculeId != null && (
+                    <span style={chipStyle(false)} onClick={() => applyQuickSelect("molecule")}>
+                      same molecule
+                    </span>
+                  )}
+                  <span style={chipStyle(false)} onClick={() => applyQuickSelect("index")}>
+                    just this
+                  </span>
+                </>
+              )}
+            </div>
+
+            <div style={{ fontSize: 11, color: "#64748b" }}>Elements</div>
+            <div style={chipRowStyle}>
+              {facts.elements.map((e) => (
+                <span
+                  key={e.symbol}
+                  data-testid={`inspector-chip-element-${e.symbol}`}
+                  style={chipStyle(chipEls.has(e.symbol))}
+                  onClick={() => {
+                    const next = toggle(chipEls, e.symbol);
+                    setChipEls(next);
+                    setCustomQuery(false);
+                    regenerateFromChips(next, chipRes, chipChains, withinR);
+                  }}
+                >
+                  {e.symbol} ({e.count})
+                </span>
+              ))}
+            </div>
+
+            {facts.resnames.length > 0 && (
+              <>
+                <div style={{ fontSize: 11, color: "#64748b" }}>Residues</div>
+                <div style={chipRowStyle}>
+                  {facts.resnames.map((r) => (
+                    <span
+                      key={r}
+                      data-testid={`inspector-chip-resname-${r}`}
+                      style={chipStyle(chipRes.has(r))}
+                      onClick={() => {
+                        const next = toggle(chipRes, r);
+                        setChipRes(next);
+                        setCustomQuery(false);
+                        regenerateFromChips(chipEls, next, chipChains, withinR);
+                      }}
+                    >
+                      {r}
+                    </span>
+                  ))}
+                </div>
+              </>
+            )}
+
+            {facts.chains.length > 0 && (
+              <>
+                <div style={{ fontSize: 11, color: "#64748b" }}>Chains</div>
+                <div style={chipRowStyle}>
+                  {facts.chains.map((c) => (
+                    <span
+                      key={c}
+                      data-testid={`inspector-chip-chain-${c}`}
+                      style={chipStyle(chipChains.has(c))}
+                      onClick={() => {
+                        const next = toggle(chipChains, c);
+                        setChipChains(next);
+                        setCustomQuery(false);
+                        regenerateFromChips(chipEls, chipRes, next, withinR);
+                      }}
+                    >
+                      {c}
+                    </span>
+                  ))}
+                </div>
+              </>
+            )}
+
+            <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+              <label style={{ fontSize: 11, color: "#64748b" }}>Within (Å)</label>
+              <input
+                data-testid="inspector-within"
+                type="number"
+                min={0}
+                step={0.5}
+                value={withinR}
+                placeholder="—"
+                style={{ ...selectStyle, width: 70 }}
+                onChange={(e) => {
+                  setWithinR(e.target.value);
+                  if (!customQuery)
+                    regenerateFromChips(chipEls, chipRes, chipChains, e.target.value);
+                }}
+              />
+              <span style={{ fontSize: 11, color: "#94a3b8" }}>of the above</span>
+            </div>
+
+            {/* Raw expression (source of truth) */}
+            <div style={{ fontSize: 11, color: "#64748b" }}>Expression</div>
+            <textarea
+              data-testid="inspector-query"
+              className="nodrag"
+              value={active.query}
+              placeholder='e.g. element == "C" and within 5 of (resname == "HEM")'
+              rows={2}
+              spellCheck={false}
+              style={{
+                ...selectStyle,
+                fontFamily: "monospace",
+                fontSize: 12,
+                resize: "vertical",
+                borderColor: queryValidation.valid ? "#cbd5e1" : "#ef4444",
+              }}
+              onChange={(e) => {
+                setCustomQuery(true);
+                updateActive((l) => ({ ...l, query: e.target.value }));
+              }}
+            />
+            <div style={{ display: "flex", justifyContent: "space-between", fontSize: 11 }}>
+              <span
+                data-testid="inspector-selected-count"
+                style={{ color: queryValidation.valid ? "#059669" : "#ef4444" }}
+              >
+                {queryValidation.valid
+                  ? selectedCount != null
+                    ? `${selectedCount} atom${selectedCount === 1 ? "" : "s"} selected`
+                    : ""
+                  : queryValidation.error}
+              </span>
+            </div>
+          </div>
+
+          {/* Appearance */}
+          <div style={sectionStyle} data-testid="inspector-appearance">
+            <span style={sectionTitleStyle}>Appearance</span>
+
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <input
+                data-testid="inspector-color-enabled"
+                type="checkbox"
+                checked={active.appearance.colorEnabled}
+                onChange={(e) => updateAppearance({ colorEnabled: e.target.checked })}
+              />
+              <span style={{ fontSize: 12, width: 70 }}>Color</span>
+              <select
+                data-testid="inspector-color-mode"
+                value={active.appearance.colorMode}
+                disabled={!active.appearance.colorEnabled}
+                style={{ ...selectStyle, flex: 1 }}
+                onChange={(e) => updateAppearance({ colorMode: e.target.value as ColorMode })}
+              >
+                {(Object.entries(COLOR_MODE_LABELS) as [ColorMode, string][]).map(([v, label]) => (
+                  <option key={v} value={v}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+              {active.appearance.colorMode === "uniform" && (
+                <input
+                  data-testid="inspector-color-value"
+                  type="color"
+                  disabled={!active.appearance.colorEnabled}
+                  value={active.appearance.uniformColor}
+                  onChange={(e) => updateAppearance({ uniformColor: e.target.value })}
+                  style={{
+                    width: 36,
+                    height: 24,
+                    border: "1px solid #cbd5e1",
+                    borderRadius: 4,
+                    padding: 0,
+                  }}
+                />
+              )}
+            </div>
+
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <input
+                data-testid="inspector-rep-enabled"
+                type="checkbox"
+                checked={active.appearance.representationEnabled}
+                onChange={(e) => updateAppearance({ representationEnabled: e.target.checked })}
+              />
+              <span style={{ fontSize: 12, width: 70 }}>Style</span>
+              <select
+                data-testid="inspector-rep-mode"
+                value={active.appearance.representation}
+                disabled={!active.appearance.representationEnabled}
+                style={{ ...selectStyle, flex: 1 }}
+                onChange={(e) =>
+                  updateAppearance({ representation: e.target.value as RepresentationMode })
+                }
+              >
+                {(Object.entries(REP_LABELS) as [RepresentationMode, string][]).map(
+                  ([v, label]) => (
+                    <option key={v} value={v}>
+                      {label}
+                    </option>
+                  ),
+                )}
+              </select>
+            </div>
+
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <span style={{ fontSize: 12, width: 80 }}>
+                Size {active.appearance.scale.toFixed(2)}
+              </span>
+              <input
+                data-testid="inspector-scale"
+                type="range"
+                min={0.1}
+                max={2}
+                step={0.05}
+                value={active.appearance.scale}
+                style={{ flex: 1 }}
+                onChange={(e) => updateAppearance({ scale: Number(e.target.value) })}
+              />
+            </div>
+
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <span style={{ fontSize: 12, width: 80 }}>
+                Opacity {active.appearance.opacity.toFixed(2)}
+              </span>
+              <input
+                data-testid="inspector-opacity"
+                type="range"
+                min={0}
+                max={1}
+                step={0.05}
+                value={active.appearance.opacity}
+                disabled={!active.appearance.visible}
+                style={{ flex: 1 }}
+                onChange={(e) => updateAppearance({ opacity: Number(e.target.value) })}
+              />
+            </div>
+
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <input
+                data-testid="inspector-visible"
+                type="checkbox"
+                checked={active.appearance.visible}
+                onChange={(e) => updateAppearance({ visible: e.target.checked })}
+              />
+              <span style={{ fontSize: 12 }}>Visible</span>
+            </div>
+          </div>
+
+          <button
+            data-testid="inspector-open-editor"
+            onClick={() => setMode("editor")}
+            style={{ ...selectStyle, cursor: "pointer", alignSelf: "flex-start" }}
+          >
+            Open generated nodes in Editor →
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/Viewport.tsx
+++ b/src/components/Viewport.tsx
@@ -16,6 +16,16 @@ interface ViewportProps {
   onHover?: (info: HoverInfo) => void;
   onAtomRightClick?: (atomIndex: number) => void;
   onFrameUpdated?: () => void;
+  /** Atom indices to highlight live as the Inspector's current selection. */
+  previewIndices?: number[] | null;
+  /** When true, left-drag draws a rubber-band box instead of rotating. */
+  boxSelectActive?: boolean;
+  /** Called with the atom indices inside a completed box drag. */
+  onBoxSelect?: (indices: number[]) => void;
+  /** Called when an atom is left-clicked while the Inspector is active. */
+  onInspectorPick?: (atomIndex: number) => void;
+  /** True while the Selection Inspector tab is the active editing surface. */
+  inspectorActive?: boolean;
 }
 
 export function Viewport({
@@ -27,17 +37,30 @@ export function Viewport({
   onHover,
   onAtomRightClick,
   onFrameUpdated,
+  previewIndices,
+  boxSelectActive,
+  onBoxSelect,
+  onInspectorPick,
+  inspectorActive,
 }: ViewportProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const rendererRef = useRef<MoleculeRenderer | null>(null);
   const onHoverRef = useRef(onHover);
   const onAtomRightClickRef = useRef(onAtomRightClick);
   const onFrameUpdatedRef = useRef(onFrameUpdated);
+  const boxSelectActiveRef = useRef(boxSelectActive);
+  const onBoxSelectRef = useRef(onBoxSelect);
+  const onInspectorPickRef = useRef(onInspectorPick);
+  const inspectorActiveRef = useRef(inspectorActive);
 
   // Keep callback refs up to date
   onHoverRef.current = onHover;
   onAtomRightClickRef.current = onAtomRightClick;
   onFrameUpdatedRef.current = onFrameUpdated;
+  boxSelectActiveRef.current = boxSelectActive;
+  onBoxSelectRef.current = onBoxSelect;
+  onInspectorPickRef.current = onInspectorPick;
+  inspectorActiveRef.current = inspectorActive;
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -97,6 +120,69 @@ export function Viewport({
       }
     };
 
+    // Inspector left-click pick: a plain click on an atom while the Inspector
+    // is active (and not box-selecting) reports it for a "quick expand".
+    const handleClick = (e: MouseEvent) => {
+      if (!inspectorActiveRef.current || boxSelectActiveRef.current) return;
+      if (e.button !== 0) return;
+      const info = renderer.raycastAtPixel(e.clientX, e.clientY);
+      if (info && info.kind === "atom") {
+        onInspectorPickRef.current?.(info.atomIndex);
+      }
+    };
+
+    // ── Box (rubber-band) selection ──
+    // Active only while `boxSelectActive`; camera rotation is suspended by an
+    // effect below so the drag can't also orbit the camera.
+    let boxStart: { x: number; y: number } | null = null;
+    let boxEl: HTMLDivElement | null = null;
+
+    const clearBoxEl = () => {
+      boxEl?.remove();
+      boxEl = null;
+    };
+
+    const handleBoxDown = (e: PointerEvent) => {
+      if (!boxSelectActiveRef.current || e.button !== 0) return;
+      boxStart = { x: e.clientX, y: e.clientY };
+      boxEl = document.createElement("div");
+      boxEl.setAttribute("data-testid", "viewport-box-select");
+      Object.assign(boxEl.style, {
+        position: "fixed",
+        border: "1px dashed #2563eb",
+        background: "rgba(37, 99, 235, 0.12)",
+        pointerEvents: "none",
+        zIndex: "50",
+        left: `${e.clientX}px`,
+        top: `${e.clientY}px`,
+        width: "0px",
+        height: "0px",
+      } as CSSStyleDeclaration);
+      document.body.appendChild(boxEl);
+      (e.target as Element)?.setPointerCapture?.(e.pointerId);
+    };
+
+    const handleBoxMove = (e: PointerEvent) => {
+      if (!boxStart || !boxEl) return;
+      const x = Math.min(boxStart.x, e.clientX);
+      const y = Math.min(boxStart.y, e.clientY);
+      boxEl.style.left = `${x}px`;
+      boxEl.style.top = `${y}px`;
+      boxEl.style.width = `${Math.abs(e.clientX - boxStart.x)}px`;
+      boxEl.style.height = `${Math.abs(e.clientY - boxStart.y)}px`;
+    };
+
+    const handleBoxUp = (e: PointerEvent) => {
+      if (!boxStart) return;
+      const rect = { x0: boxStart.x, y0: boxStart.y, x1: e.clientX, y1: e.clientY };
+      boxStart = null;
+      clearBoxEl();
+      // Ignore an accidental click (no meaningful drag area).
+      if (Math.abs(rect.x1 - rect.x0) < 3 && Math.abs(rect.y1 - rect.y0) < 3) return;
+      const indices = renderer.selectAtomsInRect(rect);
+      onBoxSelectRef.current?.(indices);
+    };
+
     // ── Axes-inset drag handlers (pointer events for mouse+touch) ──
 
     const containerEl = containerRef.current!;
@@ -112,24 +198,30 @@ export function Viewport({
         e.preventDefault();
         renderer.startAxesDrag(x, y);
         (e.target as Element)?.setPointerCapture?.(e.pointerId);
+        return;
       }
+      handleBoxDown(e);
     };
 
     const handlePointerMove = (e: PointerEvent) => {
       if (renderer.isAxesDragging()) {
         const { x, y } = toCSSCoords(e);
         renderer.moveAxesDrag(x, y);
+        return;
       }
+      handleBoxMove(e);
     };
 
-    const handlePointerUp = (_e: PointerEvent) => {
+    const handlePointerUp = (e: PointerEvent) => {
       renderer.endAxesDrag();
+      handleBoxUp(e);
     };
 
     canvas.addEventListener("mousemove", handleMouseMove);
     canvas.addEventListener("contextmenu", handleContextMenu);
     canvas.addEventListener("mouseleave", handleMouseLeave);
     canvas.addEventListener("dblclick", handleDblClick);
+    canvas.addEventListener("click", handleClick);
     canvas.addEventListener("pointerdown", handlePointerDown);
     canvas.addEventListener("pointermove", handlePointerMove);
     canvas.addEventListener("pointerup", handlePointerUp);
@@ -140,13 +232,29 @@ export function Viewport({
       canvas.removeEventListener("contextmenu", handleContextMenu);
       canvas.removeEventListener("mouseleave", handleMouseLeave);
       canvas.removeEventListener("dblclick", handleDblClick);
+      canvas.removeEventListener("click", handleClick);
       canvas.removeEventListener("pointerdown", handlePointerDown);
       canvas.removeEventListener("pointermove", handlePointerMove);
       canvas.removeEventListener("pointerup", handlePointerUp);
       canvas.removeEventListener("pointercancel", handlePointerUp);
+      clearBoxEl();
       if (rafId !== null) cancelAnimationFrame(rafId);
     };
   }, []);
+
+  // Live preview highlight of the Inspector's current selection.
+  useEffect(() => {
+    rendererRef.current?.setPreviewSelection(previewIndices ?? null);
+  }, [previewIndices]);
+
+  // Suspend camera rotation while box-select is armed so a drag draws the box
+  // instead of orbiting the camera.
+  useEffect(() => {
+    rendererRef.current?.setControlsEnabled(!boxSelectActive);
+    return () => {
+      rendererRef.current?.setControlsEnabled(true);
+    };
+  }, [boxSelectActive]);
 
   useEffect(() => {
     if (snapshot && rendererRef.current) {

--- a/src/components/nodes/FilterNode.tsx
+++ b/src/components/nodes/FilterNode.tsx
@@ -100,7 +100,9 @@ export function FilterNode({ id, data }: NodeProps<Node<PipelineNodeData>>) {
       />
       {error && <div style={errorStyle}>{error}</div>}
       {!error && !localQuery && (
-        <div style={hintStyle}>element, index, x, y, z, resname, mass, molecule_id</div>
+        <div style={hintStyle}>
+          element, index, x, y, z, resname, resid, chain, mass, molecule_id · within R of (…)
+        </div>
       )}
       <input
         value={localBondQuery}

--- a/src/pipeline/catalog.ts
+++ b/src/pipeline/catalog.ts
@@ -179,7 +179,7 @@ export const NODE_CATALOG: Record<PipelineNodeType, NodeCatalogEntry> = {
       },
     ],
     promptNotes: [
-      '`query`: atom selection (e.g. `element == "C"`, `index < 10`, `resname == "ALA"`, `element == "O" or element == "N"`)',
+      '`query`: atom selection (e.g. `element == "C"`, `index < 10`, `resname == "ALA"`, `chain == "A"`, `resid == 42`, `within 5 of (resname == "HEM")`)',
       '`bond_query`: optional bond selection (e.g. `both element != "H"`)',
     ],
     promptInputs: "`in` (accepts particle or bond data type)",

--- a/src/pipeline/inspectorQuery.ts
+++ b/src/pipeline/inspectorQuery.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure helpers that turn Inspector UI choices — element/residue/chain chips, a
+ * distance radius, or a clicked atom — into selection-DSL expression strings
+ * (see `selection.ts`). Kept separate from React so they can be unit-tested and
+ * reused by both the chip builder and the 3D click "quick expand" actions.
+ */
+
+/** Wrap a value in the double quotes the DSL requires for string comparisons. */
+export function quoteValue(v: string): string {
+  return `"${v.replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Build an OR-group comparing `field` against each value, e.g.
+ * `element == "C"` for one value or `(element == "C" or element == "N")` for
+ * several. Returns "" for an empty value list.
+ */
+export function orGroup(field: string, values: string[]): string {
+  if (values.length === 0) return "";
+  const terms = values.map((v) => `${field} == ${quoteValue(v)}`);
+  if (terms.length === 1) return terms[0];
+  return `(${terms.join(" or ")})`;
+}
+
+export interface ChipQueryInput {
+  elements?: string[];
+  resnames?: string[];
+  chains?: string[];
+  /** When set (and the base selection is non-empty), wrap it in `within R of (...)`. */
+  withinRadius?: number | null;
+}
+
+/**
+ * Compose a selection query from chip selections. Non-empty category groups are
+ * AND-ed together; an optional radius expands the whole selection via `within`.
+ * Returns "" when nothing is selected (meaning "all atoms").
+ */
+export function buildQueryFromChips(input: ChipQueryInput): string {
+  const groups: string[] = [];
+  const elems = orGroup("element", input.elements ?? []);
+  if (elems) groups.push(elems);
+  const res = orGroup("resname", input.resnames ?? []);
+  if (res) groups.push(res);
+  const chains = orGroup("chain", input.chains ?? []);
+  if (chains) groups.push(chains);
+
+  const base = groups.join(" and ");
+  if (!base) return "";
+  const r = input.withinRadius;
+  if (r != null && Number.isFinite(r) && r > 0) {
+    return `within ${r} of (${base})`;
+  }
+  return base;
+}
+
+/** Which per-atom property a "quick expand" click selects by. */
+export type QuickSelectKind = "element" | "resname" | "chain" | "molecule" | "index";
+
+/** Facts about a clicked atom, used to synthesize a quick-select expression. */
+export interface ClickedAtom {
+  index: number;
+  element: string;
+  resname?: string | null;
+  chain?: string | null;
+  moleculeId?: number | null;
+}
+
+/**
+ * Build an expression selecting atoms that share a property with the clicked
+ * atom (or just the atom itself for "index"). Returns "" when the requested
+ * property is unavailable for that atom.
+ */
+export function quickSelectExpression(kind: QuickSelectKind, atom: ClickedAtom): string {
+  switch (kind) {
+    case "element":
+      return atom.element ? `element == ${quoteValue(atom.element)}` : "";
+    case "resname":
+      return atom.resname ? `resname == ${quoteValue(atom.resname)}` : "";
+    case "chain":
+      return atom.chain ? `chain == ${quoteValue(atom.chain)}` : "";
+    case "molecule":
+      return atom.moleculeId != null ? `molecule_id == ${atom.moleculeId}` : "";
+    case "index":
+      return `index == ${atom.index}`;
+  }
+}
+
+/** Build an `index == a or index == b ...` expression from a set of indices. */
+export function indicesToExpression(indices: number[]): string {
+  const uniq = [...new Set(indices)].sort((a, b) => a - b);
+  if (uniq.length === 0) return "none";
+  return uniq.map((i) => `index == ${i}`).join(" or ");
+}

--- a/src/pipeline/inspectorQuery.ts
+++ b/src/pipeline/inspectorQuery.ts
@@ -5,9 +5,17 @@
  * reused by both the chip builder and the 3D click "quick expand" actions.
  */
 
-/** Wrap a value in the double quotes the DSL requires for string comparisons. */
+/**
+ * Wrap a value in the double quotes the DSL requires for string comparisons.
+ *
+ * The selection DSL has no string-escape mechanism (its tokenizer reads raw
+ * characters up to the next quote), so a value can't contain a quote or a
+ * backslash. Element/residue/chain values never do, but we strip both defensively
+ * — removing the characters entirely rather than emitting escapes the tokenizer
+ * cannot decode (and avoids an incomplete-escaping footgun on untrusted labels).
+ */
 export function quoteValue(v: string): string {
-  return `"${v.replace(/"/g, '\\"')}"`;
+  return `"${v.replace(/["\\]/g, "")}"`;
 }
 
 /**

--- a/src/pipeline/inspectorSync.ts
+++ b/src/pipeline/inspectorSync.ts
@@ -1,0 +1,300 @@
+/**
+ * Selection Inspector → pipeline authoring.
+ *
+ * The Inspector is a lightweight third editing surface (alongside the visual
+ * pipeline editor and the AI chat) for "select a subset, change how it looks".
+ * Rather than maintaining a parallel rendering path, every Inspector *layer*
+ * compiles down to ordinary pipeline nodes — a `filter` (the selection) chained
+ * into optional `color` / `representation` / `modify` nodes, terminating at the
+ * viewport. Because the pipeline store is the single source of truth, the nodes
+ * an Inspector layer produces show up verbatim in the visual editor: editing in
+ * the Inspector *is* editing the pipeline.
+ *
+ * Inspector-owned nodes are marked two ways so `reconcileInspectorLayers` can
+ * rebuild them idempotently without disturbing the rest of the graph:
+ *   - a deterministic id, `insp-<layerId>-<role>` (survives re-runs, so React
+ *     Flow doesn't remount and node positions stay put);
+ *   - `data.inspectorLayerId` (used to reconstruct layer models from a live
+ *     graph via `layersFromGraph`).
+ */
+
+import type { Node, Edge } from "@xyflow/react";
+import type { PipelineNodeData } from "./execute";
+import type {
+  ColorMode,
+  RepresentationMode,
+  FilterParams,
+  ColorParams,
+  RepresentationParams,
+  ModifyParams,
+} from "./types";
+
+/** Prefix shared by every node/edge the Inspector owns. */
+export const INSPECTOR_NODE_PREFIX = "insp-";
+
+/** Visual settings a single Inspector layer applies to its selection. */
+export interface InspectorAppearance {
+  /** Emit a `color` node when true. */
+  colorEnabled: boolean;
+  colorMode: ColorMode;
+  /** Hex color used when `colorMode === "uniform"`. */
+  uniformColor: string;
+  /** Emit a `representation` node when true. */
+  representationEnabled: boolean;
+  representation: RepresentationMode;
+  /** Atom scale factor (1 = unchanged). */
+  scale: number;
+  /** Opacity 0–1 (1 = fully opaque); ignored when `visible` is false. */
+  opacity: number;
+  /** When false the layer's atoms are driven to opacity 0 (hidden). */
+  visible: boolean;
+}
+
+/** One selection + appearance rule authored in the Inspector. */
+export interface InspectorLayer {
+  /** Stable id; drives the deterministic node ids for this layer. */
+  id: string;
+  name: string;
+  /** Atom selection expression (Filter node `query`). */
+  query: string;
+  appearance: InspectorAppearance;
+}
+
+/** Sensible starting appearance for a freshly created layer. */
+export function defaultInspectorAppearance(): InspectorAppearance {
+  return {
+    colorEnabled: true,
+    colorMode: "uniform",
+    uniformColor: "#ff8800",
+    representationEnabled: false,
+    representation: "atoms",
+    scale: 1.0,
+    opacity: 1.0,
+    visible: true,
+  };
+}
+
+/** True when a modify node is needed to realize this layer's appearance. */
+function needsModify(a: InspectorAppearance): boolean {
+  return a.scale !== 1.0 || a.opacity !== 1.0 || !a.visible;
+}
+
+/** The particle source an Inspector layer branches from. */
+export interface InspectorSource {
+  nodeId: string;
+  handle: string;
+}
+
+type Role = "filter" | "color" | "representation" | "modify";
+
+function nodeId(layerId: string, role: Role): string {
+  return `${INSPECTOR_NODE_PREFIX}${layerId}-${role}`;
+}
+
+/** True when a node/edge id belongs to the Inspector. */
+export function isInspectorId(id: string): boolean {
+  return id.startsWith(INSPECTOR_NODE_PREFIX);
+}
+
+function makeNode(
+  id: string,
+  type: Role,
+  position: { x: number; y: number },
+  params: PipelineNodeData["params"],
+  layerId: string,
+): Node<PipelineNodeData> {
+  return {
+    id,
+    type,
+    position,
+    data: { params, enabled: true, inspectorLayerId: layerId },
+  };
+}
+
+/**
+ * Build the nodes and edges realizing a single layer, branching from `source`
+ * and terminating at the viewport's `particle` input.
+ */
+function buildLayer(
+  layer: InspectorLayer,
+  layerIndex: number,
+  source: InspectorSource,
+  viewportId: string,
+): { nodes: Node<PipelineNodeData>[]; edges: Edge[] } {
+  const a = layer.appearance;
+  const nodes: Node<PipelineNodeData>[] = [];
+  const edges: Edge[] = [];
+
+  // Lay each layer out in its own column to the right of the main graph so the
+  // generated nodes are visible (and non-overlapping) in the editor.
+  const colX = 900 + layerIndex * 280;
+  let rowY = 40;
+  const rowStep = 150;
+
+  const roles: Role[] = ["filter"];
+  if (a.colorEnabled) roles.push("color");
+  if (a.representationEnabled) roles.push("representation");
+  if (needsModify(a)) roles.push("modify");
+
+  const paramsFor = (role: Role): PipelineNodeData["params"] => {
+    switch (role) {
+      case "filter":
+        return { type: "filter", query: layer.query, bond_query: "" } as FilterParams;
+      case "color":
+        return {
+          type: "color",
+          mode: a.colorMode,
+          uniformColor: a.uniformColor,
+        } as ColorParams;
+      case "representation":
+        return { type: "representation", mode: a.representation } as RepresentationParams;
+      case "modify":
+        return {
+          type: "modify",
+          scale: a.scale,
+          opacity: a.visible ? a.opacity : 0,
+        } as ModifyParams;
+    }
+  };
+
+  // Create the chain nodes.
+  const ids = roles.map((role) => nodeId(layer.id, role));
+  roles.forEach((role, i) => {
+    nodes.push(makeNode(ids[i], role, { x: colX, y: rowY }, paramsFor(role), layer.id));
+    rowY += rowStep;
+  });
+
+  // Wire: source.particle → first.in, then out→in along the chain,
+  // finally last.out → viewport.particle.
+  edges.push({
+    id: `e-${INSPECTOR_NODE_PREFIX}${layer.id}-src`,
+    source: source.nodeId,
+    target: ids[0],
+    sourceHandle: source.handle,
+    targetHandle: "in",
+  });
+  for (let i = 0; i < ids.length - 1; i++) {
+    edges.push({
+      id: `e-${INSPECTOR_NODE_PREFIX}${layer.id}-${roles[i]}-${roles[i + 1]}`,
+      source: ids[i],
+      target: ids[i + 1],
+      sourceHandle: "out",
+      targetHandle: "in",
+    });
+  }
+  edges.push({
+    id: `e-${INSPECTOR_NODE_PREFIX}${layer.id}-vp`,
+    source: ids[ids.length - 1],
+    target: viewportId,
+    sourceHandle: "out",
+    targetHandle: "particle",
+  });
+
+  return { nodes, edges };
+}
+
+/**
+ * Rebuild the Inspector-owned portion of the graph from `layers`, leaving every
+ * other node and edge untouched. Idempotent: running it again with the same
+ * layers produces the same node ids and positions.
+ *
+ * `source` is the particle stream the layers branch from (typically whatever
+ * node currently feeds `viewport.particle`, so replicate/supercell effects are
+ * preserved). `viewportId` is where each layer terminates.
+ */
+export function reconcileInspectorLayers(
+  nodes: Node<PipelineNodeData>[],
+  edges: Edge[],
+  layers: InspectorLayer[],
+  source: InspectorSource,
+  viewportId: string,
+): { nodes: Node<PipelineNodeData>[]; edges: Edge[] } {
+  // Drop the previous Inspector nodes and any edge touching them.
+  const keptNodes = nodes.filter((n) => !isInspectorId(n.id));
+  const keptEdges = edges.filter(
+    (e) =>
+      !isInspectorId(e.id.replace(/^e-/, "")) &&
+      !isInspectorId(e.source) &&
+      !isInspectorId(e.target),
+  );
+
+  const newNodes: Node<PipelineNodeData>[] = [];
+  const newEdges: Edge[] = [];
+  layers.forEach((layer, i) => {
+    const built = buildLayer(layer, i, source, viewportId);
+    newNodes.push(...built.nodes);
+    newEdges.push(...built.edges);
+  });
+
+  return {
+    nodes: [...keptNodes, ...newNodes],
+    edges: [...keptEdges, ...newEdges],
+  };
+}
+
+/**
+ * Reconstruct Inspector layer models from a live graph by reading the nodes
+ * tagged with `data.inspectorLayerId`. Lets the Inspector re-open showing the
+ * layers it previously authored (within a session). Layers are returned in
+ * ascending layer-id order for determinism.
+ */
+export function layersFromGraph(nodes: Node<PipelineNodeData>[]): InspectorLayer[] {
+  const byLayer = new Map<string, Node<PipelineNodeData>[]>();
+  for (const n of nodes) {
+    const layerId = (n.data as { inspectorLayerId?: string }).inspectorLayerId;
+    if (!layerId) continue;
+    const group = byLayer.get(layerId);
+    if (group) group.push(n);
+    else byLayer.set(layerId, [n]);
+  }
+
+  const layers: InspectorLayer[] = [];
+  for (const [layerId, group] of byLayer) {
+    const find = (role: Role) => group.find((n) => n.id === nodeId(layerId, role));
+    const filter = find("filter");
+    if (!filter) continue; // a layer without a filter is malformed; skip it
+    const appearance = defaultInspectorAppearance();
+
+    const colorNode = find("color");
+    if (colorNode) {
+      const p = colorNode.data.params as ColorParams;
+      appearance.colorEnabled = true;
+      appearance.colorMode = p.mode;
+      appearance.uniformColor = p.uniformColor;
+    } else {
+      appearance.colorEnabled = false;
+    }
+
+    const repNode = find("representation");
+    if (repNode) {
+      const p = repNode.data.params as RepresentationParams;
+      appearance.representationEnabled = true;
+      appearance.representation = p.mode;
+    } else {
+      appearance.representationEnabled = false;
+    }
+
+    const modifyNode = find("modify");
+    if (modifyNode) {
+      const p = modifyNode.data.params as ModifyParams;
+      appearance.scale = p.scale;
+      if (p.opacity === 0) {
+        appearance.visible = false;
+        appearance.opacity = 1.0;
+      } else {
+        appearance.visible = true;
+        appearance.opacity = p.opacity;
+      }
+    }
+
+    layers.push({
+      id: layerId,
+      name: layerId,
+      query: (filter.data.params as FilterParams).query,
+      appearance,
+    });
+  }
+
+  layers.sort((a, b) => a.id.localeCompare(b.id));
+  return layers;
+}

--- a/src/pipeline/selection.ts
+++ b/src/pipeline/selection.ts
@@ -7,9 +7,11 @@
  *   OrExpr     := AndExpr ("or" AndExpr)*
  *   AndExpr    := NotExpr ("and" NotExpr)*
  *   NotExpr    := "not" NotExpr | Atom
- *   Atom       := Comparison | "(" OrExpr ")" | "all" | "none"
+ *   Atom       := Comparison | Within | "(" OrExpr ")" | "all" | "none"
+ *   Within     := "within" Number "of" Atom
  *   Comparison := Field Op Value
- *   Field      := "element" | "index" | "x" | "y" | "z" | "resname" | "mass" | "molecule_id"
+ *   Field      := "element" | "index" | "x" | "y" | "z" | "resname" | "resid"
+ *               | "chain" | "mass" | "molecule_id"
  *   Op         := "==" | "!=" | ">" | "<" | ">=" | "<="
  *   Value      := QuotedString | Number
  *
@@ -18,6 +20,14 @@
  *   connectivity) that the atom belongs to. Atoms with no bonds form their
  *   own single-atom molecule. IDs are assigned in order of the smallest atom
  *   index in each component (the component containing atom 0 gets 0, etc.).
+ *   "chain": per-atom chain ID as a single character (e.g. "A"), derived from
+ *   `snapshot.atomChainIds`. Atoms without chain info compare as "".
+ *   "resid": residue sequence number parsed from the trailing digits of the
+ *   atom label (e.g. "ALA42" → 42). Atoms whose label has no trailing number
+ *   compare as NaN (never match a numeric comparison).
+ *   "within R of (SEL)": atoms lying within distance R (Å) of ANY atom
+ *   selected by the inner expression SEL (the selected atoms themselves are
+ *   included, being at distance 0).
  */
 
 import type { Snapshot } from "../types";
@@ -97,6 +107,8 @@ type TokenType =
   | "and"
   | "or"
   | "not"
+  | "within"
+  | "of"
   | "lparen"
   | "rparen"
   | "all"
@@ -108,7 +120,18 @@ interface Token {
   value: string;
 }
 
-const FIELDS = new Set(["element", "index", "x", "y", "z", "resname", "mass", "molecule_id"]);
+const FIELDS = new Set([
+  "element",
+  "index",
+  "x",
+  "y",
+  "z",
+  "resname",
+  "resid",
+  "chain",
+  "mass",
+  "molecule_id",
+]);
 
 function tokenize(query: string): Token[] {
   const tokens: Token[] = [];
@@ -196,6 +219,8 @@ function tokenize(query: string): Token[] {
       if (word === "and") tokens.push({ type: "and", value: word });
       else if (word === "or") tokens.push({ type: "or", value: word });
       else if (word === "not") tokens.push({ type: "not", value: word });
+      else if (word === "within") tokens.push({ type: "within", value: word });
+      else if (word === "of") tokens.push({ type: "of", value: word });
       else if (word === "all") tokens.push({ type: "all", value: word });
       else if (word === "none") tokens.push({ type: "none", value: word });
       else if (FIELDS.has(word)) tokens.push({ type: "field", value: word });
@@ -214,6 +239,7 @@ function tokenize(query: string): Token[] {
 
 type ASTNode =
   | { kind: "comparison"; field: string; op: string; value: string | number }
+  | { kind: "within"; radius: number; operand: ASTNode }
   | { kind: "and"; left: ASTNode; right: ASTNode }
   | { kind: "or"; left: ASTNode; right: ASTNode }
   | { kind: "not"; operand: ASTNode }
@@ -303,6 +329,16 @@ class Parser {
       return node;
     }
 
+    if (t.type === "within") {
+      this.advance();
+      const radiusToken = this.expect("number");
+      const radius = parseFloat(radiusToken.value);
+      if (isNaN(radius)) throw new Error("Invalid radius after 'within'");
+      this.expect("of");
+      const operand = this.parseAtom();
+      return { kind: "within", radius, operand };
+    }
+
     if (t.type === "field") {
       const field = this.advance().value;
       const op = this.expect("op").value;
@@ -331,6 +367,90 @@ export function parseResname(label: string): string {
   return match ? match[1] : label;
 }
 
+/**
+ * Extract a residue sequence number from an atom label by reading the last run
+ * of digits (e.g. "ALA42" → 42, "HOH" → NaN). Returns NaN when the label has no
+ * trailing number, so a numeric `resid` comparison never matches those atoms.
+ */
+export function parseResid(label: string): number {
+  const match = label.match(/(\d+)(?!.*\d)/);
+  return match ? parseInt(match[1], 10) : NaN;
+}
+
+/**
+ * Build a predicate selecting atoms within `radius` (Å) of any atom matched by
+ * `inner`. Uses a uniform spatial grid (cell size = radius) so the cost scales
+ * with local density rather than O(nAtoms · nSelected). The selected atoms
+ * themselves satisfy the predicate (distance 0). An empty inner selection
+ * yields a predicate that matches nothing.
+ */
+function buildWithinPredicate(
+  inner: (index: number) => boolean,
+  snapshot: Snapshot,
+  radius: number,
+): (index: number) => boolean {
+  const { positions, nAtoms } = snapshot;
+  const seeds: number[] = [];
+  for (let i = 0; i < nAtoms; i++) if (inner(i)) seeds.push(i);
+  if (seeds.length === 0) return () => false;
+
+  const r = radius;
+  const r2 = r * r;
+
+  // Radii <= 0 (or non-finite) can't drive a spatial grid; fall back to a
+  // direct scan over the (usually small) seed set.
+  if (!(r > 0)) {
+    return (i) => {
+      const x = positions[i * 3];
+      const y = positions[i * 3 + 1];
+      const z = positions[i * 3 + 2];
+      for (const j of seeds) {
+        const dx = x - positions[j * 3];
+        const dy = y - positions[j * 3 + 1];
+        const dz = z - positions[j * 3 + 2];
+        if (dx * dx + dy * dy + dz * dz <= r2) return true;
+      }
+      return false;
+    };
+  }
+
+  const grid = new Map<string, number[]>();
+  const cellKey = (cx: number, cy: number, cz: number) => `${cx},${cy},${cz}`;
+  for (const j of seeds) {
+    const cx = Math.floor(positions[j * 3] / r);
+    const cy = Math.floor(positions[j * 3 + 1] / r);
+    const cz = Math.floor(positions[j * 3 + 2] / r);
+    const key = cellKey(cx, cy, cz);
+    const cell = grid.get(key);
+    if (cell) cell.push(j);
+    else grid.set(key, [j]);
+  }
+
+  return (i) => {
+    const x = positions[i * 3];
+    const y = positions[i * 3 + 1];
+    const z = positions[i * 3 + 2];
+    const bx = Math.floor(x / r);
+    const by = Math.floor(y / r);
+    const bz = Math.floor(z / r);
+    for (let cx = bx - 1; cx <= bx + 1; cx++) {
+      for (let cy = by - 1; cy <= by + 1; cy++) {
+        for (let cz = bz - 1; cz <= bz + 1; cz++) {
+          const cell = grid.get(cellKey(cx, cy, cz));
+          if (!cell) continue;
+          for (const j of cell) {
+            const dx = x - positions[j * 3];
+            const dy = y - positions[j * 3 + 1];
+            const dz = z - positions[j * 3 + 2];
+            if (dx * dx + dy * dy + dz * dz <= r2) return true;
+          }
+        }
+      }
+    }
+    return false;
+  };
+}
+
 function compileAST(
   ast: ASTNode,
   snapshot: Snapshot,
@@ -354,6 +474,10 @@ function compileAST(
       const left = compileAST(ast.left, snapshot, atomLabels);
       const right = compileAST(ast.right, snapshot, atomLabels);
       return (i) => left(i) || right(i);
+    }
+    case "within": {
+      const inner = compileAST(ast.operand, snapshot, atomLabels);
+      return buildWithinPredicate(inner, snapshot, ast.radius);
     }
     case "comparison": {
       const { field, op, value } = ast;
@@ -379,6 +503,14 @@ function compileAST(
           case "resname":
             fieldValue = atomLabels?.[i] ? parseResname(atomLabels[i]) : "";
             break;
+          case "resid":
+            fieldValue = atomLabels?.[i] != null ? parseResid(atomLabels[i]) : NaN;
+            break;
+          case "chain": {
+            const code = snapshot.atomChainIds?.[i] ?? 0;
+            fieldValue = code === 0 ? "" : String.fromCharCode(code);
+            break;
+          }
           case "mass":
             fieldValue = getAtomicMass(snapshot.elements[i]);
             break;

--- a/src/pipeline/selection.ts
+++ b/src/pipeline/selection.ts
@@ -371,10 +371,18 @@ export function parseResname(label: string): string {
  * Extract a residue sequence number from an atom label by reading the last run
  * of digits (e.g. "ALA42" → 42, "HOH" → NaN). Returns NaN when the label has no
  * trailing number, so a numeric `resid` comparison never matches those atoms.
+ *
+ * Implemented as a linear back-to-front scan rather than a regex: atom labels
+ * come from parsed files (untrusted input), and a lookahead like
+ * `/(\d+)(?!.*\d)/` has polynomial worst-case matching time (ReDoS).
  */
 export function parseResid(label: string): number {
-  const match = label.match(/(\d+)(?!.*\d)/);
-  return match ? parseInt(match[1], 10) : NaN;
+  const isDigit = (c: string) => c >= "0" && c <= "9";
+  let end = label.length;
+  while (end > 0 && !isDigit(label[end - 1])) end--;
+  let start = end;
+  while (start > 0 && isDigit(label[start - 1])) start--;
+  return start === end ? NaN : parseInt(label.slice(start, end), 10);
 }
 
 /**

--- a/src/pipeline/store.ts
+++ b/src/pipeline/store.ts
@@ -26,6 +26,7 @@ import { createDefaultPipeline, createDemoPipeline, createEmptyPipeline } from "
 import { PIPELINE_TEMPLATES } from "./templates";
 import { getLayoutedElements } from "./layout";
 import { performOpenFile, type OpenFileOptions } from "./openFile";
+import { reconcileInspectorLayers, isInspectorId, type InspectorLayer } from "./inspectorSync";
 
 let nextNodeId = 1;
 
@@ -112,6 +113,12 @@ export interface PipelineStore {
   // updates inside a single store transaction so the post-deserialize
   // execute() sees the matching per-node snapshots.
   loadPipeline: (json: SerializedPipeline, nodeSnapshots: Record<string, NodeSnapshotData>) => void;
+
+  // Selection Inspector: replace the Inspector-owned subgraph with the nodes
+  // realizing `layers` (filter → color/representation/modify → viewport),
+  // branching from whatever currently feeds viewport.particle so replicate /
+  // supercell effects are preserved. Non-Inspector nodes are left untouched.
+  setInspectorLayers: (layers: InspectorLayer[]) => void;
 
   // Templates
   pendingTemplateId: string | null;
@@ -545,6 +552,33 @@ const pipelineStateCreator: StateCreator<PipelineStore> = (set, get, api) => ({
       nodeSnapshots: { ...nodeSnapshots },
       snapshot: primarySnapshot,
     });
+    get().execute();
+  },
+
+  setInspectorLayers: (layers) => {
+    const { nodes, edges } = get();
+    const viewport = nodes.find((n) => n.type === "viewport");
+    if (!viewport) return;
+
+    // Prefer the node currently feeding viewport.particle (e.g. replicate) as
+    // the branch source so filtered layers inherit any supercell expansion.
+    const baseEdge = edges.find(
+      (e) =>
+        e.target === viewport.id &&
+        (e.targetHandle ?? "") === "particle" &&
+        !isInspectorId(e.source),
+    );
+    let source: { nodeId: string; handle: string } | null = null;
+    if (baseEdge) {
+      source = { nodeId: baseEdge.source, handle: baseEdge.sourceHandle ?? "particle" };
+    } else {
+      const loader = nodes.find((n) => n.type === "load_structure");
+      if (loader) source = { nodeId: loader.id, handle: "particle" };
+    }
+    if (!source) return;
+
+    const next = reconcileInspectorLayers(nodes, edges, layers, source, viewport.id);
+    set({ nodes: next.nodes, edges: next.edges });
     get().execute();
   },
 

--- a/src/renderer/MoleculeRenderer.ts
+++ b/src/renderer/MoleculeRenderer.ts
@@ -33,7 +33,7 @@ import { SurfaceRenderer } from "./SurfaceRenderer";
 import { LineRenderer } from "./LineRenderer";
 import type { MeshData } from "../pipeline/types";
 import { getRadius, BALL_STICK_ATOM_SCALE, LICORICE_RADIUS } from "../constants";
-import { pickAtPixel, projectToScreen } from "./Picking";
+import { pickAtPixel, projectToScreen, atomsInRect, type ClientRect } from "./Picking";
 import { computeMeasurement } from "./Selection";
 import { FpsCounter } from "./FpsCounter";
 import { perfMark, perfMeasure, perfPushFrame, perfRendererReady } from "../perf";
@@ -77,6 +77,47 @@ const _testMode = (() => {
  */
 export function isMeganeTestMode(): boolean {
   return _testMode;
+}
+
+/** Remove and dispose every child of a THREE.Group (meshes and lines). */
+function clearGroup(group: THREE.Group): void {
+  while (group.children.length > 0) {
+    const child = group.children[0];
+    group.remove(child);
+    if (child instanceof THREE.Mesh || child instanceof THREE.Line) {
+      child.geometry.dispose();
+      if (Array.isArray(child.material)) child.material.forEach((m) => m.dispose());
+      else child.material.dispose();
+    }
+  }
+}
+
+/** Draw translucent highlight spheres (1.6× atom radius) over the given atoms. */
+function drawHighlightSpheres(
+  group: THREE.Group,
+  atomIndices: number[],
+  positions: Float32Array,
+  elements: Uint8Array,
+  color: number,
+  opacity: number,
+): void {
+  for (const atomIdx of atomIndices) {
+    const r = getRadius(elements[atomIdx]) * BALL_STICK_ATOM_SCALE * 1.6;
+    const geo = new THREE.SphereGeometry(r, 16, 16);
+    const mat = new THREE.MeshBasicMaterial({
+      color,
+      transparent: true,
+      opacity,
+      depthWrite: false,
+    });
+    const sphere = new THREE.Mesh(geo, mat);
+    sphere.position.set(
+      positions[atomIdx * 3],
+      positions[atomIdx * 3 + 1],
+      positions[atomIdx * 3 + 2],
+    );
+    group.add(sphere);
+  }
 }
 
 interface MeganeTestReady {
@@ -312,6 +353,9 @@ export class MoleculeRenderer {
   // Atom selection & measurement
   private selectedAtoms: number[] = [];
   private selectionGroup = new THREE.Group();
+  // Inspector preview highlight — an arbitrary-size, uncapped set drawn in a
+  // distinct color, independent of the 4-atom measurement selection above.
+  private previewSelectionGroup = new THREE.Group();
 
   /** Mount the viewer into a DOM element. */
   mount(container: HTMLElement): void {
@@ -414,6 +458,7 @@ export class MoleculeRenderer {
 
     // Selection overlay group
     this.scene.add(this.selectionGroup);
+    this.scene.add(this.previewSelectionGroup);
 
     // Pivot marker (3D crosshair at rotation center)
     this.pivotMarker = new PivotMarker();
@@ -1569,6 +1614,41 @@ export class MoleculeRenderer {
     return { atoms: [...this.selectedAtoms] };
   }
 
+  /**
+   * Highlight an arbitrary set of atoms as a live "preview" of the Selection
+   * Inspector's current selection (green, translucent). Independent of the
+   * measurement selection. Pass `null` or `[]` to clear.
+   */
+  setPreviewSelection(atomIndices: number[] | null): void {
+    clearGroup(this.previewSelectionGroup);
+    if (!this.snapshot || !atomIndices || atomIndices.length === 0) return;
+    drawHighlightSpheres(
+      this.previewSelectionGroup,
+      atomIndices,
+      this.getCurrentPositions(),
+      this.snapshot.elements,
+      0x22c55e,
+      0.3,
+    );
+  }
+
+  /** Return the indices of atoms whose centers fall inside a screen rectangle. */
+  selectAtomsInRect(rect: ClientRect): number[] {
+    if (!this.container || !this.snapshot) return [];
+    return atomsInRect(
+      this.camera,
+      this.container,
+      this.snapshot,
+      this.getCurrentPositions(),
+      rect,
+    );
+  }
+
+  /** Enable/disable orbit controls (used to suspend camera rotation during a box drag). */
+  setControlsEnabled(enabled: boolean): void {
+    if (this.controls) this.controls.enabled = enabled;
+  }
+
   /** Clear all selected atoms. */
   clearSelection(): void {
     this.selectedAtoms = [];
@@ -1582,19 +1662,7 @@ export class MoleculeRenderer {
   }
 
   private updateSelectionVisuals(): void {
-    // Clear old visuals
-    while (this.selectionGroup.children.length > 0) {
-      const child = this.selectionGroup.children[0];
-      this.selectionGroup.remove(child);
-      if (child instanceof THREE.Mesh || child instanceof THREE.Line) {
-        child.geometry.dispose();
-        if (Array.isArray(child.material)) {
-          child.material.forEach((m) => m.dispose());
-        } else {
-          child.material.dispose();
-        }
-      }
-    }
+    clearGroup(this.selectionGroup);
 
     if (!this.snapshot || this.selectedAtoms.length === 0) return;
 
@@ -1602,19 +1670,7 @@ export class MoleculeRenderer {
     const elements = this.snapshot.elements;
 
     // Highlight spheres
-    for (const atomIdx of this.selectedAtoms) {
-      const r = getRadius(elements[atomIdx]) * BALL_STICK_ATOM_SCALE * 1.6;
-      const geo = new THREE.SphereGeometry(r, 16, 16);
-      const mat = new THREE.MeshBasicMaterial({
-        color: 0x4285f4,
-        transparent: true,
-        opacity: 0.35,
-        depthWrite: false,
-      });
-      const sphere = new THREE.Mesh(geo, mat);
-      sphere.position.set(pos[atomIdx * 3], pos[atomIdx * 3 + 1], pos[atomIdx * 3 + 2]);
-      this.selectionGroup.add(sphere);
-    }
+    drawHighlightSpheres(this.selectionGroup, this.selectedAtoms, pos, elements, 0x4285f4, 0.35);
 
     // Connecting lines
     if (this.selectedAtoms.length >= 2) {

--- a/src/renderer/Picking.ts
+++ b/src/renderer/Picking.ts
@@ -156,3 +156,49 @@ export function pickAtPixel(
 
   return null;
 }
+
+/** A rubber-band rectangle in client coordinates (any corner order). */
+export interface ClientRect {
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+}
+
+/**
+ * Return the indices of every atom whose projected center falls inside `rect`
+ * (a screen-space rubber-band box in client coordinates). Atoms behind the
+ * camera are ignored. Uses the same CPU projection as `pickAtPixel`, so it is
+ * consistent with click picking.
+ */
+export function atomsInRect(
+  camera: THREE.OrthographicCamera | THREE.PerspectiveCamera,
+  container: HTMLElement,
+  snapshot: Snapshot,
+  currentPositions: Float32Array,
+  rect: ClientRect,
+): number[] {
+  const bounds = container.getBoundingClientRect();
+  const w = bounds.width;
+  const h = bounds.height;
+  const minX = Math.min(rect.x0, rect.x1) - bounds.left;
+  const maxX = Math.max(rect.x0, rect.x1) - bounds.left;
+  const minY = Math.min(rect.y0, rect.y1) - bounds.top;
+  const maxY = Math.max(rect.y0, rect.y1) - bounds.top;
+
+  const pos = currentPositions;
+  const result: number[] = [];
+  for (let i = 0; i < snapshot.nAtoms; i++) {
+    const { sx, sy, depth } = projectToScreen(
+      camera,
+      pos[i * 3],
+      pos[i * 3 + 1],
+      pos[i * 3 + 2],
+      w,
+      h,
+    );
+    if (depth <= 0) continue; // behind camera
+    if (sx >= minX && sx <= maxX && sy >= minY && sy <= maxY) result.push(i);
+  }
+  return result;
+}

--- a/src/stores/useInspectorInteractionStore.ts
+++ b/src/stores/useInspectorInteractionStore.ts
@@ -1,0 +1,39 @@
+/**
+ * Bridge between the Selection Inspector (in the pipeline panel) and the 3D
+ * Viewport (in the viewer). They live in different component subtrees, so this
+ * small store carries the live preview highlight one way and the 3D pick /
+ * box-select results the other way.
+ */
+
+import { create } from "zustand";
+import type { ClickedAtom } from "../pipeline/inspectorQuery";
+
+let nextToken = 1;
+
+interface InspectorInteractionStore {
+  /** Atom indices the Inspector wants highlighted live in the 3D view. */
+  previewIndices: number[] | null;
+  /** True while the Inspector has "box select" armed (suspends camera rotate). */
+  boxSelectActive: boolean;
+  /** Result of a completed box drag (token de-dupes repeated identical sets). */
+  boxResult: { indices: number[]; token: number } | null;
+  /** An atom clicked in the 3D view while the Inspector is active. */
+  pickedAtom: (ClickedAtom & { token: number }) | null;
+
+  setPreviewIndices: (indices: number[] | null) => void;
+  setBoxSelectActive: (active: boolean) => void;
+  publishBoxResult: (indices: number[]) => void;
+  publishPickedAtom: (atom: ClickedAtom) => void;
+}
+
+export const useInspectorInteractionStore = create<InspectorInteractionStore>((set) => ({
+  previewIndices: null,
+  boxSelectActive: false,
+  boxResult: null,
+  pickedAtom: null,
+
+  setPreviewIndices: (indices) => set({ previewIndices: indices }),
+  setBoxSelectActive: (active) => set({ boxSelectActive: active }),
+  publishBoxResult: (indices) => set({ boxResult: { indices, token: nextToken++ } }),
+  publishPickedAtom: (atom) => set({ pickedAtom: { ...atom, token: nextToken++ } }),
+}));

--- a/src/stores/usePipelineUIStore.ts
+++ b/src/stores/usePipelineUIStore.ts
@@ -11,7 +11,7 @@
 
 import { create } from "zustand";
 
-export type PipelinePanelMode = "editor" | "chat";
+export type PipelinePanelMode = "editor" | "chat" | "inspector";
 
 export interface PipelineAppliedNotice {
   kind: "applied";
@@ -26,7 +26,10 @@ function loadMode(): PipelinePanelMode {
     const raw = sessionStorage.getItem(STORAGE_KEY);
     if (raw) {
       const parsed = JSON.parse(raw);
-      if (parsed && (parsed.mode === "editor" || parsed.mode === "chat")) {
+      if (
+        parsed &&
+        (parsed.mode === "editor" || parsed.mode === "chat" || parsed.mode === "inspector")
+      ) {
         return parsed.mode;
       }
     }

--- a/tests/e2e/inspector.spec.ts
+++ b/tests/e2e/inspector.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Selection Inspector E2E (webapp).
+ *
+ * Verifies the third pipeline tab: building a selection from element chips
+ * writes the expression, the live selected-count updates, and — crucially —
+ * the selection + appearance are reflected as real pipeline nodes (a
+ * filter → color chain) visible in the Editor tab. Asserts DOM and store
+ * state rather than pixels to stay robust against font/GL drift.
+ */
+
+import { test, expect } from "playwright/test";
+import { waitForReady } from "./lib/setup";
+
+test.describe("inspector: webapp", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      (globalThis as { __MEGANE_TEST__?: boolean }).__MEGANE_TEST__ = true;
+    });
+    await page.goto("/?test=1", { waitUntil: "domcontentloaded" });
+    await waitForReady(page);
+  });
+
+  test("builds a selection layer reflected as pipeline nodes", async ({ page }) => {
+    await page.locator('[data-testid="pipeline-editor-tab-inspector"]').click();
+    await expect(page.locator('[data-testid="pipeline-inspector"]')).toBeVisible();
+
+    // Add a layer, then select carbons via the element chip.
+    await page.locator('[data-testid="inspector-add-layer"]').click();
+    const carbon = page.locator('[data-testid="inspector-chip-element-C"]');
+    await expect(carbon).toBeVisible();
+    await carbon.click();
+
+    // Expression and live count reflect the chip choice.
+    await expect(page.locator('[data-testid="inspector-query"]')).toHaveValue('element == "C"');
+    await expect(page.locator('[data-testid="inspector-selected-count"]')).toContainText("atom");
+
+    // Reflection: the Editor tab now shows the generated filter + color nodes.
+    await page.locator('[data-testid="pipeline-editor-tab-editor"]').click();
+    await expect(page.locator('[data-testid="pipeline-node-filter"]').first()).toBeVisible();
+    await expect(page.locator('[data-testid="pipeline-node-color"]').first()).toBeVisible();
+
+    // The generated nodes are Inspector-owned and carry the selection query.
+    const info = await page.evaluate(() => {
+      const store = (
+        window as unknown as {
+          __megane_test_pipeline_store?: {
+            getState: () => {
+              nodes: {
+                id: string;
+                type?: string;
+                data: { params: Record<string, unknown> };
+              }[];
+            };
+          };
+        }
+      ).__megane_test_pipeline_store;
+      const nodes = store?.getState().nodes ?? [];
+      const insp = nodes.filter((n) => n.id.startsWith("insp-"));
+      const filter = insp.find((n) => n.type === "filter");
+      const color = insp.find((n) => n.type === "color");
+      return {
+        count: insp.length,
+        query: filter?.data.params.query,
+        colorMode: color?.data.params.mode,
+      };
+    });
+    expect(info.count).toBeGreaterThanOrEqual(2);
+    expect(info.query).toBe('element == "C"');
+    expect(info.colorMode).toBe("uniform");
+  });
+
+  test("editing the raw expression drives the live count and filter node", async ({ page }) => {
+    await page.locator('[data-testid="pipeline-editor-tab-inspector"]').click();
+    await page.locator('[data-testid="inspector-add-layer"]').click();
+
+    const query = page.locator('[data-testid="inspector-query"]');
+    await query.fill('element != "H"');
+    await expect(page.locator('[data-testid="inspector-selected-count"]')).toContainText("atom");
+
+    const filterQuery = await page.evaluate(() => {
+      const store = (
+        window as unknown as {
+          __megane_test_pipeline_store?: {
+            getState: () => {
+              nodes: { id: string; type?: string; data: { params: Record<string, unknown> } }[];
+            };
+          };
+        }
+      ).__megane_test_pipeline_store;
+      const nodes = store?.getState().nodes ?? [];
+      return nodes.find((n) => n.id.startsWith("insp-") && n.type === "filter")?.data.params.query;
+    });
+    expect(filterQuery).toBe('element != "H"');
+  });
+});

--- a/tests/ts/ai/__fixtures__/node-schema-section.txt
+++ b/tests/ts/ai/__fixtures__/node-schema-section.txt
@@ -40,7 +40,7 @@ Filters atoms (and optionally bonds) by a selection query. See the
 "Atom & Bond Selection Query Language" section below for the full, authoritative
 grammar — only the syntax documented there is supported.
 - Parameters: `{ type: "filter", query: string, bond_query?: string }`
-  - `query`: atom selection (e.g. `element == "C"`, `index < 10`, `resname == "ALA"`, `element == "O" or element == "N"`)
+  - `query`: atom selection (e.g. `element == "C"`, `index < 10`, `resname == "ALA"`, `chain == "A"`, `resid == 42`, `within 5 of (resname == "HEM")`)
   - `bond_query`: optional bond selection (e.g. `both element != "H"`)
 - Inputs: `in` (accepts particle or bond data type)
 - Outputs: `out` (same type as input)

--- a/tests/ts/ai/structureSummary.test.ts
+++ b/tests/ts/ai/structureSummary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { summarizeStructure } from "@/ai/structureSummary";
+import { summarizeStructure, getStructureFacts } from "@/ai/structureSummary";
 import type { Snapshot } from "@/types";
 
 /** Build a minimal Snapshot for testing. Carbon=6, Hydrogen=1, Oxygen=8. */
@@ -83,5 +83,49 @@ describe("summarizeStructure", () => {
 
     const withoutCell = summarizeStructure(makeSnapshot([6]), null);
     expect(withoutCell).toContain("Unit cell: no");
+  });
+});
+
+describe("getStructureFacts", () => {
+  it("returns null for no / empty structure", () => {
+    expect(getStructureFacts(null, null)).toBeNull();
+    expect(getStructureFacts(makeSnapshot([]), null)).toBeNull();
+  });
+
+  it("returns elements with counts, sorted descending", () => {
+    const facts = getStructureFacts(makeSnapshot([6, 6, 6, 1, 1, 8]), null)!;
+    expect(facts.nAtoms).toBe(6);
+    expect(facts.elements).toEqual([
+      { symbol: "C", count: 3 },
+      { symbol: "H", count: 2 },
+      { symbol: "O", count: 1 },
+    ]);
+  });
+
+  it("returns unique sorted resnames from labels", () => {
+    const facts = getStructureFacts(makeSnapshot([6, 6, 8, 8]), ["HOH2", "ALA1", "ALA1", "HOH3"])!;
+    expect(facts.resnames).toEqual(["ALA", "HOH"]);
+  });
+
+  it("returns empty resnames when labels are absent", () => {
+    const facts = getStructureFacts(makeSnapshot([6, 1]), null)!;
+    expect(facts.resnames).toEqual([]);
+  });
+
+  it("returns unique sorted chains, ignoring code 0", () => {
+    const snap = makeSnapshot([6, 6, 6, 6], {
+      atomChainIds: new Uint8Array([66, 65, 65, 0]), // 'B','A','A', none
+    });
+    const facts = getStructureFacts(snap, null)!;
+    expect(facts.chains).toEqual(["A", "B"]);
+  });
+
+  it("reports cell and bond presence", () => {
+    const facts = getStructureFacts(
+      makeSnapshot([6], { box: new Float32Array(9), nBonds: 3 }),
+      null,
+    )!;
+    expect(facts.hasCell).toBe(true);
+    expect(facts.nBonds).toBe(3);
   });
 });

--- a/tests/ts/components/PipelineInspector.test.tsx
+++ b/tests/ts/components/PipelineInspector.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
+import { usePipelineStore } from "@/pipeline/store";
+import { usePipelineUIStore } from "@/stores/usePipelineUIStore";
+import { useInspectorInteractionStore } from "@/stores/useInspectorInteractionStore";
+import { PipelineInspector } from "@/components/PipelineInspector";
+import { isInspectorId } from "@/pipeline/inspectorSync";
+import type { Snapshot } from "@/types";
+import type { FilterParams, ColorParams } from "@/pipeline/types";
+
+function tinySnapshot(): Snapshot {
+  return {
+    nAtoms: 3,
+    nBonds: 0,
+    nFileBonds: 0,
+    positions: new Float32Array([0, 0, 0, 1, 0, 0, 2, 0, 0]),
+    elements: new Uint8Array([6, 7, 8]), // C, N, O
+    bonds: new Uint32Array(0),
+    bondOrders: null,
+    box: null,
+    boxOrigin: null,
+    atomChainIds: new Uint8Array([65, 65, 66]), // A, A, B
+    atomBFactors: null,
+  };
+}
+
+function inspectorNodes() {
+  return usePipelineStore.getState().nodes.filter((n) => isInspectorId(n.id));
+}
+
+describe("PipelineInspector", () => {
+  beforeEach(() => {
+    usePipelineStore.getState().setInspectorLayers([]);
+    usePipelineStore.getState().setSnapshot(tinySnapshot());
+    usePipelineStore.getState().setAtomLabels(["ALA1", "ALA1", "HOH2"]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    usePipelineStore.getState().setInspectorLayers([]);
+    usePipelineStore.getState().setSnapshot(null);
+    usePipelineStore.getState().setAtomLabels(null);
+  });
+
+  it("prompts to load a structure when none is present", () => {
+    usePipelineStore.getState().setSnapshot(null);
+    render(<PipelineInspector />);
+    expect(screen.getByText(/Load a structure/i)).toBeTruthy();
+  });
+
+  it("renders element/residue/chain chips from the loaded structure", () => {
+    render(<PipelineInspector />);
+    fireEvent.click(screen.getByTestId("inspector-add-layer"));
+    // Elements C/N/O present.
+    expect(screen.getByTestId("inspector-chip-element-C")).toBeTruthy();
+    expect(screen.getByTestId("inspector-chip-element-N")).toBeTruthy();
+    // Residues from labels.
+    expect(screen.getByTestId("inspector-chip-resname-ALA")).toBeTruthy();
+    expect(screen.getByTestId("inspector-chip-resname-HOH")).toBeTruthy();
+    // Chains.
+    expect(screen.getByTestId("inspector-chip-chain-A")).toBeTruthy();
+    expect(screen.getByTestId("inspector-chip-chain-B")).toBeTruthy();
+  });
+
+  it("adding a layer creates Inspector-owned pipeline nodes (reflected in the graph)", () => {
+    render(<PipelineInspector />);
+    fireEvent.click(screen.getByTestId("inspector-add-layer"));
+    const nodes = inspectorNodes();
+    // Filter (always) + color (default appearance has color on).
+    expect(nodes.some((n) => n.type === "filter")).toBe(true);
+    expect(nodes.some((n) => n.type === "color")).toBe(true);
+  });
+
+  it("clicking an element chip writes the selection query into the filter node", () => {
+    render(<PipelineInspector />);
+    fireEvent.click(screen.getByTestId("inspector-add-layer"));
+    fireEvent.click(screen.getByTestId("inspector-chip-element-C"));
+
+    const filter = inspectorNodes().find((n) => n.type === "filter");
+    expect(filter).toBeDefined();
+    expect((filter!.data.params as FilterParams).query).toBe('element == "C"');
+    // Live count reflects the single carbon.
+    expect(screen.getByTestId("inspector-selected-count").textContent).toContain("1 atom");
+  });
+
+  it("editing the raw expression updates the filter query", () => {
+    render(<PipelineInspector />);
+    fireEvent.click(screen.getByTestId("inspector-add-layer"));
+    fireEvent.change(screen.getByTestId("inspector-query"), {
+      target: { value: 'element != "H"' },
+    });
+    const filter = inspectorNodes().find((n) => n.type === "filter");
+    expect((filter!.data.params as FilterParams).query).toBe('element != "H"');
+  });
+
+  it("changing the uniform color updates the color node", () => {
+    render(<PipelineInspector />);
+    fireEvent.click(screen.getByTestId("inspector-add-layer"));
+    fireEvent.change(screen.getByTestId("inspector-color-value"), {
+      target: { value: "#112233" },
+    });
+    const color = inspectorNodes().find((n) => n.type === "color");
+    expect((color!.data.params as ColorParams).uniformColor).toBe("#112233");
+  });
+
+  it("deleting a layer removes its nodes from the graph", () => {
+    render(<PipelineInspector />);
+    fireEvent.click(screen.getByTestId("inspector-add-layer"));
+    expect(inspectorNodes().length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByTestId("inspector-delete-layer-1"));
+    expect(inspectorNodes().length).toBe(0);
+  });
+
+  it("shows a validation error for a malformed expression", () => {
+    render(<PipelineInspector />);
+    fireEvent.click(screen.getByTestId("inspector-add-layer"));
+    fireEvent.change(screen.getByTestId("inspector-query"), {
+      target: { value: "element ==" },
+    });
+    // Count label switches to the parser error message.
+    expect(screen.getByTestId("inspector-selected-count").textContent).not.toContain("atom");
+  });
+});
+
+describe("PipelineInspector — 3D interactions", () => {
+  beforeEach(() => {
+    usePipelineStore.getState().setInspectorLayers([]);
+    usePipelineStore.getState().setSnapshot(tinySnapshot());
+    usePipelineStore.getState().setAtomLabels(["ALA1", "ALA1", "HOH2"]);
+    usePipelineUIStore.getState().setMode("inspector");
+    useInspectorInteractionStore.setState({
+      previewIndices: null,
+      boxSelectActive: false,
+      boxResult: null,
+      pickedAtom: null,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    usePipelineUIStore.getState().setMode("editor");
+    usePipelineStore.getState().setInspectorLayers([]);
+    usePipelineStore.getState().setSnapshot(null);
+    usePipelineStore.getState().setAtomLabels(null);
+  });
+
+  it("publishes a live preview of the active selection to the 3D bridge", () => {
+    render(<PipelineInspector />);
+    fireEvent.click(screen.getByTestId("inspector-add-layer"));
+    fireEvent.click(screen.getByTestId("inspector-chip-element-N"));
+    // The nitrogen atom is index 1.
+    expect(useInspectorInteractionStore.getState().previewIndices).toEqual([1]);
+  });
+
+  it("consumes a completed box selection into the active layer's expression", () => {
+    render(<PipelineInspector />);
+    fireEvent.click(screen.getByTestId("inspector-add-layer"));
+    act(() => {
+      useInspectorInteractionStore.getState().publishBoxResult([0, 2]);
+    });
+    const filter = inspectorNodes().find((n) => n.type === "filter");
+    expect((filter!.data.params as FilterParams).query).toBe("index == 0 or index == 2");
+    // Box mode auto-disarms after a selection.
+    expect(useInspectorInteractionStore.getState().boxSelectActive).toBe(false);
+  });
+
+  it("quick-expands a clicked atom to a same-element selection", () => {
+    render(<PipelineInspector />);
+    fireEvent.click(screen.getByTestId("inspector-add-layer"));
+    act(() => {
+      useInspectorInteractionStore.getState().publishPickedAtom({
+        index: 0,
+        element: "C",
+        resname: "ALA",
+        chain: "A",
+        moleculeId: null,
+      });
+    });
+    fireEvent.click(screen.getByTestId("inspector-quick-element"));
+    const filter = inspectorNodes().find((n) => n.type === "filter");
+    expect((filter!.data.params as FilterParams).query).toBe('element == "C"');
+  });
+
+  it("toggles box-select mode on the bridge store", () => {
+    render(<PipelineInspector />);
+    fireEvent.click(screen.getByTestId("inspector-add-layer"));
+    fireEvent.click(screen.getByTestId("inspector-box-toggle"));
+    expect(useInspectorInteractionStore.getState().boxSelectActive).toBe(true);
+  });
+});

--- a/tests/ts/components/Viewport.inspector.test.tsx
+++ b/tests/ts/components/Viewport.inspector.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Tests for the Selection Inspector interactions wired into the Viewport:
+ * live preview highlight, box-select drag, camera-rotation suspension, and
+ * click-to-quick-expand. The WebGL MoleculeRenderer is mocked so the DOM event
+ * plumbing can be exercised in jsdom.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+
+const canvas = document.createElement("canvas");
+
+const rendererMock = {
+  mount: vi.fn(),
+  dispose: vi.fn(),
+  getCanvas: () => canvas,
+  raycastAtPixel: vi.fn(() => ({ kind: "atom", atomIndex: 5 })),
+  getCurrentPositionsCopy: vi.fn(() => new Float32Array([0, 0, 0])),
+  setRotationCenter: vi.fn(),
+  hitTestAxesInset: vi.fn(() => false),
+  isAxesDragging: vi.fn(() => false),
+  startAxesDrag: vi.fn(),
+  moveAxesDrag: vi.fn(),
+  endAxesDrag: vi.fn(),
+  loadSnapshot: vi.fn(),
+  updateFrame: vi.fn(),
+  setLabels: vi.fn(),
+  setVectors: vi.fn(),
+  setPreviewSelection: vi.fn(),
+  setControlsEnabled: vi.fn(),
+  selectAtomsInRect: vi.fn(() => [1, 2]),
+};
+
+vi.mock("@/renderer/MoleculeRenderer", () => ({
+  MoleculeRenderer: function () {
+    return rendererMock;
+  },
+  isMeganeTestMode: () => true,
+}));
+
+import { Viewport } from "@/components/Viewport";
+
+function pointer(type: string, x: number, y: number, button = 0) {
+  canvas.dispatchEvent(
+    new MouseEvent(type, { clientX: x, clientY: y, button, bubbles: true }) as unknown as Event,
+  );
+}
+
+describe("Viewport — Inspector interactions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("pushes the preview selection to the renderer", () => {
+    render(<Viewport snapshot={null} frame={null} previewIndices={[3, 4]} />);
+    expect(rendererMock.setPreviewSelection).toHaveBeenCalledWith([3, 4]);
+    cleanup();
+  });
+
+  it("suspends camera controls while box-select is armed", () => {
+    render(<Viewport snapshot={null} frame={null} boxSelectActive />);
+    expect(rendererMock.setControlsEnabled).toHaveBeenCalledWith(false);
+    cleanup();
+  });
+
+  it("reports box-selected atom indices on drag release", () => {
+    const onBoxSelect = vi.fn();
+    render(<Viewport snapshot={null} frame={null} boxSelectActive onBoxSelect={onBoxSelect} />);
+    pointer("pointerdown", 10, 10);
+    pointer("pointermove", 60, 60);
+    pointer("pointerup", 60, 60);
+    expect(rendererMock.selectAtomsInRect).toHaveBeenCalled();
+    expect(onBoxSelect).toHaveBeenCalledWith([1, 2]);
+    // The rubber-band element is cleaned up.
+    expect(document.querySelector('[data-testid="viewport-box-select"]')).toBeNull();
+    cleanup();
+  });
+
+  it("ignores a box drag that is too small (treated as a click)", () => {
+    const onBoxSelect = vi.fn();
+    render(<Viewport snapshot={null} frame={null} boxSelectActive onBoxSelect={onBoxSelect} />);
+    pointer("pointerdown", 10, 10);
+    pointer("pointerup", 11, 11);
+    expect(onBoxSelect).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("reports a clicked atom when the Inspector is active", () => {
+    const onInspectorPick = vi.fn();
+    render(
+      <Viewport snapshot={null} frame={null} inspectorActive onInspectorPick={onInspectorPick} />,
+    );
+    pointer("click", 20, 20);
+    expect(onInspectorPick).toHaveBeenCalledWith(5);
+    cleanup();
+  });
+
+  it("does not quick-pick when the Inspector is inactive", () => {
+    const onInspectorPick = vi.fn();
+    render(<Viewport snapshot={null} frame={null} onInspectorPick={onInspectorPick} />);
+    pointer("click", 20, 20);
+    expect(onInspectorPick).not.toHaveBeenCalled();
+    cleanup();
+  });
+});

--- a/tests/ts/components/nodes/FilterNode.test.tsx
+++ b/tests/ts/components/nodes/FilterNode.test.tsx
@@ -157,7 +157,11 @@ describe("FilterNode", () => {
       params: { query: "", bond_query: "" },
     });
     render(<FilterNode {...nodeProps("f1", seeded.data.params as FilterParams)} />);
-    expect(screen.getByText("element, index, x, y, z, resname, mass, molecule_id")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "element, index, x, y, z, resname, resid, chain, mass, molecule_id · within R of (…)",
+      ),
+    ).toBeInTheDocument();
     expect(
       screen.getByText('bond_index, atom_index, element, molecule_id · "both" for AND'),
     ).toBeInTheDocument();

--- a/tests/ts/pipeline/inspectorQuery.test.ts
+++ b/tests/ts/pipeline/inspectorQuery.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+  orGroup,
+  buildQueryFromChips,
+  quickSelectExpression,
+  indicesToExpression,
+} from "@/pipeline/inspectorQuery";
+import { validateQuery } from "@/pipeline/selection";
+
+describe("orGroup", () => {
+  it("returns '' for no values", () => {
+    expect(orGroup("element", [])).toBe("");
+  });
+  it("returns a bare comparison for one value", () => {
+    expect(orGroup("element", ["C"])).toBe('element == "C"');
+  });
+  it("returns a parenthesized OR for several values", () => {
+    expect(orGroup("element", ["C", "N"])).toBe('(element == "C" or element == "N")');
+  });
+});
+
+describe("buildQueryFromChips", () => {
+  it("returns '' when nothing is selected", () => {
+    expect(buildQueryFromChips({})).toBe("");
+  });
+
+  it("ANDs non-empty category groups", () => {
+    const q = buildQueryFromChips({ elements: ["C"], resnames: ["ALA", "GLY"] });
+    expect(q).toBe('element == "C" and (resname == "ALA" or resname == "GLY")');
+    expect(validateQuery(q).valid).toBe(true);
+  });
+
+  it("wraps in within when a positive radius is set", () => {
+    const q = buildQueryFromChips({ resnames: ["HOH"], withinRadius: 5 });
+    expect(q).toBe('within 5 of (resname == "HOH")');
+    expect(validateQuery(q).valid).toBe(true);
+  });
+
+  it("ignores the radius when the base selection is empty", () => {
+    expect(buildQueryFromChips({ withinRadius: 5 })).toBe("");
+  });
+
+  it("ignores a non-positive radius", () => {
+    expect(buildQueryFromChips({ elements: ["C"], withinRadius: 0 })).toBe('element == "C"');
+  });
+
+  it("produces valid queries for chain chips", () => {
+    const q = buildQueryFromChips({ chains: ["A", "B"] });
+    expect(q).toBe('(chain == "A" or chain == "B")');
+    expect(validateQuery(q).valid).toBe(true);
+  });
+});
+
+describe("quickSelectExpression", () => {
+  const atom = { index: 7, element: "Fe", resname: "HEM", chain: "A", moleculeId: 3 };
+  it("selects by element", () => {
+    expect(quickSelectExpression("element", atom)).toBe('element == "Fe"');
+  });
+  it("selects by resname", () => {
+    expect(quickSelectExpression("resname", atom)).toBe('resname == "HEM"');
+  });
+  it("selects by chain", () => {
+    expect(quickSelectExpression("chain", atom)).toBe('chain == "A"');
+  });
+  it("selects by molecule", () => {
+    expect(quickSelectExpression("molecule", atom)).toBe("molecule_id == 3");
+  });
+  it("selects by index", () => {
+    expect(quickSelectExpression("index", atom)).toBe("index == 7");
+  });
+  it("returns '' when a property is missing", () => {
+    expect(quickSelectExpression("resname", { index: 1, element: "C" })).toBe("");
+    expect(quickSelectExpression("molecule", { index: 1, element: "C" })).toBe("");
+  });
+});
+
+describe("indicesToExpression", () => {
+  it("returns 'none' for an empty set", () => {
+    expect(indicesToExpression([])).toBe("none");
+  });
+  it("dedups and sorts indices", () => {
+    expect(indicesToExpression([3, 1, 1, 2])).toBe("index == 1 or index == 2 or index == 3");
+  });
+});

--- a/tests/ts/pipeline/inspectorSync.test.ts
+++ b/tests/ts/pipeline/inspectorSync.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import type { Node, Edge } from "@xyflow/react";
+import type { PipelineNodeData } from "@/pipeline/execute";
+import {
+  reconcileInspectorLayers,
+  layersFromGraph,
+  defaultInspectorAppearance,
+  isInspectorId,
+  type InspectorLayer,
+} from "@/pipeline/inspectorSync";
+import type { ColorParams, ModifyParams, FilterParams } from "@/pipeline/types";
+
+/** A tiny base graph: replicate feeds viewport.particle. */
+function baseGraph(): { nodes: Node<PipelineNodeData>[]; edges: Edge[] } {
+  const nodes: Node<PipelineNodeData>[] = [
+    {
+      id: "replicate-1",
+      type: "replicate",
+      position: { x: 0, y: 0 },
+      data: { params: { type: "replicate", nx: 1, ny: 1, nz: 1 }, enabled: true },
+    },
+    {
+      id: "viewport-1",
+      type: "viewport",
+      position: { x: 0, y: 300 },
+      data: {
+        params: {
+          type: "viewport",
+          perspective: false,
+          cellAxesVisible: true,
+          pivotMarkerVisible: true,
+        },
+        enabled: true,
+      },
+    },
+  ];
+  const edges: Edge[] = [
+    {
+      id: "e-base",
+      source: "replicate-1",
+      target: "viewport-1",
+      sourceHandle: "particle",
+      targetHandle: "particle",
+    },
+  ];
+  return { nodes, edges };
+}
+
+const SOURCE = { nodeId: "replicate-1", handle: "particle" };
+const VP = "viewport-1";
+
+function layer(overrides: Partial<InspectorLayer> = {}): InspectorLayer {
+  return {
+    id: "L1",
+    name: "Layer 1",
+    query: 'element == "C"',
+    appearance: defaultInspectorAppearance(),
+    ...overrides,
+  };
+}
+
+describe("reconcileInspectorLayers", () => {
+  it("emits only a filter node when appearance needs nothing else", () => {
+    const a = defaultInspectorAppearance();
+    a.colorEnabled = false; // default has color on; turn it off
+    const { nodes, edges } = baseGraph();
+    const out = reconcileInspectorLayers(nodes, edges, [layer({ appearance: a })], SOURCE, VP);
+
+    const insp = out.nodes.filter((n) => isInspectorId(n.id));
+    expect(insp.map((n) => n.id)).toEqual(["insp-L1-filter"]);
+    // src → filter, filter → viewport
+    const inspEdges = out.edges.filter(
+      (e) => e.source === "insp-L1-filter" || e.target === "insp-L1-filter",
+    );
+    expect(inspEdges).toHaveLength(2);
+    expect((insp[0].data.params as FilterParams).query).toBe('element == "C"');
+    expect((insp[0].data as { inspectorLayerId?: string }).inspectorLayerId).toBe("L1");
+  });
+
+  it("chains filter → color when color is enabled", () => {
+    const { nodes, edges } = baseGraph();
+    const out = reconcileInspectorLayers(nodes, edges, [layer()], SOURCE, VP);
+    const ids = out.nodes.filter((n) => isInspectorId(n.id)).map((n) => n.id);
+    expect(ids).toContain("insp-L1-filter");
+    expect(ids).toContain("insp-L1-color");
+    // color node terminates at the viewport
+    const toVp = out.edges.find((e) => e.source === "insp-L1-color" && e.target === VP);
+    expect(toVp?.targetHandle).toBe("particle");
+    // filter feeds color
+    expect(
+      out.edges.some((e) => e.source === "insp-L1-filter" && e.target === "insp-L1-color"),
+    ).toBe(true);
+  });
+
+  it("adds a modify node when scale/opacity/visibility change, with opacity 0 when hidden", () => {
+    const a = defaultInspectorAppearance();
+    a.visible = false;
+    const { nodes, edges } = baseGraph();
+    const out = reconcileInspectorLayers(nodes, edges, [layer({ appearance: a })], SOURCE, VP);
+    const modify = out.nodes.find((n) => n.id === "insp-L1-modify");
+    expect(modify).toBeDefined();
+    expect((modify!.data.params as ModifyParams).opacity).toBe(0);
+  });
+
+  it("uses the uniform color on the emitted color node", () => {
+    const a = defaultInspectorAppearance();
+    a.uniformColor = "#123456";
+    const { nodes, edges } = baseGraph();
+    const out = reconcileInspectorLayers(nodes, edges, [layer({ appearance: a })], SOURCE, VP);
+    const color = out.nodes.find((n) => n.id === "insp-L1-color");
+    expect((color!.data.params as ColorParams).uniformColor).toBe("#123456");
+  });
+
+  it("is idempotent: re-running yields the same node ids", () => {
+    const g0 = baseGraph();
+    const g1 = reconcileInspectorLayers(g0.nodes, g0.edges, [layer()], SOURCE, VP);
+    const g2 = reconcileInspectorLayers(g1.nodes, g1.edges, [layer()], SOURCE, VP);
+    const ids1 = g1.nodes.map((n) => n.id).sort();
+    const ids2 = g2.nodes.map((n) => n.id).sort();
+    expect(ids2).toEqual(ids1);
+    // No duplication of inspector nodes.
+    expect(g2.nodes.filter((n) => n.id === "insp-L1-filter")).toHaveLength(1);
+  });
+
+  it("removes a layer's nodes/edges when the layer is dropped", () => {
+    const g0 = baseGraph();
+    const two = [layer({ id: "L1" }), layer({ id: "L2", query: 'element == "N"' })];
+    const g1 = reconcileInspectorLayers(g0.nodes, g0.edges, two, SOURCE, VP);
+    expect(g1.nodes.some((n) => n.id === "insp-L2-filter")).toBe(true);
+
+    const g2 = reconcileInspectorLayers(g1.nodes, g1.edges, [layer({ id: "L1" })], SOURCE, VP);
+    expect(g2.nodes.some((n) => isInspectorId(n.id) && n.id.includes("L2"))).toBe(false);
+    expect(g2.edges.some((e) => e.source.includes("L2") || e.target.includes("L2"))).toBe(false);
+    // L1 survives; base graph untouched.
+    expect(g2.nodes.some((n) => n.id === "insp-L1-filter")).toBe(true);
+    expect(g2.nodes.some((n) => n.id === "replicate-1")).toBe(true);
+    expect(g2.edges.some((e) => e.id === "e-base")).toBe(true);
+  });
+
+  it("leaves non-inspector nodes and edges untouched", () => {
+    const g0 = baseGraph();
+    const g1 = reconcileInspectorLayers(g0.nodes, g0.edges, [layer()], SOURCE, VP);
+    expect(
+      g1.nodes
+        .filter((n) => !isInspectorId(n.id))
+        .map((n) => n.id)
+        .sort(),
+    ).toEqual(["replicate-1", "viewport-1"]);
+    expect(g1.edges.filter((e) => e.id === "e-base")).toHaveLength(1);
+  });
+});
+
+describe("layersFromGraph", () => {
+  it("round-trips layers authored by reconcile", () => {
+    const a = defaultInspectorAppearance();
+    a.representationEnabled = true;
+    a.representation = "licorice";
+    a.scale = 1.5;
+    const input = layer({ id: "L1", query: 'resname == "HOH"', appearance: a });
+
+    const g0 = baseGraph();
+    const g1 = reconcileInspectorLayers(g0.nodes, g0.edges, [input], SOURCE, VP);
+    const recovered = layersFromGraph(g1.nodes);
+
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0].id).toBe("L1");
+    expect(recovered[0].query).toBe('resname == "HOH"');
+    expect(recovered[0].appearance.representationEnabled).toBe(true);
+    expect(recovered[0].appearance.representation).toBe("licorice");
+    expect(recovered[0].appearance.scale).toBe(1.5);
+    expect(recovered[0].appearance.colorEnabled).toBe(true);
+  });
+
+  it("recovers a hidden layer as visible=false", () => {
+    const a = defaultInspectorAppearance();
+    a.visible = false;
+    const g0 = baseGraph();
+    const g1 = reconcileInspectorLayers(g0.nodes, g0.edges, [layer({ appearance: a })], SOURCE, VP);
+    const recovered = layersFromGraph(g1.nodes);
+    expect(recovered[0].appearance.visible).toBe(false);
+  });
+
+  it("returns nothing for a graph with no inspector nodes", () => {
+    expect(layersFromGraph(baseGraph().nodes)).toEqual([]);
+  });
+});

--- a/tests/ts/pipeline/selection.newFields.test.ts
+++ b/tests/ts/pipeline/selection.newFields.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import { evaluateSelection, validateQuery, parseResid } from "@/pipeline/selection";
+import type { Snapshot } from "@/types";
+
+/** Build a small Snapshot, including optional chain IDs, for testing. */
+function makeSnapshot(opts: {
+  nAtoms: number;
+  positions: number[];
+  elements: number[];
+  bonds?: number[];
+  atomChainIds?: number[];
+}): Snapshot {
+  return {
+    nAtoms: opts.nAtoms,
+    nBonds: (opts.bonds?.length ?? 0) / 2,
+    nFileBonds: (opts.bonds?.length ?? 0) / 2,
+    positions: new Float32Array(opts.positions),
+    elements: new Uint8Array(opts.elements),
+    bonds: new Uint32Array(opts.bonds ?? []),
+    bondOrders: null,
+    box: null,
+    boxOrigin: null,
+    atomChainIds: opts.atomChainIds ? new Uint8Array(opts.atomChainIds) : null,
+    atomBFactors: null,
+  };
+}
+
+describe("parseResid", () => {
+  it("extracts the trailing residue number", () => {
+    expect(parseResid("ALA42")).toBe(42);
+    expect(parseResid("GLY1")).toBe(1);
+    expect(parseResid("HIS103")).toBe(103);
+  });
+
+  it("returns NaN when the label has no trailing number", () => {
+    expect(parseResid("HOH")).toBeNaN();
+    expect(parseResid("")).toBeNaN();
+  });
+
+  it("reads the LAST run of digits", () => {
+    // A label like a serial+resname+resid uses the final number as the resid.
+    expect(parseResid("A12ALA42")).toBe(42);
+  });
+});
+
+describe("selection field: chain", () => {
+  // chains: A A B B (atom 4 has no chain → code 0)
+  const snap = makeSnapshot({
+    nAtoms: 5,
+    positions: [0, 0, 0, 1, 0, 0, 2, 0, 0, 3, 0, 0, 4, 0, 0],
+    elements: [6, 6, 6, 6, 6],
+    atomChainIds: [65, 65, 66, 66, 0], // 'A','A','B','B', none
+  });
+
+  it("selects atoms on chain A", () => {
+    expect(evaluateSelection('chain == "A"', snap, null)).toEqual(new Set([0, 1]));
+  });
+
+  it("selects atoms on chain B", () => {
+    expect(evaluateSelection('chain == "B"', snap, null)).toEqual(new Set([2, 3]));
+  });
+
+  it("treats a missing chain code as empty string", () => {
+    expect(evaluateSelection('chain == ""', snap, null)).toEqual(new Set([4]));
+    expect(evaluateSelection('chain != "A"', snap, null)).toEqual(new Set([2, 3, 4]));
+  });
+
+  it("selects nothing for chain when the snapshot has no chain data", () => {
+    const noChain = makeSnapshot({
+      nAtoms: 2,
+      positions: [0, 0, 0, 1, 0, 0],
+      elements: [6, 6],
+    });
+    // Both atoms compare as "" (no chain info).
+    expect(evaluateSelection('chain == "A"', noChain, null)).toEqual(new Set());
+    expect(evaluateSelection('chain == ""', noChain, null)).toEqual(new Set([0, 1]));
+  });
+});
+
+describe("selection field: resid", () => {
+  const snap = makeSnapshot({
+    nAtoms: 4,
+    positions: [0, 0, 0, 1, 0, 0, 2, 0, 0, 3, 0, 0],
+    elements: [7, 6, 8, 6],
+  });
+  const labels = ["ALA1", "ALA1", "GLY2", "GLY2"];
+
+  it("selects atoms by residue number", () => {
+    expect(evaluateSelection("resid == 1", snap, labels)).toEqual(new Set([0, 1]));
+    expect(evaluateSelection("resid == 2", snap, labels)).toEqual(new Set([2, 3]));
+  });
+
+  it("supports numeric ranges on resid", () => {
+    expect(evaluateSelection("resid >= 2", snap, labels)).toEqual(new Set([2, 3]));
+  });
+
+  it("matches nothing when labels are absent (resid → NaN)", () => {
+    expect(evaluateSelection("resid == 1", snap, null)).toEqual(new Set());
+  });
+});
+
+describe("selection: within R of (...)", () => {
+  // A line of atoms 2 Å apart along x: indices 0..4 at x = 0,2,4,6,8
+  const line = makeSnapshot({
+    nAtoms: 5,
+    positions: [0, 0, 0, 2, 0, 0, 4, 0, 0, 6, 0, 0, 8, 0, 0],
+    elements: [8, 6, 6, 6, 6], // O at index 0, rest C
+  });
+
+  it("includes the seed atoms themselves (distance 0)", () => {
+    // within 1 of the O keeps just the O.
+    expect(evaluateSelection('within 1 of (element == "O")', line, null)).toEqual(new Set([0]));
+  });
+
+  it("captures neighbors inside the radius", () => {
+    // within 2 of the O reaches index 1 (2 Å away) but not index 2 (4 Å).
+    expect(evaluateSelection('within 2 of (element == "O")', line, null)).toEqual(new Set([0, 1]));
+  });
+
+  it("captures a wider shell for a larger radius", () => {
+    // within 4 of the O reaches indices 1 (2Å) and 2 (4Å).
+    expect(evaluateSelection('within 4 of (element == "O")', line, null)).toEqual(
+      new Set([0, 1, 2]),
+    );
+  });
+
+  it("selects nothing when the inner selection is empty", () => {
+    expect(evaluateSelection('within 5 of (element == "Xe")', line, null)).toEqual(new Set());
+  });
+
+  it("composes with boolean operators", () => {
+    // Carbons within 2 Å of the oxygen: only index 1.
+    expect(
+      evaluateSelection('element == "C" and within 2 of (element == "O")', line, null),
+    ).toEqual(new Set([1]));
+    // Everything NOT within 2 Å of the oxygen.
+    expect(evaluateSelection('not within 2 of (element == "O")', line, null)).toEqual(
+      new Set([2, 3, 4]),
+    );
+  });
+
+  it("accepts an unparenthesized inner comparison", () => {
+    expect(evaluateSelection('within 2 of element == "O"', line, null)).toEqual(new Set([0, 1]));
+  });
+});
+
+describe("validateQuery: new fields and within", () => {
+  it("accepts chain / resid comparisons", () => {
+    expect(validateQuery('chain == "A"').valid).toBe(true);
+    expect(validateQuery("resid >= 10").valid).toBe(true);
+  });
+
+  it("accepts within expressions", () => {
+    expect(validateQuery('within 5 of (resname == "HOH")').valid).toBe(true);
+  });
+
+  it("rejects within without a radius or 'of'", () => {
+    expect(validateQuery('within of (element == "O")').valid).toBe(false);
+    expect(validateQuery('within 5 (element == "O")').valid).toBe(false);
+  });
+});

--- a/tests/ts/renderer/MoleculeRenderer.previewSelection.test.ts
+++ b/tests/ts/renderer/MoleculeRenderer.previewSelection.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for the Selection Inspector preview overlay and box-select
+ * plumbing on MoleculeRenderer (setPreviewSelection / selectAtomsInRect /
+ * setControlsEnabled). These paths are additive to the measurement selection
+ * and are exercised without a WebGL context by stubbing renderer internals.
+ */
+
+import { describe, it, expect } from "vitest";
+import { MoleculeRenderer } from "@/renderer/MoleculeRenderer";
+import type { Snapshot } from "@/types";
+
+function makeSnapshot(): Snapshot {
+  return {
+    nAtoms: 3,
+    nBonds: 0,
+    positions: new Float32Array([0, 0, 0, 1, 0, 0, 2, 0, 0]),
+    elements: new Uint8Array([6, 7, 8]),
+    bonds: new Uint32Array(0),
+  } as Snapshot;
+}
+
+function makeRenderer() {
+  const renderer = new MoleculeRenderer();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const internals = renderer as any;
+  internals.snapshot = makeSnapshot();
+  return { renderer, internals };
+}
+
+describe("MoleculeRenderer — preview selection", () => {
+  it("draws one highlight sphere per previewed atom", () => {
+    const { renderer, internals } = makeRenderer();
+    renderer.setPreviewSelection([0, 2]);
+    expect(internals.previewSelectionGroup.children.length).toBe(2);
+  });
+
+  it("clears the preview on null/empty", () => {
+    const { renderer, internals } = makeRenderer();
+    renderer.setPreviewSelection([0, 1, 2]);
+    expect(internals.previewSelectionGroup.children.length).toBe(3);
+    renderer.setPreviewSelection(null);
+    expect(internals.previewSelectionGroup.children.length).toBe(0);
+    renderer.setPreviewSelection([]);
+    expect(internals.previewSelectionGroup.children.length).toBe(0);
+  });
+
+  it("does not touch the measurement selection group", () => {
+    const { renderer, internals } = makeRenderer();
+    renderer.setPreviewSelection([0, 1]);
+    expect(internals.selectionGroup.children.length).toBe(0);
+  });
+
+  it("selectAtomsInRect returns [] without a container", () => {
+    const { renderer } = makeRenderer();
+    expect(renderer.selectAtomsInRect({ x0: 0, y0: 0, x1: 10, y1: 10 })).toEqual([]);
+  });
+
+  it("setControlsEnabled toggles the orbit controls flag", () => {
+    const { renderer, internals } = makeRenderer();
+    internals.controls = { enabled: true };
+    renderer.setControlsEnabled(false);
+    expect(internals.controls.enabled).toBe(false);
+    renderer.setControlsEnabled(true);
+    expect(internals.controls.enabled).toBe(true);
+  });
+});

--- a/tests/ts/renderer/Picking.atomsInRect.test.ts
+++ b/tests/ts/renderer/Picking.atomsInRect.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import * as THREE from "three";
+import { atomsInRect } from "@/renderer/Picking";
+import type { Snapshot } from "@/types";
+
+/** 100×100 container anchored at the client origin. */
+const container = {
+  getBoundingClientRect: () => ({
+    left: 0,
+    top: 0,
+    width: 100,
+    height: 100,
+    right: 100,
+    bottom: 100,
+    x: 0,
+    y: 0,
+    toJSON() {},
+  }),
+} as unknown as HTMLElement;
+
+function orthoCamera(): THREE.OrthographicCamera {
+  const cam = new THREE.OrthographicCamera(-10, 10, 10, -10, 0.1, 1000);
+  cam.position.set(0, 0, 50);
+  cam.lookAt(0, 0, 0);
+  cam.updateMatrixWorld(true);
+  cam.matrixWorldInverse.copy(cam.matrixWorld).invert();
+  cam.updateProjectionMatrix();
+  return cam;
+}
+
+function snap(): Snapshot {
+  // index 0 at origin (screen x=50), 1 at +x (x=75), 2 at -x (x=25)
+  return {
+    nAtoms: 3,
+    nBonds: 0,
+    nFileBonds: 0,
+    positions: new Float32Array([0, 0, 0, 5, 0, 0, -5, 0, 0]),
+    elements: new Uint8Array([6, 6, 6]),
+    bonds: new Uint32Array(0),
+    bondOrders: null,
+    box: null,
+    boxOrigin: null,
+    atomChainIds: null,
+    atomBFactors: null,
+  };
+}
+
+describe("atomsInRect", () => {
+  let cam: THREE.OrthographicCamera;
+  let s: Snapshot;
+
+  beforeEach(() => {
+    cam = orthoCamera();
+    s = snap();
+  });
+
+  it("selects only atoms whose projected center is inside the rect", () => {
+    // Left band (x 0..40) captures the -x atom (screen x≈25) only.
+    const got = atomsInRect(cam, container, s, s.positions, { x0: 0, y0: 0, x1: 40, y1: 100 });
+    expect(got).toEqual([2]);
+  });
+
+  it("selects everything when the rect covers the whole viewport", () => {
+    const got = atomsInRect(cam, container, s, s.positions, { x0: 0, y0: 0, x1: 100, y1: 100 });
+    expect(got.sort()).toEqual([0, 1, 2]);
+  });
+
+  it("is corner-order independent", () => {
+    const a = atomsInRect(cam, container, s, s.positions, { x0: 0, y0: 0, x1: 40, y1: 100 });
+    const b = atomsInRect(cam, container, s, s.positions, { x0: 40, y0: 100, x1: 0, y1: 0 });
+    expect(a).toEqual(b);
+  });
+
+  it("returns nothing for a rect over empty space", () => {
+    const got = atomsInRect(cam, container, s, s.positions, { x0: 0, y0: 0, x1: 5, y1: 5 });
+    expect(got).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **third pipeline-panel tab, the Selection Inspector**, alongside Editor and Chat, for OVITO-style *"select a subset of atoms, change how it looks"* without hand-writing expressions.

- **Structure-aware selection** — build a selection by clicking chips for the elements / residues / chains that actually exist in the loaded structure (from `getStructureFacts`), an optional `within R` distance, or the raw expression (kept in sync). Live selected-atom count and a green live highlight in the 3D view.
- **3D picking** — arm **Box select** to rubber-band atoms in the viewer, or click an atom and *quick-expand* to same element / residue / chain / molecule / just-this. Camera rotation is suspended during a box drag.
- **Reflected in the pipeline** — each Inspector *layer* compiles to ordinary `filter → color / representation / modify` nodes via a pure, idempotent reconcile step (deterministic `insp-<layerId>-<role>` ids). The pipeline store is the single source of truth, so a selection made in the Inspector appears verbatim in the **Editor** tab — editing in the Inspector *is* editing the pipeline (Inspector → pipeline authoring).
- **DSL extension** — the selection language gains `chain`, `resid`, and `within R of (…)`, kept in sync with the LLM system prompt, the node catalog, and the Filter node hint (CRITICAL RULE #6).

The Inspector rides on the shared `PipelineEditor`, so it is available in the standalone web app, JupyterLab extension, and VS Code extension. It is intentionally not shown in the in-cell Jupyter widget (which doesn't mount the pipeline editor, per rule #7).

New/changed source: `src/pipeline/{selection,inspectorSync,inspectorQuery,store,catalog}.ts`, `src/ai/{structureSummary,prompt}.ts`, `src/components/{PipelineInspector,PipelineEditor,Viewport,MeganeViewer}.tsx`, `src/components/nodes/FilterNode.tsx`, `src/stores/{usePipelineUIStore,useInspectorInteractionStore}.ts`, `src/renderer/{MoleculeRenderer,Picking}.ts`, docs.

## Test Plan

- [x] `npm test` passes (1889 unit tests; new coverage for the DSL additions, structure facts, layer reconcile/round-trip, query builder, box-select geometry, renderer preview overlay, the Inspector panel, and the Viewport interaction plumbing)
- [ ] `cargo test -p megane-core` — n/a (no Rust changes; the selection DSL is TypeScript-only)
- [ ] `python -m pytest` — n/a (no Python changes)
- [x] Manually verified the change in the browser via a DOM-based `inspector` Playwright project

### E2E notes

- Added Playwright project **`inspector`** (`tests/e2e/inspector.spec.ts`); it asserts DOM/store state (selection built from chips → live count → generated `filter`/`color` nodes reflected in the Editor) rather than pixels, so it is robust to GL/font drift.
- Ran and passed here: `inspector`, `pipeline-editor` (incl. tab-switching).
- The purely **visual-baseline** webapp projects (`webapp`, `resname-filter-opacity`) fail in this sandbox with a large (~86%) pixel diff, but they fail **identically on clean `main`** (verified by stashing this branch) — it is pre-existing environment baseline drift (swiftshader + unoptimized WASM vs. the committed baselines), not a regression from this change. No baselines were re-committed from this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pjAQDfjuPMoWpDSSZ5yek

---
_Generated by [Claude Code](https://claude.ai/code/session_013pjAQDfjuPMoWpDSSZ5yek)_