### PR TITLE
fix(vscode): inline the gif.js worker so GIF export produces a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **GIF export in the VS Code extension** produced no file: the progress bar advanced and then nothing happened, while PNG and MP4 saved normally. GIF is the only export that spawns a Web Worker (gif.js encodes there), and the webview bundle is built with Vite's default `base: "/"`, so the emitted worker URL was `/gif.worker.js` — the origin root, not the `media/` directory the file actually ships in. gif.js never listens for its worker's `onerror`, so the encode produced no Blob and the extension-host save bridge was never reached. The worker source is now inlined into every host bundle and wrapped in a `blob:` URL at runtime, so it no longer depends on a host's asset base path — the same failure that hit JupyterLab as #497 and VS Code as #599.
 - `serializePipeline` now strips the ephemeral `volumetricData` from Load Volumetric params, which its own type had always documented as "not serialized".
 
 ## [0.10.0] - 2026-07-12

--- a/docs/docs/platform-support.md
+++ b/docs/docs/platform-support.md
@@ -325,12 +325,15 @@ Sources of truth: `crates/megane-wasm/src/lib.rs` (browser parsers), `crates/meg
 | `selection_change` / `measurement` events | ✓ (React props) | ✓ | ✓² | ✓² | ✓ (React props) | n/a |
 | Programmatic frame seek (`frame_index = N`) | ✓ | ✓ | ✓³ | ✓⁴ | ✓ | n/a |
 | Export downloads (render output, pipeline JSON, measurement CSV/JSON) | ✓ | ✓⁵ | ✓ | ✓ (save dialog) | ✓ | n/a |
+| Animation export (GIF)⁶ | ✓ | ✓⁵ | ✓ | ✓ (save dialog) | ✓ | n/a |
 
 ³ JupyterLab: call `meganeReactView.seekFrame(N)` on a `MeganeReactView` instance obtained from the widget tracker. This delegates to `usePlaybackStore.seekFrame(N)` in the viewer.
 
 ⁴ VS Code: call `vscode.commands.executeCommand('megane.seekFrame', N)` from another extension, or call `meganeEditorProvider.seekFrame(N)` on an `MeganeEditorProvider` reference. The command posts a `seekFrame` message to the most recently active megane webview panel.
 
 ⁵ Jupyter widget: export downloads work when the notebook runs in a browser (JupyterLab, Jupyter Notebook). Inside a VS Code notebook the widget renders in a sandboxed webview with no path to the extension host, so downloads are unavailable — see Known gaps.
+
+⁶ GIF is the only export that runs in a Web Worker (gif.js encodes there; MP4 uses MediaRecorder on the main thread). The encoder source is inlined into each host bundle and loaded from a `blob:` URL, so it does not depend on the host's asset base path — resolving it as a URL broke JupyterLab (#497) and VS Code (#599), in both cases hanging the encode instead of erroring. Keep it worker-source-inlined when touching `resolveGifWorkerScript`.
 
 Notes:
 

--- a/jupyterlab-megane/webpack.config.js
+++ b/jupyterlab-megane/webpack.config.js
@@ -51,6 +51,14 @@ module.exports = {
         generator: {
           filename: "[name].[hash][ext]"
         }
+      },
+      // Vite's `?raw` suffix (src/renderer/RenderCapture.ts inlines the gif.js
+      // worker with it) means "import this file as a string". `asset/source` is
+      // webpack's equivalent; without this rule the labextension build fails to
+      // resolve a file literally named `gif.worker.js?raw`.
+      {
+        resourceQuery: /raw/,
+        type: "asset/source"
       }
     ]
   }

--- a/src/components/RenderModal.tsx
+++ b/src/components/RenderModal.tsx
@@ -89,14 +89,18 @@ function TabButton({
   label,
   active,
   onClick,
+  testid,
 }: {
   label: string;
   active: boolean;
   onClick: () => void;
+  testid?: string;
 }) {
   return (
     <button
       onClick={active ? undefined : onClick}
+      data-testid={testid}
+      data-active={active}
       style={{
         flex: 1,
         background: active ? "rgba(59,130,246,0.08)" : "none",
@@ -306,11 +310,13 @@ export function RenderModal({
         <div style={tabContainerStyle}>
           <TabButton
             label="Snapshot"
+            testid="render-modal-tab-snapshot"
             active={mode === "snapshot"}
             onClick={() => setMode("snapshot")}
           />
           <TabButton
             label="Animation"
+            testid="render-modal-tab-animation"
             active={mode === "animation"}
             onClick={() => {
               if (hasAnimation) setMode("animation");
@@ -330,26 +336,31 @@ export function RenderModal({
             <>
               <TabButton
                 label="PNG"
+                testid="render-modal-format-png"
                 active={snapshotFormat === "png"}
                 onClick={() => setSnapshotFormat("png")}
               />
               <TabButton
                 label="EPS"
+                testid="render-modal-format-eps"
                 active={snapshotFormat === "eps"}
                 onClick={() => setSnapshotFormat("eps")}
               />
               <TabButton
                 label="SVG"
+                testid="render-modal-format-svg"
                 active={snapshotFormat === "svg"}
                 onClick={() => setSnapshotFormat("svg")}
               />
               <TabButton
                 label="glTF"
+                testid="render-modal-format-gltf"
                 active={snapshotFormat === "gltf"}
                 onClick={() => setSnapshotFormat("gltf")}
               />
               <TabButton
                 label="OBJ"
+                testid="render-modal-format-obj"
                 active={snapshotFormat === "obj"}
                 onClick={() => setSnapshotFormat("obj")}
               />
@@ -358,11 +369,13 @@ export function RenderModal({
             <>
               <TabButton
                 label="GIF"
+                testid="render-modal-format-gif"
                 active={animationFormat === "gif"}
                 onClick={() => setAnimationFormat("gif")}
               />
               <TabButton
                 label="MP4"
+                testid="render-modal-format-mp4"
                 active={animationFormat === "mp4"}
                 onClick={() => setAnimationFormat("mp4")}
               />
@@ -383,6 +396,7 @@ export function RenderModal({
                 min={1}
                 max={7680}
                 disabled={exporting}
+                data-testid="render-modal-width"
               />
               <span style={{ color: "#94a3b8", fontSize: 12, fontWeight: 600 }}>×</span>
               <input
@@ -393,6 +407,7 @@ export function RenderModal({
                 min={1}
                 max={4320}
                 disabled={exporting}
+                data-testid="render-modal-height"
               />
             </div>
 
@@ -485,6 +500,7 @@ export function RenderModal({
                 min={0}
                 max={endFrame}
                 disabled={exporting}
+                data-testid="render-modal-start-frame"
               />
               <span style={{ color: "#94a3b8", fontSize: 12, fontWeight: 600 }}>–</span>
               <input
@@ -499,6 +515,7 @@ export function RenderModal({
                 min={startFrame}
                 max={totalFrames - 1}
                 disabled={exporting}
+                data-testid="render-modal-end-frame"
               />
             </div>
             <div style={{ fontSize: 11, color: "#94a3b8", marginTop: 4 }}>

--- a/src/renderer/RenderCapture.ts
+++ b/src/renderer/RenderCapture.ts
@@ -5,6 +5,9 @@
 import type { MoleculeRenderer } from "./MoleculeRenderer";
 import { GLTFExporter } from "three/examples/jsm/exporters/GLTFExporter.js";
 import { OBJExporter } from "three/examples/jsm/exporters/OBJExporter.js";
+// The gif.js worker is inlined as source text rather than resolved as a URL at
+// runtime — see resolveGifWorkerScript below for why.
+import gifWorkerSource from "gif.js/dist/gif.worker.js?raw";
 
 /** Composite WebGL canvas and label overlay onto an offscreen canvas. */
 export function compositeCanvases(
@@ -186,38 +189,40 @@ export async function captureSnapshot(
 }
 
 /**
- * Resolve the gif.js worker script into a same-origin `blob:` URL.
+ * Build the gif.js worker script as a same-origin `blob:` URL.
  *
- * gif.js spawns Web Workers from its `workerScript` URL during `render()`.
- * When that URL resolves to a cross-origin or otherwise unfetchable path — as
- * happens inside the JupyterLab labextension, where assets are served from a
- * different base path than the document — the worker either fails to construct
- * or loads a 404 HTML page and throws while parsing. gif.js does not listen for
- * the worker's `onerror`, so the encode hangs silently forever: the GIF progress
- * bar freezes at the frame-capture / encode boundary (80%). MP4 export is
- * unaffected because MediaRecorder needs no worker.
+ * gif.js spawns Web Workers from its `workerScript` URL during `render()` and
+ * never listens for the worker's `onerror`, so *any* failure to load that
+ * script hangs the encode forever: the GIF progress bar freezes at the
+ * frame-capture / encode boundary (80%), no Blob is produced, and the download
+ * (or the host save dialog) is never reached. MP4 export is unaffected because
+ * MediaRecorder needs no worker.
  *
- * Fetching the script ourselves and handing gif.js a same-origin `blob:` URL
- * sidesteps the cross-origin restriction. If the fetch fails we fall back to the
- * raw URL so hosts where the direct path already worked do not regress. See
- * issue #497.
+ * Resolving the worker as a *URL* is host-dependent and has broken twice:
+ *
+ *  - #497 (JupyterLab): the labextension serves its assets from a different
+ *    base path than the document, so the URL 404'd and gif.js parsed an HTML
+ *    error page as JavaScript.
+ *  - #599 (VSCode): the webview bundle is built with Vite's default
+ *    `base: "/"`, so the emitted URL was `/gif.worker.js` — the origin root
+ *    rather than the extension's `media/` directory the file actually ships in.
+ *
+ * Both were the same bug wearing a different host, so the worker source is now
+ * inlined into the bundle at build time and wrapped in a Blob here. There is no
+ * fetch to fail, no base path to get wrong, and nothing for a host CSP to
+ * reject beyond `worker-src blob:`, which every megane host already allows.
  */
-export async function resolveGifWorkerScript(): Promise<string> {
-  const workerUrl = new URL("gif.js/dist/gif.worker.js", import.meta.url).href;
-  try {
-    const response = await fetch(workerUrl);
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
-    const source = await response.text();
-    const blob = new Blob([source], { type: "application/javascript" });
-    return URL.createObjectURL(blob);
-  } catch (err) {
-    console.warn(
-      `megane: could not fetch GIF worker script (${String(err)}); falling back to direct URL`,
+export function resolveGifWorkerScript(source: string = gifWorkerSource): string {
+  // A bundler that silently resolves the `?raw` import to something other than
+  // the worker source would reintroduce the silent hang, so fail loudly here
+  // instead of handing gif.js a script that can never post a frame back.
+  if (!source || !source.includes("onmessage")) {
+    throw new Error(
+      "megane: the bundled gif.js worker source is missing or invalid; GIF export cannot start",
     );
-    return workerUrl;
   }
+  const blob = new Blob([source], { type: "application/javascript" });
+  return URL.createObjectURL(blob);
 }
 
 /** Capture animation frames as GIF using gif.js. */
@@ -254,7 +259,7 @@ export async function captureGif(
 
   // Dynamically import gif.js
   const GIF = (await import("gif.js")).default;
-  const workerScript = await resolveGifWorkerScript();
+  const workerScript = resolveGifWorkerScript();
   const gif = new GIF({
     workers: 2,
     quality: 10,
@@ -289,11 +294,7 @@ export async function captureGif(
 
   // Render GIF
   return new Promise((resolve, reject) => {
-    const cleanup = () => {
-      if (workerScript.startsWith("blob:")) {
-        URL.revokeObjectURL(workerScript);
-      }
-    };
+    const cleanup = () => URL.revokeObjectURL(workerScript);
     gif.on("finished", (blob: Blob) => {
       cleanup();
       onProgress?.(1);

--- a/tests/e2e/jupyterlab-doc.spec.ts
+++ b/tests/e2e/jupyterlab-doc.spec.ts
@@ -24,6 +24,7 @@ import {
   openLabFile,
   type JupyterLabHandle,
 } from "./lib/hosts/jupyterlab";
+import { expectGifFile, openRenderModal, useSmallGifExport } from "./lib/render-modal";
 
 const PLATFORM = "jupyterlab-doc";
 
@@ -165,4 +166,42 @@ test("DocWidget recovers when switching between two open files", async ({ page }
   });
   expect(visibleAtoms, "second-opened file should drive the visible viewer").toBeGreaterThan(0);
   expect(visibleAtoms).not.toBe(327);
+});
+
+/**
+ * Regression test for issue #497 — the JupyterLab half of the GIF-export bug
+ * whose VSCode twin is #599 (see tests/e2e/vscode.spec.ts).
+ *
+ * gif.js encodes in a Web Worker, and the labextension serves its assets from
+ * a different base path than the document, so resolving that worker as a URL
+ * used to 404 and feed gif.js an HTML error page. gif.js never listens for its
+ * worker's onerror, so the encode froze at 80% and produced no download at all.
+ * The unit tests pin the worker-source contract; only a real browser proves the
+ * bundled labextension can actually finish an encode.
+ */
+test("GIF export completes in the DocWidget (issue #497)", async ({ page }) => {
+  await openLabFile(page, { port: PORT, token: TOKEN, file: "water_multiframe.xyz" });
+
+  const viewer = page.locator('[data-testid="megane-viewer"]').last();
+  await expect(viewer).toHaveAttribute("data-megane-context", "jupyterlab-doc");
+  expect(Number(await viewer.getAttribute("data-total-frames"))).toBeGreaterThan(1);
+
+  // Export failures surface as an alert(); report its text rather than waiting
+  // out the download timeout.
+  let exportError: string | null = null;
+  page.on("dialog", (dialog) => {
+    exportError = dialog.message();
+    void dialog.dismiss();
+  });
+
+  await openRenderModal(page);
+  await useSmallGifExport(page);
+
+  const download = page.waitForEvent("download", { timeout: 120_000 });
+  await page.locator('[data-testid="render-modal-export"]').click();
+
+  const file = await download;
+  expect(exportError, `export alert: ${exportError}`).toBeNull();
+  expect(file.suggestedFilename()).toBe("megane-render.gif");
+  expectGifFile(await file.path());
 });

--- a/tests/e2e/lib/render-modal.ts
+++ b/tests/e2e/lib/render-modal.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared driver for the Render modal's animation tab.
+ *
+ * GIF export is the one export path that needs a Web Worker (gif.js encodes
+ * there; MP4 uses MediaRecorder on the main thread), which makes it the path
+ * that breaks per-host — see issues #497 (JupyterLab) and #599 (VSCode). Every
+ * host that mounts the pipeline editor drives the same flow, so the setup lives
+ * here rather than being duplicated per spec.
+ */
+
+import { readFileSync } from "fs";
+import { expect, type Frame, type Page } from "playwright/test";
+
+/** Set a controlled number input by testid, so React's onChange fires. */
+async function setNumber(scope: Page | Frame, testid: string, value: number): Promise<void> {
+  const input = scope.locator(`[data-testid="${testid}"]`);
+  await input.fill(String(value));
+  await expect(input).toHaveValue(String(value));
+}
+
+/**
+ * Open the Render modal. The pipeline panel that hosts the Render button starts
+ * collapsed when the viewport is narrow (< 768px) — which it is inside the
+ * code-server webview — so expand it first.
+ */
+export async function openRenderModal(scope: Page | Frame): Promise<void> {
+  const panel = scope.locator('[data-testid="panel-pipeline"]');
+  if ((await panel.getAttribute("data-collapsed")) === "true") {
+    await scope.locator('[data-testid="panel-pipeline-toggle"]').click();
+    await expect(panel).toHaveAttribute("data-collapsed", "false");
+  }
+
+  await scope.locator('[data-testid="pipeline-editor-render"]').click();
+  await expect(scope.locator('[data-testid="render-modal"]')).toBeVisible();
+}
+
+/**
+ * Switch an already-open Render modal to a deliberately tiny GIF export.
+ *
+ * The encode runs under software GL in E2E, so keep the resolution and frame
+ * count small: the point is whether the worker loads at all, not throughput.
+ */
+export async function useSmallGifExport(
+  scope: Page | Frame,
+  opts: { width?: number; endFrame?: number } = {},
+): Promise<void> {
+  const { width = 160, endFrame = 1 } = opts;
+
+  const animationTab = scope.locator('[data-testid="render-modal-tab-animation"]');
+  await expect(animationTab).toBeVisible();
+  await animationTab.click();
+  await expect(animationTab).toHaveAttribute("data-active", "true");
+
+  // GIF is the default animation format; only click when something changed it.
+  const gifFormat = scope.locator('[data-testid="render-modal-format-gif"]');
+  if ((await gifFormat.getAttribute("data-active")) !== "true") {
+    await gifFormat.click();
+  }
+  await expect(gifFormat).toHaveAttribute("data-active", "true");
+
+  await setNumber(scope, "render-modal-width", width);
+  await setNumber(scope, "render-modal-start-frame", 0);
+  await setNumber(scope, "render-modal-end-frame", endFrame);
+}
+
+/**
+ * Assert that a written export really is a GIF.
+ *
+ * A hung worker produced no file at all, and a worker handed an HTML error page
+ * (the #497 shape) could resolve with something that is not a GIF — so check
+ * the magic bytes rather than mere existence.
+ */
+export function expectGifFile(path: string): void {
+  const bytes = readFileSync(path);
+  expect(bytes.subarray(0, 4).toString("latin1")).toBe("GIF8");
+  expect(bytes.byteLength).toBeGreaterThan(100);
+}

--- a/tests/e2e/render-modal.spec.ts
+++ b/tests/e2e/render-modal.spec.ts
@@ -9,6 +9,7 @@
 
 import { test, expect } from "playwright/test";
 import { defaultViewerContract, assertDomContract, waitForReady } from "./lib/setup";
+import { expectGifFile, useSmallGifExport } from "./lib/render-modal";
 
 const PLATFORM = "render-modal";
 
@@ -40,10 +41,39 @@ test.describe("render-modal: webapp", () => {
     void PLATFORM;
   });
 
+  // Regression coverage for issues #497 / #599: gif.js loads its encoder as a
+  // Web Worker, and when that worker script cannot be loaded it hangs at 80%
+  // instead of erroring — no Blob, no download, no save dialog. Only a real
+  // browser exercising the built bundle can catch it, so assert an actual GIF
+  // lands on disk rather than mocking the encoder.
+  test("exports a GIF (gif.js worker must load)", async ({ page }) => {
+    await page.locator('[data-testid="pipeline-editor-render"]').click();
+    await expect(page.locator('[data-testid="render-modal"]')).toBeVisible();
+
+    // Export failures surface as an alert(); fail with its text instead of
+    // waiting out the download timeout.
+    let exportError: string | null = null;
+    page.on("dialog", (dialog) => {
+      exportError = dialog.message();
+      void dialog.dismiss();
+    });
+
+    await useSmallGifExport(page);
+
+    const download = page.waitForEvent("download", { timeout: 120_000 });
+    await page.locator('[data-testid="render-modal-export"]').click();
+
+    const file = await download;
+    expect(exportError, `export alert: ${exportError}`).toBeNull();
+    expect(file.suggestedFilename()).toBe("megane-render.gif");
+
+    expectGifFile(await file.path());
+  });
+
   test("animation export gated on MEGANE_E2E_FFMPEG", async () => {
     test.skip(
       process.env.MEGANE_E2E_FFMPEG !== "1",
-      "GIF/MP4 export requires MEGANE_E2E_FFMPEG=1 + ffmpeg on PATH",
+      "MP4 export requires MEGANE_E2E_FFMPEG=1 + ffmpeg on PATH",
     );
     // Implementation lands when ffmpeg is gated in.
   });

--- a/tests/e2e/vscode.spec.ts
+++ b/tests/e2e/vscode.spec.ts
@@ -15,7 +15,7 @@
  * `window.__MEGANE_TEST__ = true` before the bundle loads.
  */
 
-import { copyFileSync, existsSync, mkdirSync, rmSync } from "fs";
+import { copyFileSync, existsSync, mkdirSync, rmSync, statSync } from "fs";
 import { join } from "path";
 import { fileURLToPath } from "url";
 import { test, expect } from "playwright/test";
@@ -25,6 +25,7 @@ import {
   expectFullPageMatch,
   expectViewerRegionMatch,
 } from "./lib/setup";
+import { expectGifFile, openRenderModal, useSmallGifExport } from "./lib/render-modal";
 import {
   startCodeServer,
   stopCodeServer,
@@ -121,17 +122,7 @@ test("render export is saved through the extension-host saveFile bridge", async 
     ...defaultViewerContract({ expectedAtoms: 327, context: "vscode" }),
   ]);
 
-  // The pipeline panel (which hosts the Render button) starts collapsed when
-  // the webview iframe is narrow (< 768px), which it is under code-server.
-  // Expand it first so the Render button is visible.
-  const panel = wv.locator('[data-testid="panel-pipeline"]');
-  if ((await panel.getAttribute("data-collapsed")) === "true") {
-    await wv.locator('[data-testid="panel-pipeline-toggle"]').click();
-    await expect(panel).toHaveAttribute("data-collapsed", "false");
-  }
-
-  await wv.locator('[data-testid="pipeline-editor-render"]').click();
-  await expect(wv.locator('[data-testid="render-modal"]')).toBeVisible();
+  await openRenderModal(wv);
   await wv.locator('[data-testid="render-modal-export"]').click();
 
   await expect
@@ -140,4 +131,47 @@ test("render export is saved through the extension-host saveFile bridge", async 
       timeout: 60_000,
     })
     .toBe(true);
+});
+
+/**
+ * Regression test for issue #599: "Cannot find rendered GIF file".
+ *
+ * PNG/MP4 export worked in the VSCode webview while GIF silently hung at 80%,
+ * because GIF is the only export that spawns a Web Worker: gif.js loaded its
+ * worker from a URL the webview could not serve, and it never listens for the
+ * worker's onerror, so no Blob was produced and the saveFile bridge (and with
+ * it the save dialog) was never reached.
+ *
+ * This asserts the file actually lands on disk. It only holds inside a real
+ * webview — the host CSP, the `vscode-webview` origin, and the built bundle's
+ * asset URLs are all part of the bug — so it cannot be moved to a unit test or
+ * to the webapp project, which serves from the origin root and never failed.
+ */
+test("GIF export reaches the saveFile bridge (issue #599)", async ({ page }) => {
+  const exported = join(WORKSPACE, "megane-render.gif");
+  rmSync(exported, { force: true });
+
+  // A trajectory is required — the Animation tab is disabled for single-frame
+  // structures.
+  const wv = await openVscodeFile(page, { port: PORT, file: "water_multiframe.xyz" });
+  await assertDomContract(wv, [...defaultViewerContract({ context: "vscode" })]);
+
+  const viewer = wv.locator('[data-testid="megane-viewer"]');
+  expect(Number(await viewer.getAttribute("data-total-frames"))).toBeGreaterThan(1);
+
+  await openRenderModal(wv);
+  await useSmallGifExport(wv);
+
+  await wv.locator('[data-testid="render-modal-export"]').click();
+
+  await expect
+    .poll(() => (existsSync(exported) ? statSync(exported).size : 0), {
+      message:
+        "expected the extension host to write megane-render.gif into the workspace — " +
+        "an empty poll means gif.js never finished encoding (the #599 hang)",
+      timeout: 180_000,
+    })
+    .toBeGreaterThan(100);
+
+  expectGifFile(exported);
 });

--- a/tests/ts/components/RenderModal.test.tsx
+++ b/tests/ts/components/RenderModal.test.tsx
@@ -268,3 +268,64 @@ describe("RenderModal", () => {
     expect(screen.getByText("Resolution")).toBeTruthy();
   });
 });
+
+// The GIF export E2E (tests/e2e/lib/render-modal.ts, guarding issues #497 and
+// #599) drives the modal entirely through these testids. Renaming one would
+// otherwise surface as a Playwright timeout in the VSCode project — which needs
+// code-server and only runs locally — so pin the contract here instead.
+describe("RenderModal: animation export testids", () => {
+  function renderTrajectoryModal() {
+    return render(
+      <RenderModal
+        open
+        onClose={() => {}}
+        rendererRef={makeRendererRef()}
+        totalFrames={5}
+        currentFrame={0}
+        onSeek={() => {}}
+      />,
+    );
+  }
+
+  it("marks the active tab and format so E2E can await the switch", () => {
+    renderTrajectoryModal();
+
+    const snapshotTab = screen.getByTestId("render-modal-tab-snapshot");
+    const animationTab = screen.getByTestId("render-modal-tab-animation");
+    expect(snapshotTab.getAttribute("data-active")).toBe("true");
+    expect(animationTab.getAttribute("data-active")).toBe("false");
+
+    fireEvent.click(animationTab);
+
+    expect(screen.getByTestId("render-modal-tab-animation").getAttribute("data-active")).toBe(
+      "true",
+    );
+    // GIF is the default animation format, and the E2E relies on that default.
+    expect(screen.getByTestId("render-modal-format-gif").getAttribute("data-active")).toBe("true");
+    expect(screen.getByTestId("render-modal-format-mp4").getAttribute("data-active")).toBe("false");
+  });
+
+  it("exposes the resolution and frame-range inputs the GIF export drives", () => {
+    renderTrajectoryModal();
+    fireEvent.click(screen.getByTestId("render-modal-tab-animation"));
+
+    const width = screen.getByTestId("render-modal-width") as HTMLInputElement;
+    fireEvent.change(width, { target: { value: "160" } });
+    expect((screen.getByTestId("render-modal-width") as HTMLInputElement).value).toBe("160");
+    // Aspect stays locked by default, so height follows the 800×600 canvas.
+    expect((screen.getByTestId("render-modal-height") as HTMLInputElement).value).toBe("120");
+
+    const endFrame = screen.getByTestId("render-modal-end-frame") as HTMLInputElement;
+    expect(endFrame.value).toBe("4");
+    fireEvent.change(endFrame, { target: { value: "1" } });
+    expect((screen.getByTestId("render-modal-end-frame") as HTMLInputElement).value).toBe("1");
+    expect((screen.getByTestId("render-modal-start-frame") as HTMLInputElement).value).toBe("0");
+  });
+
+  it("keeps the snapshot format testids addressable", () => {
+    renderTrajectoryModal();
+    for (const fmt of ["png", "eps", "svg", "gltf", "obj"]) {
+      expect(screen.getByTestId(`render-modal-format-${fmt}`)).toBeTruthy();
+    }
+  });
+});

--- a/tests/ts/renderer/RenderCapture.test.ts
+++ b/tests/ts/renderer/RenderCapture.test.ts
@@ -349,17 +349,38 @@ describe("captureObj", () => {
   });
 });
 
-// Regression coverage for issue #497: GIF export freezes at 80% in JupyterLab
-// because gif.js cannot load its Web Worker from the raw workerScript URL and
-// hangs silently during encode. The fix fetches the worker source and hands
-// gif.js a same-origin blob: URL instead.
-describe("resolveGifWorkerScript (issue #497)", () => {
+// Regression coverage for issues #497 (JupyterLab) and #599 (VSCode): GIF
+// export freezes at 80% and never produces a file because gif.js cannot load
+// its Web Worker and hangs silently during encode instead of erroring. Both
+// hosts failed on the *URL* — a labextension base path in #497, Vite's default
+// `base: "/"` emitting `/gif.worker.js` for the VSCode webview in #599 — so the
+// worker source is inlined at build time and only ever handed to gif.js as a
+// blob: URL built in-process.
+describe("resolveGifWorkerScript (issues #497, #599)", () => {
   let createObjectURL: ReturnType<typeof vi.fn>;
+  let blobs: BlobPart[][];
 
   beforeEach(() => {
-    createObjectURL = vi.fn().mockReturnValue("blob:gif-worker-url");
+    blobs = [];
+    createObjectURL = vi.fn((blob: Blob) => {
+      void blob;
+      return "blob:gif-worker-url";
+    });
     Object.defineProperty(URL, "createObjectURL", { value: createObjectURL, configurable: true });
     Object.defineProperty(URL, "revokeObjectURL", { value: vi.fn(), configurable: true });
+
+    // Capture what gets wrapped: asserting on the Blob's contents is the only
+    // way to prove the real worker source (not an HTML error page) is used.
+    const RealBlob = globalThis.Blob;
+    vi.stubGlobal(
+      "Blob",
+      class extends RealBlob {
+        constructor(parts: BlobPart[] = [], options?: BlobPropertyBag) {
+          super(parts, options);
+          blobs.push(parts);
+        }
+      },
+    );
   });
 
   afterEach(() => {
@@ -367,42 +388,43 @@ describe("resolveGifWorkerScript (issue #497)", () => {
     vi.unstubAllGlobals();
   });
 
-  it("fetches the worker script and returns a same-origin blob: URL", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      text: () => Promise.resolve("self.onmessage = () => {};"),
-    });
+  it("returns a blob: URL built from the bundled worker source", () => {
+    const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
-    const script = await resolveGifWorkerScript();
+    const script = resolveGifWorkerScript();
 
-    // The bug: the old code passed the raw worker URL straight to gif.js without
-    // ever fetching it. A correct implementation must fetch and wrap it.
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock.mock.calls[0][0]).toContain("gif.worker.js");
-    expect(createObjectURL).toHaveBeenCalledTimes(1);
     expect(script).toBe("blob:gif-worker-url");
-    expect(script.startsWith("blob:")).toBe(true);
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    // The bug in both #497 and #599 was a worker URL resolved against a host
+    // base path. Nothing may be fetched over the network: a URL that has to be
+    // retrieved is a URL that a host can serve a 404 page for.
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("falls back to the direct URL when the fetch fails", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue({ ok: false, status: 404, text: () => Promise.resolve("") });
-    vi.stubGlobal("fetch", fetchMock);
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("wraps the real gif.js worker source, not a placeholder", () => {
+    resolveGifWorkerScript();
 
-    const script = await resolveGifWorkerScript();
+    const source = String(blobs.at(-1)?.[0] ?? "");
+    expect(source).toContain("gif.worker.js");
+    expect(source).toContain("onmessage");
+    // Bundled as source text, so it must be substantially larger than any
+    // stub — the real worker is ~16 KB.
+    expect(source.length).toBeGreaterThan(5000);
+  });
 
+  it("throws instead of hanging when the bundled source is unusable", () => {
+    // A bundler that resolved `?raw` to an empty string or an HTML error page
+    // would otherwise reproduce the original silent freeze at 80%.
+    expect(() => resolveGifWorkerScript("")).toThrow(/gif\.js worker source/);
+    expect(() => resolveGifWorkerScript("<!DOCTYPE html><html></html>")).toThrow(
+      /gif\.js worker source/,
+    );
     expect(createObjectURL).not.toHaveBeenCalled();
-    expect(script.startsWith("blob:")).toBe(false);
-    expect(script).toContain("gif.worker.js");
-    expect(warn).toHaveBeenCalled();
   });
 });
 
-describe("captureGif (issue #497)", () => {
+describe("captureGif (issues #497, #599)", () => {
   let createObjectURL: ReturnType<typeof vi.fn>;
   let revokeObjectURL: ReturnType<typeof vi.fn>;
 
@@ -426,12 +448,12 @@ describe("captureGif (issue #497)", () => {
     Object.defineProperty(URL, "createObjectURL", { value: createObjectURL, configurable: true });
     Object.defineProperty(URL, "revokeObjectURL", { value: revokeObjectURL, configurable: true });
 
+    // No fetch stub: the worker source is inlined at build time, so an encode
+    // that reaches the network at all is the #497 / #599 bug coming back.
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        text: () => Promise.resolve("self.onmessage = () => {};"),
+      vi.fn(() => {
+        throw new Error("captureGif must not fetch the gif.js worker");
       }),
     );
   });


### PR DESCRIPTION
GIF export in the VS Code extension advanced its progress bar and then
produced nothing — no file, no save dialog — while PNG and MP4 saved
normally (#599).

GIF is the only export that spawns a Web Worker: gif.js encodes there,
while MP4 uses MediaRecorder on the main thread. The webview bundle is
built with Vite's default `base: "/"`, so the worker URL emitted into
media/webview.js was `/gif.worker.js` — the origin root, not the
extension's media/ directory the file actually ships in. gif.js never
listens for its worker's onerror, so the encode never yielded a Blob and
the extension-host saveFile bridge was never reached.

Resolving that worker as a URL is host-dependent and had already broken
once as #497 (JupyterLab base path), where the fix was to fetch the URL
and wrap it in a blob:. That still assumed the URL resolved. Inline the
worker source into every host bundle instead and build the blob from it,
so there is no fetch to fail and no base path to get wrong;
resolveGifWorkerScript now throws on unusable source rather than handing
gif.js a script that can only hang.

The labextension is webpack-built and cannot parse Vite's `?raw`, so add
the equivalent `resourceQuery: /raw/ -> asset/source` rule.

Tests:
- E2E vscode: "GIF export reaches the saveFile bridge (issue #599)"
  drives the real webview and asserts the GIF lands in the workspace.
  Verified it fails on the pre-fix build (no file written) and passes
  after.
- E2E jupyterlab-doc: same flow for the #497 host.
- E2E render-modal: GIF download on the webapp, checking GIF8 magic.
- Unit: resolveGifWorkerScript must not fetch, must wrap the real worker
  source, and must throw on empty/HTML source; RenderModal pins the
  testids the E2E drives.

Adds data-testid/data-active to the Render modal tabs, format buttons,
resolution and frame-range inputs so the export flow is drivable.

Closes #599

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011uRUVg9g86cnJcLcnZtFFk