### PR TITLE
docs: catch the docs site up with the formats and nodes that shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@
 ## Features
 
 - **1M+ Atoms at 60fps** — Billboard impostor rendering scales from small molecules to massive complexes in real time. InstancedMesh for small systems auto-switches to GPU-accelerated billboard impostors for large systems. Stream XTC trajectories over WebSocket.
-- **Runs Everywhere** — Jupyter widget, standalone web app (`megane serve`), React component (npm), and VS Code extension. Rust-based parsers for 25 formats (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, mmCIF, CML, LAMMPS data, AMBER topology, XTC, DCD, ASE .traj, LAMMPS dump, AMBER NetCDF, VASP, Molden, XCrySDen XSF, JCAMP-DX, Chem3D XML, Odyssey, CASTEP magres, GAMESS output, CASTEP phonon) shared between Python (PyO3) and browser (WASM) — parse once, run anywhere.
-- **Visual Pipeline Editor** — Build visualization workflows by wiring nodes or let the AI generator build them from natural language. 16 node types with 7 typed data channels flowing through color-coded edges. Load multiple structures with layer-based rendering to compare systems side by side.
+- **Runs Everywhere** — Jupyter widget, standalone web app (`megane serve`), React component (npm), and VS Code extension. Rust-based parsers for 26 formats (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, mmCIF, CML, LAMMPS data, AMBER topology, GROMACS topology, CHARMM/NAMD PSF, XTC, DCD, ASE .traj, LAMMPS dump, AMBER NetCDF, VASP, Molden, XCrySDen XSF, JCAMP-DX, Chem3D XML, Odyssey, CASTEP magres, GAMESS output, CASTEP phonon) shared between Python (PyO3) and browser (WASM) — parse once, run anywhere.
+- **Visual Pipeline Editor** — Build visualization workflows by wiring nodes or let the AI generator build them from natural language. 19 node types with 9 typed data channels flowing through color-coded edges. Load multiple structures with layer-based rendering to compare systems side by side.
 - **Embed & Integrate** — Control the viewer from Plotly via ipywidgets events. Embed in MDX / Next.js docs. React to `frame_change`, `selection_change`, and `measurement` events. Use the framework-agnostic renderer from Vue, Svelte, or vanilla JS.
 
 ### Scale
