### PR TITLE
test(perf): give the 3k-atom PBC bond budget CI headroom

### DIFF
--- a/tests/ts/performance/inferBondsJS.perf.test.ts
+++ b/tests/ts/performance/inferBondsJS.perf.test.ts
@@ -29,6 +29,18 @@ function benchmark(fn: () => void, iterations: number = 5): number {
   return times[Math.floor(times.length / 2)];
 }
 
+/**
+ * The 30fps frame budget the per-frame bond recalc has to fit in.
+ *
+ * GitHub-hosted runners are shared and noisy: the same 3k-atom PBC benchmark
+ * that sits comfortably under 33ms locally has been observed at 33.8ms and
+ * 35.4ms on CI, which turned this assertion into an intermittent failure that
+ * blocks unrelated PRs. Keep the real budget locally and allow headroom on CI —
+ * a genuine regression (the per-pair min-image math this guards against) costs
+ * 5–6×, not 10%, so the CI budget still catches it.
+ */
+const FRAME_BUDGET_MS = process.env.CI ? 60 : 33;
+
 describe("performance: inferBondsVdwJS", () => {
   it("1,000 atoms completes under 200ms", () => {
     const { positions, elements } = generateAtoms(1_000, 20);
@@ -44,7 +56,7 @@ describe("performance: inferBondsVdwJS", () => {
     const box = new Float32Array([44, 0, 0, 0, 44, 0, 0, 0, 44]);
     const time = benchmark(() => inferBondsVdwJS(positions, elements, 3_000, 0.6, box));
     console.log(`  inferBondsVdwJS 3k atoms (PBC 44A): ${time.toFixed(1)}ms`);
-    expect(time).toBeLessThan(33);
+    expect(time).toBeLessThan(FRAME_BUDGET_MS);
   });
 
   it("PBC inner loop is not dominated by per-pair minimum-image math", () => {


### PR DESCRIPTION
## Summary

Second blocker for the open Dependabot PRs, after the `ty` fix in #588.

`tests/ts/performance/inferBondsJS.perf.test.ts` asserts that the 3,000-atom PBC bond inference stays under a hard 33 ms wall-clock budget. GitHub-hosted runners are shared, and the same benchmark has been measured right at the edge there:

- #587 → `AssertionError: expected 33.83723400000008 to be less than 33`
- #584 → `AssertionError: expected 35.44488999999999 to be less than 33`

So the **TypeScript tests** job fails intermittently and blocks PRs that have nothing to do with bond inference. Every other assertion in this file already carries a large CI cushion (200 ms for 1k atoms, 2000 ms for 10k, `ratio < 50` for the scaling test) — this one was the outlier at roughly 1.0× of the observed CI time.

This keeps the real 30 fps budget locally and allows 60 ms under `CI`. The regression the test guards against — re-introducing per-pair minimum-image math in the PBC inner loop — costs 5–6×, so the relaxed CI budget still catches it; only runner noise is absorbed.

Verified locally:
- `npx vitest run tests/ts/performance/inferBondsJS.perf.test.ts` → 6 passed
- `CI=1 npx vitest run tests/ts/performance/inferBondsJS.perf.test.ts` → 6 passed

Test-only change, no `src/` edits, so it is not UI-affecting under CRITICAL RULE #9 and needs no E2E re-baselining.

## Test Plan

- [x] `npx vitest run tests/ts/performance/inferBondsJS.perf.test.ts` passes (local budget, 33 ms)
- [x] `CI=1 npx vitest run tests/ts/performance/inferBondsJS.perf.test.ts` passes (CI budget, 60 ms)
- [ ] `cargo test -p megane-core` — unaffected by a TS test-only change, covered by CI
- [ ] `python -m pytest` — unaffected by a TS test-only change, covered by CI
- [ ] Manually verified in the browser — N/A, no UI changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHVCGeT2goDarZpi91aV5J)_