### PR TITLE
fix(python): narrow optional node id before dict lookup to unblock CI

### DIFF
--- a/python/megane/pipeline.py
+++ b/python/megane/pipeline.py
@@ -1043,7 +1043,7 @@ class Pipeline:
         # Update parent LoadStructure's hasTrajectory flag. Only mark true
         # when there is more than one frame — single-frame sources
         # shouldn't advertise a playable trajectory to the frontend.
-        if trajectory.n_frames > 1 and source._id in self._nodes:
+        if trajectory.n_frames > 1 and source._id is not None and source._id in self._nodes:
             self._nodes[source._id][1]["hasTrajectory"] = True
 
 


### PR DESCRIPTION
## Summary

CI on `main` has been failing the **Python lint & type check** job since 2026-07-23, which blocks every open Dependabot PR (#582–#587) — none of them can reach a mergeable state until `main` is green again.

The failure is a `ty` diagnostic, not a dependency problem:

```
error[invalid-argument-type]: Method `__getitem__` ... cannot be called with key of type `None`
    --> python/megane/pipeline.py:1047:13
1047 |             self._nodes[source._id][1]["hasTrajectory"] = True
```

`PipelineNode._id` is typed `str | None`, and the `source._id in self._nodes` membership test does not narrow the optional away for `ty`. This adds an explicit `is not None` guard so the subscript is statically valid.

Behaviour is unchanged: `_nodes` is only ever keyed by non-`None` ids (see `Pipeline.add_node`), so a `None` id could never have matched the membership test anyway — the guard just makes that invariant explicit.

Verified locally:
- `uvx ty check python/` → `All checks passed!`
- `ruff check python/` → `All checks passed!`
- `ruff format --check python/` → `22 files already formatted`

The changed line is exercised by the existing `LoadStructure` → `LoadTrajectory` wiring tests in `tests/python/test_pipeline.py`, so patch coverage is unaffected.

Not UI-affecting (Python-only change outside the paths listed in CRITICAL RULE #9), so no E2E re-baselining is required.

## Test Plan

- [x] `uvx ty check python/` passes (the failing job's command)
- [x] `ruff check python/` / `ruff format --check python/` pass
- [ ] `npm test` — not run locally; unrelated to this change, covered by CI
- [ ] `cargo test -p megane-core` — not run locally; unrelated to this change, covered by CI
- [ ] `python -m pytest` — not run locally (the `megane` extension is not built in this sandbox); covered by CI
- [ ] Manually verified in the browser — N/A, no UI changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHVCGeT2goDarZpi91aV5J)_