@@ -62,9 +62,9 @@ The secret: parsers for 26 formats (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, mmCIF, CM
 
 Wire nodes to build visualization workflows — no code required.
 
-**16 node types** across 5 categories: load data (structure, trajectory, streaming, vector, volumetric), bonds, process (filter, modify, color, representation), overlay (labels, polyhedra, surface meshes, isosurfaces, vectors), and display in a 3D viewport.
+**19 node types** across 5 categories: load data (structure, trajectory, streaming, vector, volumetric, spectrum), bonds, process (filter, modify, color, representation, replicate), overlay (labels, polyhedra, surface meshes, isosurfaces, vectors), and display in a 3D viewport or a 2D spectrum plot.
 
-**8 typed data channels** — particle, bond, cell, label, mesh, trajectory, vector, volumetric — flow through color-coded edges. Only matching types can connect.
+**9 typed data channels** — particle, bond, cell, label, mesh, trajectory, vector, volumetric, spectrum — flow through color-coded edges. Only matching types can connect.
 
 Pipelines serialize to JSON, so you can save, share, and version-control your visualization recipes.
 
@@ -266,7 +266,7 @@ make test-all              # All tests
 src/                     TypeScript frontend
   renderer/              Three.js rendering (impostor, mesh, shaders)
   protocol/              Binary protocol decoder + web workers
-  parsers/               WASM-based file parsers (25 formats: PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, mmCIF, CML, LAMMPS data/dump, AMBER topology/NetCDF, XTC, DCD, ASE .traj, VASP, Molden, XCrySDen XSF, JCAMP-DX, Chem3D XML, Odyssey, CASTEP magres, GAMESS output, CASTEP phonon)
+  parsers/               WASM-based file parsers (26 formats: PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, mmCIF, CML, LAMMPS data/dump, AMBER topology/NetCDF, GROMACS topology, CHARMM/NAMD PSF, XTC, DCD, ASE .traj, VASP, Molden, XCrySDen XSF, JCAMP-DX, Chem3D XML, Odyssey, CASTEP magres, GAMESS output, CASTEP phonon)
   logic/                 Bond / label / vector source logic
   components/            React UI components
   hooks/                 Custom React hooks

--- a/docs/docs/dev/architecture.md
+++ b/docs/docs/dev/architecture.md
@@ -10,7 +10,7 @@ megane's visual pipeline is built on three core principles:
 
 ### Typed Data Flow
 
-The pipeline is a directed acyclic graph where edges carry one of **8 typed data channels**: `particle`, `bond`, `cell`, `trajectory`, `label`, `mesh`, `vector`, and `volumetric`. Nodes declare typed input/output ports via `NODE_PORTS` in `src/pipeline/types.ts`. The UI prevents connections between incompatible port types at the graph level (see `canConnect()`), so executors can trust that incoming data has the expected shape.
+The pipeline is a directed acyclic graph where edges carry one of **9 typed data channels**: `particle`, `bond`, `cell`, `trajectory`, `label`, `mesh`, `vector`, `volumetric`, and `spectrum`. Nodes declare typed input/output ports via `NODE_PORTS` in `src/pipeline/types.ts`. The UI prevents connections between incompatible port types at the graph level (see `canConnect()`), so executors can trust that incoming data has the expected shape.
 
 ### Separation of Computation and Rendering
 
@@ -55,7 +55,7 @@ flowchart TB
 
 ## Pipeline Data Types
 
-Eight typed channels flow through pipeline edges. Defined in `src/pipeline/types.ts`.
+Nine typed channels flow through pipeline edges. Defined in `src/pipeline/types.ts`.
 
 | Channel | Interface | Key Fields | Produced By | Consumed By |
 |---------|-----------|------------|-------------|-------------|
@@ -67,6 +67,7 @@ Eight typed channels flow through pipeline edges. Defined in `src/pipeline/types
 | `mesh` | `MeshData` | `positions`, `indices`, `normals`, `colors` | PolyhedronGenerator, SurfaceMesh, Isosurface | Viewport |
 | `vector` | `VectorData` | `frames` (VectorFrame[]), `scale` | LoadVector, VectorOverlay | VectorOverlay, Viewport |
 | `volumetric` | `VolumetricData` | `nx`, `ny`, `nz`, `origin`, `step`, `data` | LoadVolumetric | Isosurface |
+| `spectrum` | `SpectrumData` | `title`, `dataType`, `xUnits`, `yUnits`, `x`, `y` | LoadSpectrum | SpectrumPlot |
 
 Each edge in the UI is color-coded by data type (`DATA_TYPE_COLORS`). Filter and Modify nodes are generic — they accept both `particle` and `bond` inputs via `GENERIC_NODE_ACCEPTS`. The Color and Representation nodes are particle-only modifiers that share the same Modify category in the toolbar (Ovito-style stack: each modifier owns one visual property — Modify = scale & opacity, Color = per-atom palette, Representation = atoms/licorice/cartoon/both/surface/line).
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -95,19 +95,33 @@ For multiple independent viewers per page (e.g. embedding in MDX docs), use
 |--------|-----------|-------------|
 | PDB | `.pdb` | Protein Data Bank — most common molecular structure format |
 | GRO | `.gro` | GROMACS structure file |
-| XYZ | `.xyz` | Simple cartesian coordinate format (single- or multi-frame) |
+| XYZ | `.xyz`, `.jxyz` | Simple cartesian coordinate format (single- or multi-frame); `.jxyz` is Jmol's second name for it |
 | MOL | `.mol` | MDL Molfile (V2000) — small molecules with bond information |
 | SDF | `.sdf` | MDL SDfile — uses the MOL V2000 parser |
 | MOL2 | `.mol2` | Tripos MOL2 |
-| CIF | `.cif` | Crystallographic Information File |
+| CIF | `.cif` | Crystallographic Information File — the asymmetric unit is expanded to the full cell on load |
 | mmCIF | `.mmcif` | Macromolecular CIF (PDBx/mmCIF) — large structure databases |
 | LAMMPS data | `.data`, `.lammps` | LAMMPS data file |
 | AMBER topology | `.prmtop` | AMBER parameter/topology file (no coordinates) |
+| VASP | `POSCAR`, `CONTCAR`, `XDATCAR`, `.vasp` | VASP crystal structure; `XDATCAR` is multi-frame. Matched by filename as well as extension |
+| Molden | `.molden` | Molden output — `[Atoms]` geometry and `[GEOMETRIES] XYZ` optimisation frames |
+| XCrySDen | `.xsf`, `.axsf` | XCrySDen structure; `.axsf` is a multi-frame animation with optional per-atom forces |
+| CML | `.cml` | Chemical Markup Language (Open Babel / Avogadro / ChemDraw) |
+| Chem3D XML | `.c3xml` | PerkinElmer Chem3D / ChemDraw XML |
+| Odyssey | `.xodydata`, `.odydata` | Wavefunction Odyssey — XML and older Spartan-style text layouts |
+| CASTEP magres | `.magres` | CASTEP / Quantum ESPRESSO NMR output — the `[atoms]` block |
+| GAMESS output | `.gamess` | GAMESS (US / Firefly) log — each coordinate block becomes a frame |
+| CASTEP phonon | `.phonon` | CASTEP lattice-dynamics output (structure half) |
 | XTC | `.xtc` | GROMACS compressed trajectory |
 | DCD | `.dcd` | CHARMM/NAMD binary trajectory |
 | ASE .traj | `.traj` | ASE trajectory (ULM binary format) |
-| LAMMPS dump | `.lammpstrj`, `.dump` | LAMMPS dump trajectory |
+| LAMMPS dump | `.lammpstrj`, `.dump`, `.trj` | LAMMPS dump — opens standalone as a multi-frame structure, or attaches to a topology |
 | AMBER NetCDF | `.nc` | AMBER compressed trajectory (NetCDF format) |
+| Gaussian CUBE | `.cube`, `.cub` | Volumetric grid, rendered as an isosurface over a loaded structure |
+| OpenDX | `.dx` | Volumetric scalar field (APBS electrostatics) |
+| JCAMP-DX | `.jdx`, `.jcamp`, `.dx` | IR / NMR / MS / UV-Vis spectra, drawn by the `SpectrumPlot` node |
+| GROMACS topology | `.top` | Bond connectivity for the Add Bond node |
+| CHARMM/NAMD PSF | `.psf` | Bond connectivity for the Add Bond node |
 
 Not every host opens every extension from its native file picker — see
 [Platform Support](./platform-support) for the per-host matrix.

--- a/docs/docs/guide/jupyterlab.md
+++ b/docs/docs/guide/jupyterlab.md
@@ -18,11 +18,15 @@ Double-click any supported file in the JupyterLab file browser and megane opens 
 
 | File type | Extensions |
 |-----------|-----------|
-| Structures | `.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf`, `.mol2`, `.cif`, `.mmcif`, `.data`, `.lammps`, `.prmtop`, `.traj` |
-| Trajectories | `.xtc`, `.dcd`, `.lammpstrj`, `.dump`, `.nc` |
+| Structures | `.pdb`, `.gro`, `.xyz`, `.jxyz`, `.mol`, `.sdf`, `.mol2`, `.cif`, `.mmcif`, `.data`, `.lammps`, `.prmtop`, `.traj`, `.lammpstrj`, `.dump`, `.trj`, `POSCAR`, `CONTCAR`, `XDATCAR`, `.vasp`, `.molden`, `.xsf`, `.axsf`, `.cml`, `.c3xml`, `.xodydata`, `.odydata`, `.magres`, `.gamess`, `.phonon` |
+| Trajectories | `.xtc`, `.dcd`, `.nc` |
+| Volumetric grids | `.cube`, `.cub`, `.dx` |
+| Spectra | `.jdx`, `.jcamp`, `.dx` |
 | Pipelines | `.megane.json` |
 
-Trajectory-only formats (`.xtc`, `.dcd`, `.lammpstrj`, `.dump`, `.nc`) need a topology loaded first — open the structure file, then wire the trajectory in through the pipeline editor. Opening one directly surfaces an actionable error.
+The VASP names are matched as filenames rather than extensions, so `POSCAR`, `POSCAR.orig` and friends all open.
+
+Trajectory-only formats (`.xtc`, `.dcd`, `.nc`) and volumetric grids (`.cube`, `.cub`, `.dx`) need a structure loaded first — open the structure file, then wire the trajectory or grid in through the pipeline editor. Opening one directly surfaces an actionable error. LAMMPS dumps are *not* in that group: they carry their own topology in frame 0, so `.lammpstrj` / `.dump` / `.trj` open standalone as multi-frame structures (and can still be attached to a separate topology through the Load Trajectory node).
 
 ## Visual pipeline editor
 

--- a/docs/docs/guide/pipeline/index.md
+++ b/docs/docs/guide/pipeline/index.md
@@ -70,7 +70,7 @@ Jump straight to a node, e.g. [`polyhedron_generator`](/reference/node-reference
 
 ## Data Types
 
-Seven typed data channels flow through color-coded edges:
+Nine typed data channels flow through color-coded edges:
 
 | Type | Color | Description |
 |------|-------|-------------|
@@ -80,7 +80,9 @@ Seven typed data channels flow through color-coded edges:
 | **label** | Violet | Text labels positioned at atoms |
 | **mesh** | Gray | Triangle mesh for polyhedra rendering |
 | **trajectory** | Pink | Multi-frame coordinate data |
-| **vector** | Teal | Per-atom 3D vector data (forces, velocities, etc.) |
+| **vector** | Red | Per-atom 3D vector data (forces, velocities, etc.) |
+| **volumetric** | Cyan | Scalar field on a 3D grid, consumed by the Isosurface node |
+| **spectrum** | Lime | 2D (x, y) trace, consumed by the terminal Spectrum Plot node |
 
 ## Filter DSL
 

--- a/docs/docs/guide/vscode.md
+++ b/docs/docs/guide/vscode.md
@@ -15,10 +15,15 @@ Once installed, the extension registers a custom editor for the supported file t
 
 | File type | Extensions |
 |-----------|-----------|
-| Structures | `.pdb`, `.gro`, `.xyz`, `.mol`, `.sdf`, `.mol2`, `.cif`, `.mmcif`, `.data`, `.lammps`, `.prmtop`, `.traj` |
-| Trajectories | `.xtc`, `.dcd`, `.lammpstrj`, `.dump`, `.nc` |
+| Structures | `.pdb`, `.gro`, `.xyz`, `.jxyz`, `.mol`, `.sdf`, `.mol2`, `.cif`, `.mmcif`, `.data`, `.lammps`, `.prmtop`, `.traj`, `.lammpstrj`, `.dump`, `.trj`, `POSCAR*`, `CONTCAR*`, `XDATCAR*`, `.vasp`, `.molden`, `.xsf`, `.axsf`, `.cml`, `.c3xml`, `.xodydata`, `.odydata`, `.magres`, `.gamess`, `.phonon` |
+| Trajectories | `.xtc`, `.dcd`, `.nc` |
+| Volumetric grids | `.cube`, `.cub`, `.dx` |
+| Spectra | `.jdx`, `.jcamp`, `.dx` |
+| Pipelines | `.megane.json` |
 
-Trajectory-only formats (`.xtc`, `.dcd`, `.lammpstrj`, `.dump`, `.nc`) need a topology loaded first — open the structure file, then wire the trajectory in via the pipeline editor. Opening one directly surfaces an actionable error.
+The VASP entries are registered as filename globs rather than extensions, so `POSCAR`, `CONTCAR.bak` and similar all open.
+
+Trajectory-only formats (`.xtc`, `.dcd`, `.nc`) and volumetric grids (`.cube`, `.cub`, `.dx`) need a structure loaded first — open the structure file, then wire the trajectory or grid in via the pipeline editor. Opening one directly surfaces an actionable error. LAMMPS dumps are *not* in that group: frame 0 supplies the topology, so `.lammpstrj` / `.dump` / `.trj` open standalone as multi-frame structures (and can still be attached to a separate topology through the Load Trajectory node).
 
 ## Visual pipeline editor
 

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -5,7 +5,7 @@
 ## What can megane do?
 
 - **Render 1M+ atoms at 60 fps** in the browser using billboard impostor rendering
-- **Load 15 file formats**: PDB, GRO, XYZ, MOL, SDF, MOL2, CIF, mmCIF, LAMMPS data, AMBER topology, XTC, DCD, ASE `.traj`, LAMMPS dump, AMBER NetCDF
+- **Load 29 file formats** — structures (PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, mmCIF, LAMMPS data, VASP, Molden, XCrySDen, CML and more), trajectories (XTC, DCD, ASE `.traj`, LAMMPS dump, AMBER NetCDF), volumetric grids (Gaussian CUBE, OpenDX) and spectra (JCAMP-DX)
 - **Stream XTC trajectories from the `megane serve` CLI** over WebSocket — scrub multi-GB files without loading every frame into memory (browser/Jupyter without the CLI load full trajectories)
 - **Build visual pipelines** with a drag-and-drop node editor, or write them as Python/TypeScript code
 - **Integrate with Plotly**, MDX/Next.js, ipywidgets, and any framework via the framework-agnostic renderer
@@ -28,11 +28,13 @@ For a side-by-side comparison of which formats and UI features each distribution
 
 ## Supported file formats
 
+### Structures
+
 | Format | Extension |
 |--------|-----------|
 | Protein Data Bank | `.pdb` |
 | GROMACS structure | `.gro` |
-| XYZ | `.xyz` |
+| XYZ (single- or multi-frame, incl. extended `Lattice=`) | `.xyz`, `.jxyz` |
 | MDL Molfile (V2000) | `.mol` |
 | MDL SDfile (parsed via the V2000 Molfile reader) | `.sdf` |
 | Tripos MOL2 | `.mol2` |
@@ -40,11 +42,43 @@ For a side-by-side comparison of which formats and UI features each distribution
 | Macromolecular CIF (mmCIF/PDBx) | `.mmcif` |
 | LAMMPS data | `.data`, `.lammps` |
 | AMBER topology | `.prmtop` |
+| ASE trajectory | `.traj` |
+| LAMMPS dump (opens standalone as a multi-frame structure) | `.lammpstrj`, `.dump`, `.trj` |
+| VASP (matched by filename as well as extension; `XDATCAR` is multi-frame) | `POSCAR`, `CONTCAR`, `XDATCAR`, `.vasp` |
+| Molden (`[Atoms]` geometry and `[GEOMETRIES] XYZ` frames) | `.molden` |
+| XCrySDen (`.axsf` is a multi-frame animation) | `.xsf`, `.axsf` |
+| Chemical Markup Language | `.cml` |
+| Chem3D XML | `.c3xml` |
+| Wavefunction Odyssey (XML and Spartan-style text layouts) | `.xodydata`, `.odydata` |
+| CASTEP NMR magres | `.magres` |
+| GAMESS output (each coordinate block becomes a frame) | `.gamess` |
+| CASTEP phonon (structure half) | `.phonon` |
+
+### Trajectories
+
+| Format | Extension |
+|--------|-----------|
 | GROMACS trajectory | `.xtc` |
 | CHARMM/NAMD DCD trajectory | `.dcd` |
-| ASE trajectory | `.traj` |
-| LAMMPS dump | `.lammpstrj`, `.dump` |
 | AMBER NetCDF trajectory | `.nc` |
+| LAMMPS dump (also loadable standalone, above) | `.lammpstrj`, `.dump`, `.trj` |
+
+### Volumetric grids and spectra
+
+| Format | Extension |
+|--------|-----------|
+| Gaussian CUBE | `.cube`, `.cub` |
+| OpenDX scalar field | `.dx` |
+| JCAMP-DX spectra (AFFN plus the SQZ/DIF/DUP compressed forms) | `.jdx`, `.jcamp`, `.dx` |
+
+A grid is rendered as an isosurface over a separately-loaded structure; a spectrum is a 2D trace drawn by the terminal `SpectrumPlot` node. `.dx` is claimed by both OpenDX and JCAMP-DX, so the loader sniffs the file head and tells you if it is really the other one.
+
+### Bonds and topology
+
+| Format | Extension |
+|--------|-----------|
+| GROMACS topology | `.top` |
+| CHARMM/NAMD PSF | `.psf` |
 
 Per-host coverage (which formats each platform's UI can open vs. parser-only access) is enumerated in [Platform Support](./platform-support).
 

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -145,11 +145,11 @@ const CAPABILITIES = [
   },
   {
     title: "One Rust core, every host",
-    body: "PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, LAMMPS data, XTC, ASE .traj and more are parsed in Rust, compiled to both PyO3 and WASM. Parse once, run anywhere — Jupyter, browser, React, VS Code, JupyterLab.",
+    body: "PDB, GRO, XYZ, MOL/SDF, MOL2, CIF, LAMMPS data and dump, VASP, Molden, XCrySDen, CML, XTC, ASE .traj and more are parsed in Rust, compiled to both PyO3 and WASM. Parse once, run anywhere — Jupyter, browser, React, VS Code, JupyterLab.",
   },
   {
     title: "Visual pipeline editor",
-    body: "Wire 11 node types across 5 categories to load, filter, style and overlay — no code required. 7 typed data channels flow through color-coded edges; only matching types connect. Pipelines serialize to JSON to save and share.",
+    body: "Wire 19 node types across 5 categories to load, filter, style and overlay — no code required. 9 typed data channels flow through color-coded edges; only matching types connect. Pipelines serialize to JSON to save and share.",
   },
   {
     title: "Embed & integrate",


### PR DESCRIPTION
## Summary

`docs/docs/platform-support.md` was kept current as each new format landed — CRITICAL RULE #6 names it as the single source of truth and it held up. Nothing else did. Every other page still described the 0.7-era feature set, so a reader landing on the introduction or the host guides would not learn that twelve formats were added, and in two places would be told something that is now false.

This came out of the v0.11.0 release check (#625). The README half of the fix went in with that PR; this is the docs site.

### What was wrong

- **`introduction.md`** claimed "Load 15 file formats" and listed none of the twelve added since. Its table is now grouped the same way as `platform-support.md` (structures / trajectories / volumetric + spectra / bonds + topology) so the two stay comparable.

- **`getting-started.md`**'s format table was missing the same twelve.

- **The JupyterLab and VS Code guides** listed a twelve-extension subset of the ~39 patterns each host actually registers, and told readers:

  > Trajectory-only formats (`.xtc`, `.dcd`, `.lammpstrj`, `.dump`, `.nc`) need a topology loaded first

  That stopped being true in 0.11.0. LAMMPS dumps carry their topology in frame 0 and open standalone as multi-frame structures — that was one of the release's headline changes, and the docs actively told people not to try it. Trajectory-only is now `.xtc` / `.dcd` / `.nc`, and the "load a structure first" caveat moves to volumetric grids, which is where it belongs.

- **Counts had drifted everywhere.** The landing page said 11 node types and 7 data channels; `architecture.md` said 8 channels and its table was missing the `spectrum` row outright; the pipeline guide said "Seven typed data channels" and had `vector` down as Teal when it is red. The real numbers are 19 node types and 9 channels.

### Verifying the numbers

Counted from the implementation rather than from the prose:

| Claim | Source of truth |
|---|---|
| 19 node types | `src/pipeline/catalog.ts`, cross-checked against the generated Node Reference (6 category headings, 19 node entries) |
| 9 data channels | the `PipelineDataType` union in `src/pipeline/types.ts` |
| channel colors | `DATA_TYPE_COLORS` in the same file — this is where the Teal/red error showed up |
| 26 parser formats | parser modules in `megane-core` (`mol.rs` covers MOL and SDF), including `.top` and `.psf` since `src/parsers/structure.ts` parses both |
| registered extensions | `vscode-megane/package.json` `customEditors` and `jupyterlab-megane/src/filetypes.ts` |

### Not changed

`docs/docs/reference/node-reference.md` needed no edit. It is generated from `src/pipeline/catalog.ts` at docs build time and gitignored, so it already listed all 19 nodes correctly. That is the one page that could not drift — worth noting, because generating the other format and node tables from the catalog the same way would have prevented this entire PR.

## Test Plan

- [x] `npm test` passes — unaffected, no `src/` runtime code changed (the only non-docs file is `docs/src/pages/index.tsx`)
- [x] `cargo test -p megane-core` passes — unaffected
- [x] `python -m pytest` passes (if Python changes are included) — no Python changes
- [x] Manually verified the change in the browser (if UI changes are included) — no viewer changes; `cd docs && npm run build` completes with 0 errors, and the generated Node Reference confirms the 19-node count used in the prose

No E2E run: this PR touches no path listed under CRITICAL RULE #9. `docs/src/pages/index.tsx` is the Docusaurus landing page, not the viewer.

---
_Generated by [Claude Code](https://claude.ai/code/session_017kD9X3M89V6teV57pK6cie)_